### PR TITLE
fix: mertsniper review — reasoning + Polymarket-only

### DIFF
--- a/skills/mertsniper/SKILL.md
+++ b/skills/mertsniper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simmer-mertsniper
-displayName: Mert Sniper
+displayName: Polymarket Mert Sniper
 description: Near-expiry conviction trading on Polymarket. Snipe markets about to resolve when the odds are heavily skewed. Filter by topic, cap your bets, and only trade strong splits close to deadline.
 metadata: {"clawdbot":{"emoji":"🎯","requires":{"env":["SIMMER_API_KEY"]},"cron":null,"autostart":false}}
 authors:
@@ -16,6 +16,8 @@ Near-expiry conviction trading on Polymarket. Snipe markets about to resolve whe
 > Strategy by [@0xMert_](https://x.com/mert/status/2020216613279060433) — filter by topic, cap your bets, wait until near expiry, and only trade strong splits.
 
 ## When to Use This Skill
+
+> **Polymarket only.** All trades execute on Polymarket with real USDC. Use `--live` for real trades, dry-run is the default.
 
 Use this skill when the user wants to:
 - Trade markets that are about to resolve (last-minute conviction bets)

--- a/skills/mertsniper/mert_sniper.py
+++ b/skills/mertsniper/mert_sniper.py
@@ -213,13 +213,14 @@ def check_context_safeguards(context):
     return True, reasons
 
 
-def execute_trade(api_key, market_id, side, amount):
+def execute_trade(api_key, market_id, side, amount, reasoning=""):
     return sdk_request(api_key, "POST", "/api/sdk/trade", {
         "market_id": market_id,
         "side": side,
         "amount": amount,
         "venue": "polymarket",
         "source": TRADE_SOURCE,
+        "reasoning": reasoning,
     })
 
 
@@ -465,12 +466,14 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
             print(f"     Skip: ${position_size:.2f} too small for {MIN_SHARES_PER_ORDER} shares at ${side_price:.2f}")
             continue
 
+        reasoning = f"Near-expiry snipe: {side.upper()} at {side_price:.0%} with {format_duration(mins_left)} to resolution"
+
         if dry_run:
             est_shares = position_size / side_price
             print(f"     [DRY RUN] Would buy ${position_size:.2f} on {side.upper()} (~{est_shares:.1f} shares)")
         else:
             print(f"     Executing trade...")
-            result = execute_trade(api_key, market_id, side, position_size)
+            result = execute_trade(api_key, market_id, side, position_size, reasoning=reasoning)
 
             if result.get("success"):
                 trades_executed += 1


### PR DESCRIPTION
Review fixes for the new Mert Sniper skill:

1. **Trade reasoning** — passes reasoning to the trade API so it shows on market pages and agent profiles
2. **Display name** — "Polymarket Mert Sniper" for consistency with other skills
3. **Polymarket-only callout** in SKILL.md

3 small changes, no logic changes to the strategy.