### PR TITLE
feat: version sync + check_for_updates()

### DIFF
--- a/simmer_sdk/__init__.py
+++ b/simmer_sdk/__init__.py
@@ -59,7 +59,13 @@ from .approvals import (
     format_approval_guide,
 )
 
-__version__ = "0.2.7"
+# Single source of truth: read version from package metadata (set in pyproject.toml)
+try:
+    from importlib.metadata import version as _get_version
+    __version__ = _get_version("simmer-sdk")
+except Exception:
+    # Fallback for development installs or older Python
+    __version__ = "0.3.2"
 __all__ = [
     "SimmerClient",
     "get_required_approvals",


### PR DESCRIPTION
## Changes

1. **Version sync** — Use `importlib.metadata.version()` to read version from pyproject.toml (single source of truth)
2. **check_for_updates()** — New static method on SimmerClient to check PyPI for newer versions

## Usage

```python
from simmer_sdk import SimmerClient

# Check for updates (prints warning if outdated)
SimmerClient.check_for_updates()

# Or check silently
info = SimmerClient.check_for_updates(warn=False)
if info["update_available"]:
    print(f"Update available: {info["latest"]}")
```