### PR TITLE
feat: add trade detail logging to automaton cycle journal

### DIFF
--- a/skills/simmer-automaton/SKILL.md
+++ b/skills/simmer-automaton/SKILL.md
@@ -137,6 +137,103 @@ python automaton.py --budget 50 --days 30
 
 **Debugging tip:** When trades aren't executing, check the journal first: `python automaton.py --journal 10`. It shows per-cycle skip reasons, execution errors, and tuning hints — everything you need to diagnose why signals aren't converting to trades.
 
+## Skill Report Protocol
+
+Skills emit a JSON report line during execution. The automaton parses this to populate the cycle journal and update state.
+
+**Skill report format:**
+```json
+{
+  "automaton": {
+    "signals": 5,
+    "trades_attempted": 3,
+    "trades_executed": 2,
+    "amount_usd": 15.50,
+    "skip_reason": "safeguard: slippage > 10%",
+    "execution_errors": ["insufficient_funds on trade 2"],
+    "trades": [
+      {
+        "market_id": "abc123xyz",
+        "question": "Will Bitcoin hit $100k by Feb 28?",
+        "side": "yes",
+        "shares": 45.2,
+        "entry_price": 0.475,
+        "amount_usd": 21.47,
+        "success": true,
+        "notes": "Kelly-sized position"
+      },
+      {
+        "market_id": "def456uvw",
+        "question": "Will Fed raise rates?",
+        "side": "no",
+        "shares": 22.8,
+        "entry_price": 0.625,
+        "amount_usd": 14.25,
+        "success": true,
+        "notes": "Positioned for deflationary signal"
+      }
+    ]
+  }
+}
+```
+
+**Fields:**
+- `signals` (required) — Number of opportunities identified this cycle
+- `trades_attempted` (required) — Number of trades tried to execute
+- `trades_executed` (required) — Number that actually filled
+- `amount_usd` (required) — Total USD spent this cycle
+- `skip_reason` (optional) — Comma-separated skip reasons (e.g. "safeguard: slippage, already_holding")
+- `execution_errors` (optional) — Array of error messages from failed trade attempts
+- `trades` (optional but **recommended**) — Array of trade detail objects (see below)
+
+**Trade detail object (when `trades_executed > 0`):**
+- `market_id` (required) — Polymarket/Kalshi market ID
+- `question` (required) — Market question (for audit trail)
+- `side` (required) — `"yes"` or `"no"`
+- `shares` (required) — Number of shares bought
+- `entry_price` (required) — Price per share when filled
+- `amount_usd` (required) — Total USD spent on this trade
+- `success` (required) — `true` if fill confirmed, `false` if rejected/failed
+- `notes` (optional) — Why this trade was chosen (e.g. "Kelly-sized", "sentiment spike")
+
+**How to emit the report:**
+
+From within your skill script (Python):
+```python
+import json
+import sys
+
+# ... trading logic ...
+
+report = {
+  "automaton": {
+    "signals": 5,
+    "trades_attempted": 2,
+    "trades_executed": 1,
+    "amount_usd": 10.0,
+    "skip_reason": "position too small, already_holding",
+    "execution_errors": [],
+    "trades": [
+      {
+        "market_id": "abc123",
+        "question": "Will X?",
+        "side": "yes",
+        "shares": 50,
+        "entry_price": 0.20,
+        "amount_usd": 10.0,
+        "success": True,
+      }
+    ]
+  }
+}
+
+# Emit as final JSON line to stdout
+print(json.dumps(report))
+sys.exit(0)
+```
+
+The automaton reads your last JSON line, extracts the `automaton` key, and logs it to the cycle journal. Include trade details for full audit trails and debugging.
+
 ## Journal Schema (`cycle_journal.jsonl`)
 
 Each line is a JSON object representing one cycle. Your agent can read this file programmatically to build custom dashboards, alerts, or insights.

--- a/skills/simmer-automaton/automaton.py
+++ b/skills/simmer-automaton/automaton.py
@@ -506,7 +506,20 @@ def _avg_reward(skill_entry):
 def _parse_skill_report(stdout):
     """Extract structured report from skill stdout.
 
-    Skills emit a JSON line like: {"automaton": {"signals": 3, ...}}
+    Skills emit a JSON line like: {"automaton": {"signals": 3, "trades": [...], ...}}
+    Trades array format (optional, for detail logging):
+      [
+        {
+          "market_id": "abc123",
+          "question": "Will X happen?",
+          "side": "yes" | "no",
+          "shares": 45.2,
+          "entry_price": 0.22,
+          "amount_usd": 10.0,
+          "success": true | false
+        },
+        ...
+      ]
     Returns the inner dict or None if not found.
     """
     if not stdout:
@@ -1054,7 +1067,7 @@ def run_cycle(config, live=False, quiet=False):
         res = run_results.get(slug, {})
         report = res.get("report", {}) or {}
         skip_reason = report.get("skip_reason")
-        journal_entry["results"][slug] = {
+        entry = {
             "signals": report.get("signals", 0),
             "trades_attempted": report.get("trades_attempted", 0),
             "trades_executed": report.get("trades_executed", 0),
@@ -1065,6 +1078,10 @@ def run_cycle(config, live=False, quiet=False):
             "exit_code": res.get("returncode", -1),
             "success": res.get("success", False),
         }
+        # Include trade details if skill provided them
+        if report.get("trades"):
+            entry["trades"] = report["trades"]
+        journal_entry["results"][slug] = entry
     # Generate tuning hints once (used in journal + summary)
     hints = generate_tuning_hints(state)
     journal_entry["tuning_hints"] = hints


### PR DESCRIPTION
## Summary
- Add optional `trades` array to automaton skill report protocol for full audit trails
- Include trade details (market_id, question, side, shares, entry_price, amount_usd, success) in cycle journal
- Document Skill Report Protocol in SKILL.md with format spec and examples

Cherry-picked from #new/feature/trade-detail-logging (041f233), excluding:
- Fast-loop config changes (asset BTC→ETH, momentum threshold) — operator-specific
- Fast-loop `automaton.managed: false` — changes default for all users
- Hardcoded `phase3_start` date filter in `fetch_pnl_by_source` — operator-specific

## Test plan
- [ ] Run automaton with a skill that emits `trades` array — verify trades appear in `cycle_journal.jsonl`
- [ ] Run automaton with a skill that does NOT emit `trades` — verify no regression
- [ ] Verify `fetch_pnl_by_source` still returns all position P&L (no date filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)