### PR TITLE
fix: allow sub-cent prices (0.001-0.999) for neg_risk Polymarket markets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.9.1"
+version = "0.9.2"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -673,9 +673,10 @@ class SimmerClient:
                 - "GTC": Good Till Cancelled - limit order, stays on book until filled
                 - "GTD": Good Till Date - limit order with expiry
                 Only applies to venue="polymarket". Ignored for simmer.
-            price: Limit price (0.01-0.99) for the outcome being traded. For side="yes",
+            price: Limit price (0.001-0.999) for the outcome being traded. For side="yes",
                 this is the YES token price. For side="no", this is the NO token price
                 (NOT 1-price). If omitted, uses current market price for that outcome.
+                Sub-cent prices (e.g. 0.009 for 0.9¢) are supported for neg_risk markets.
                 Only applies to venue="polymarket". Ignored for simmer.
             reasoning: Optional explanation for the trade. This will be displayed
                 publicly on the market's trade history page, allowing spectators
@@ -789,8 +790,8 @@ class SimmerClient:
 
         # Validate price if provided
         if price is not None:
-            if price < 0.01 or price > 0.99:
-                raise ValueError("price must be between 0.01 and 0.99 (Polymarket share prices)")
+            if price < 0.001 or price > 0.999:
+                raise ValueError("price must be between 0.001 and 0.999 (Polymarket share prices)")
             if effective_venue != "polymarket":
                 raise ValueError(f"price parameter only supported for venue='polymarket' (you specified venue='{effective_venue}')")
 
@@ -890,7 +891,7 @@ class SimmerClient:
         price = float(market.get("external_price_yes") or market.get("current_probability") or 0.5)
         if side == "no":
             price = 1.0 - price
-        price = max(price, 0.01)  # Floor to avoid division by zero
+        price = max(price, 0.001)  # Floor to avoid division by zero (supports sub-cent neg_risk markets)
 
         if action == "buy":
             shares_filled = amount / price
@@ -2062,7 +2063,7 @@ class SimmerClient:
             shares: Number of shares (for sells)
             action: 'buy' or 'sell'
             order_type: Order type ('FAK', 'GTC', etc.)
-            price: Optional limit price (0.01-0.99). If None, uses current market price.
+            price: Optional limit price (0.001-0.999). If None, uses current market price.
         """
         if not self._private_key or not self._wallet_address:
             return None


### PR DESCRIPTION
## Problem

Neg_risk Polymarket markets (e.g. long-shot outcomes) trade below 1¢. The current SDK and API validation floor of `0.01` blocks GTC limit orders at prices like `0.009` (0.9¢).

Discovered while trying to place a GTC sell order on "Will Trump nominate no one before 2027?" — trading at **0.9¢ bid / 1.0¢ ask** — which is blocked by the current validation.

## Changes

- **Validation**: `price < 0.01 or price > 0.99` → `price < 0.001 or price > 0.999`
- **Price floor guard**: `max(price, 0.01)` → `max(price, 0.001)`
- **Docstrings**: Updated range from `0.01-0.99` to `0.001-0.999`, noted sub-cent support
- **Version bump**: `0.9.1` → `0.9.2`

## Why 0.001?

Polymarket tick sizes go down to `0.0001`. Setting the floor to `0.001` covers all realistic sub-cent markets while still guarding against division-by-zero edge cases.

## Testing

After backend deploys the matching fix, test with:
```python
client.trade(
    market_id="2eb3554b-8cde-4bb2-9109-affcad15f621",
    side="yes",
    action="sell",
    shares=4000,
    venue="polymarket",
    order_type="GTC",
    price=0.009  # was blocked before this fix
)
```