### PR TITLE
refactor: fold paper trading into live=False path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,48 @@ client.trade(market_id, side="yes", amount=10.0, venue="polymarket")
 
 > **Spread caveat:** $SIM fills instantly (AMM, no spread). Real venues have orderbook spreads of 2–5%. Target edges >5% in $SIM before graduating to real money.
 
+## Polymarket Paper Trading
+
+Practice on real Polymarket markets with simulated money. Paper mode uses live CLOB prices and models the bid-ask spread for realistic P&L — no wallet or USDC required.
+
+```python
+client = SimmerClient(
+    api_key="sk_live_...",
+    venue="polymarket",
+    paper_mode=True,           # Simulate fills, no real money
+    starting_balance=10_000.0  # Virtual capital (default: 10,000)
+)
+
+# Browse real Polymarket markets
+markets = client.get_markets(import_source="polymarket", limit=10)
+
+# Trade with simulated fills (uses live Polymarket prices + spread)
+result = client.trade(
+    market_id=markets[0].id,
+    side="yes",
+    amount=50.0,
+    reasoning="Paper trade — testing strategy"
+)
+print(f"Filled {result.shares_bought:.2f} shares at ${result.cost:.2f} (simulated)")
+
+# Check positions — auto-settles resolved markets
+positions = client.get_positions()
+for p in positions:
+    print(f"{p.question[:50]}: P&L ${p.pnl:.2f}")
+
+# Portfolio summary
+summary = client.get_paper_summary()
+print(f"Balance: ${summary['balance']:.2f}, P&L: ${summary['total_pnl']:.2f}")
+```
+
+**How it works:**
+- `trade()` fetches the live Polymarket mid-price, applies the CLOB spread (from market data or ~1 cent default), and fills at the ask (buys) or bid (sells).
+- `get_positions()` returns in-memory positions valued at current live prices.
+- Resolved markets auto-settle: winning shares pay $1, losers pay $0.
+- `get_paper_summary()` returns balance, P&L, and position breakdown.
+
+**Graduation path:** `sim` (instant fills, no spread) → `polymarket` + `paper_mode=True` (real prices, spread modeled) → `polymarket` live (real USDC).
+
 ## Key Methods
 
 | Method | Description |
@@ -145,6 +187,7 @@ client.trade(market_id, side="yes", amount=10.0, venue="polymarket")
 | `register_webhook()` | Push notifications for trades, resolutions, price moves |
 | `redeem()` | Redeem a specific winning Polymarket position |
 | `auto_redeem()` | Scan all positions and redeem any winning ones automatically |
+| `get_paper_summary()` | Paper mode portfolio summary (balance, P&L, positions) |
 | `get_settings()` / `update_settings()` | Configure trade limits and notifications |
 | `link_wallet()` | Link external EVM wallet for Polymarket |
 | `set_approvals()` | Set Polymarket token approvals |

--- a/README.md
+++ b/README.md
@@ -119,47 +119,28 @@ client.trade(market_id, side="yes", amount=10.0, venue="polymarket")
 
 > **Spread caveat:** $SIM fills instantly (AMM, no spread). Real venues have orderbook spreads of 2–5%. Target edges >5% in $SIM before graduating to real money.
 
-## Polymarket Paper Trading
+### Paper trading on real venues
 
-Practice on real Polymarket markets with simulated money. Paper mode uses live CLOB prices and models the bid-ask spread for realistic P&L — no wallet or USDC required.
+Pass `live=False` to simulate trades with real market prices — no wallet or USDC required. For Polymarket, fills model the CLOB bid-ask spread for realistic P&L. Resolved markets auto-settle (winning shares pay $1, losers $0).
 
 ```python
 client = SimmerClient(
     api_key="sk_live_...",
     venue="polymarket",
-    paper_mode=True,           # Simulate fills, no real money
+    live=False,                # Simulate fills, no real money
     starting_balance=10_000.0  # Virtual capital (default: 10,000)
 )
 
-# Browse real Polymarket markets
-markets = client.get_markets(import_source="polymarket", limit=10)
-
-# Trade with simulated fills (uses live Polymarket prices + spread)
-result = client.trade(
-    market_id=markets[0].id,
-    side="yes",
-    amount=50.0,
-    reasoning="Paper trade — testing strategy"
-)
-print(f"Filled {result.shares_bought:.2f} shares at ${result.cost:.2f} (simulated)")
-
-# Check positions — auto-settles resolved markets
-positions = client.get_positions()
-for p in positions:
-    print(f"{p.question[:50]}: P&L ${p.pnl:.2f}")
+result = client.trade(market_id=markets[0].id, side="yes", amount=50.0,
+                      reasoning="Testing strategy")
+print(f"Filled {result.shares_bought:.2f} shares (simulated)")
 
 # Portfolio summary
 summary = client.get_paper_summary()
 print(f"Balance: ${summary['balance']:.2f}, P&L: ${summary['total_pnl']:.2f}")
 ```
 
-**How it works:**
-- `trade()` fetches the live Polymarket mid-price, applies the CLOB spread (from market data or ~1 cent default), and fills at the ask (buys) or bid (sells).
-- `get_positions()` returns in-memory positions valued at current live prices.
-- Resolved markets auto-settle: winning shares pay $1, losers pay $0.
-- `get_paper_summary()` returns balance, P&L, and position breakdown.
-
-**Graduation path:** `sim` (instant fills, no spread) → `polymarket` + `paper_mode=True` (real prices, spread modeled) → `polymarket` live (real USDC).
+**Graduation path:** `sim` (instant fills, no spread) → `polymarket` + `live=False` (real prices, spread modeled) → `polymarket` live (real USDC).
 
 ## Key Methods
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -141,7 +141,6 @@ class SimmerClient:
         venue: str = "sim",
         private_key: Optional[str] = None,
         live: bool = True,
-        paper_mode: bool = False,
         starting_balance: float = 10_000.0
     ):
         """
@@ -161,14 +160,10 @@ class SimmerClient:
                 When False, trades are simulated with real market prices
                 and tracked in memory for the duration of the run. All read
                 endpoints (get_markets, get_context, etc.) work normally.
-            paper_mode: Convenience flag — equivalent to ``live=False``.
-                When True, the client uses real market data from Polymarket
-                (or any configured venue) but simulates all fills locally.
-                No real money is involved.  Positions auto-settle when the
-                market resolves.  For Polymarket, fills model the CLOB
-                bid-ask spread for realistic P&L.
+                For Polymarket, fills model the CLOB bid-ask spread for
+                realistic P&L. Positions auto-settle when markets resolve.
             starting_balance: Virtual starting capital for paper trading
-                (default: 10,000). Only used when paper_mode=True / live=False.
+                (default: 10,000). Only used when live=False.
             private_key: Optional EVM wallet private key for Polymarket trading.
                 When provided, orders are signed locally instead of server-side.
                 This enables trading with your own Polymarket wallet.
@@ -295,9 +290,6 @@ class SimmerClient:
         self._auto_redeem_enabled: bool = True
         self._auto_redeem_enabled_fetched_at: float = 0.0
 
-        # Paper trading mode (paper_mode=True is a convenience alias for live=False)
-        if paper_mode:
-            live = False
         self.live = live
         self._paper_portfolio = None
         if not self.live:

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -140,7 +140,9 @@ class SimmerClient:
         base_url: str = "https://api.simmer.markets",
         venue: str = "sim",
         private_key: Optional[str] = None,
-        live: bool = True
+        live: bool = True,
+        paper_mode: bool = False,
+        starting_balance: float = 10_000.0
     ):
         """
         Initialize the Simmer client.
@@ -159,6 +161,14 @@ class SimmerClient:
                 When False, trades are simulated with real market prices
                 and tracked in memory for the duration of the run. All read
                 endpoints (get_markets, get_context, etc.) work normally.
+            paper_mode: Convenience flag — equivalent to ``live=False``.
+                When True, the client uses real market data from Polymarket
+                (or any configured venue) but simulates all fills locally.
+                No real money is involved.  Positions auto-settle when the
+                market resolves.  For Polymarket, fills model the CLOB
+                bid-ask spread for realistic P&L.
+            starting_balance: Virtual starting capital for paper trading
+                (default: 10,000). Only used when paper_mode=True / live=False.
             private_key: Optional EVM wallet private key for Polymarket trading.
                 When provided, orders are signed locally instead of server-side.
                 This enables trading with your own Polymarket wallet.
@@ -285,13 +295,19 @@ class SimmerClient:
         self._auto_redeem_enabled: bool = True
         self._auto_redeem_enabled_fetched_at: float = 0.0
 
-        # Paper trading mode
+        # Paper trading mode (paper_mode=True is a convenience alias for live=False)
+        if paper_mode:
+            live = False
         self.live = live
         self._paper_portfolio = None
         if not self.live:
             from .paper import PaperPortfolio
-            self._paper_portfolio = PaperPortfolio()
-            logger.info("Paper trading mode enabled. Trades will be simulated with real prices.")
+            self._paper_portfolio = PaperPortfolio(starting_balance=starting_balance)
+            logger.info(
+                "Paper trading mode enabled (venue=%s, balance=%.2f). "
+                "Trades will be simulated with real market data.",
+                venue, starting_balance
+            )
 
         # Auto-process risk alerts on init (external wallets only)
         if self.live and self._private_key and venue in ("polymarket",):
@@ -969,9 +985,22 @@ class SimmerClient:
             self._held_markets_cache = None  # Invalidate so next check sees new position
         return result
 
+    # Default half-spread for Polymarket paper trades (in probability units).
+    # Real Polymarket spreads are typically 1-3 cents; 1 cent per side is
+    # conservative.  Overridden when the market returns ``spread_cents``.
+    _POLY_PAPER_DEFAULT_HALF_SPREAD = 0.01
+
     def _paper_trade(self, market_id, side, amount, shares, action, venue):
-        """Simulate a trade using real market prices."""
+        """Simulate a trade using real market prices.
+
+        For Polymarket venues, models the CLOB bid-ask spread so paper P&L
+        is closer to what a live FAK order would experience.  Buys fill at
+        the ask (mid + half-spread), sells at the bid (mid - half-spread).
+        """
         import time as _time
+
+        # Auto-settle any resolved paper positions before trading
+        self._settle_paper_positions()
 
         # Fetch current price from the venue
         try:
@@ -989,14 +1018,37 @@ class SimmerClient:
             )
 
         market = ctx["market"]
-        price = float(market.get("external_price_yes") or market.get("current_probability") or 0.5)
+        mid_price = float(market.get("external_price_yes") or market.get("current_probability") or 0.5)
         if side == "no":
-            price = 1.0 - price
-        price = max(price, 0.001)  # Floor to avoid division by zero (supports sub-cent neg_risk markets)
+            mid_price = 1.0 - mid_price
+        mid_price = max(mid_price, 0.001)  # Floor to avoid division by zero
+
+        # Polymarket CLOB spread modeling — buys fill at ask, sells at bid
+        is_polymarket = venue in ("polymarket",)
+        if is_polymarket:
+            spread_raw = market.get("spread_cents")
+            if spread_raw is not None:
+                half_spread = float(spread_raw) / 100.0 / 2.0  # cents → probability
+            else:
+                half_spread = self._POLY_PAPER_DEFAULT_HALF_SPREAD
+            if action == "buy":
+                fill_price = min(mid_price + half_spread, 0.999)
+            else:
+                fill_price = max(mid_price - half_spread, 0.001)
+        else:
+            fill_price = mid_price
 
         if action == "buy":
-            shares_filled = amount / price
             cost = amount
+            # Check paper balance
+            if cost > self._paper_portfolio.balance:
+                return TradeResult(
+                    success=False, market_id=market_id, side=side,
+                    error=f"Insufficient paper balance ({self._paper_portfolio.balance:.2f} < {cost:.2f})",
+                    simulated=True,
+                    balance=round(self._paper_portfolio.balance, 4),
+                )
+            shares_filled = amount / fill_price
         else:
             pos = self._paper_portfolio.get_position(market_id)
             available = getattr(pos, f"shares_{side}", 0)
@@ -1007,9 +1059,9 @@ class SimmerClient:
                     error=f"No paper position to sell (have {available:.2f} {side} shares)",
                     simulated=True
                 )
-            cost = shares_filled * price
+            cost = shares_filled * fill_price
 
-        self._paper_portfolio.log_trade(market_id, side, action, shares_filled, cost, price)
+        self._paper_portfolio.log_trade(market_id, side, action, shares_filled, cost, fill_price, venue=venue)
 
         return TradeResult(
             success=True,
@@ -1017,13 +1069,102 @@ class SimmerClient:
             market_id=market_id,
             side=side,
             venue=venue,
-            shares_bought=shares_filled,
-            shares_requested=shares_filled,
+            shares_bought=round(shares_filled, 6),
+            shares_requested=round(shares_filled, 6),
             order_status="simulated",
             cost=round(cost, 4),
-            new_price=price,
+            new_price=mid_price,
             simulated=True,
+            balance=round(self._paper_portfolio.balance, 4),
         )
+
+    # ==========================================
+    # PAPER TRADING HELPERS
+    # ==========================================
+
+    def _get_paper_positions(self) -> List[Position]:
+        """Build Position list from in-memory paper portfolio."""
+        positions = []
+        for mid, pos in self._paper_portfolio.positions.items():
+            if pos.shares_yes <= 0 and pos.shares_no <= 0:
+                continue
+            # Fetch live price for current value estimate
+            price_yes = 0.5
+            question = mid
+            try:
+                ctx = self.get_market_context(mid)
+                if ctx and "market" in ctx:
+                    m = ctx["market"]
+                    price_yes = float(
+                        m.get("external_price_yes")
+                        or m.get("current_probability")
+                        or 0.5
+                    )
+                    question = m.get("question", mid)
+            except Exception:
+                pass
+            current_value = (pos.shares_yes * price_yes) + (pos.shares_no * (1 - price_yes))
+            pnl = current_value - pos.total_cost
+            positions.append(Position(
+                market_id=mid,
+                question=question,
+                shares_yes=pos.shares_yes,
+                shares_no=pos.shares_no,
+                current_value=round(current_value, 4),
+                pnl=round(pnl, 4),
+                status="active",
+                venue=pos.venue,
+                cost_basis=round(pos.total_cost, 4),
+                current_price=price_yes,
+            ))
+        return positions
+
+    def _settle_paper_positions(self):
+        """Check open paper positions for resolved markets and settle them."""
+        if self._paper_portfolio is None:
+            return
+        open_ids = self._paper_portfolio.get_open_market_ids()
+        if not open_ids:
+            return
+        for mid in open_ids:
+            try:
+                ctx = self.get_market_context(mid)
+                if not ctx or "market" not in ctx:
+                    continue
+                m = ctx["market"]
+                status = m.get("status", "")
+                if status != "resolved":
+                    continue
+                # Determine outcome from resolved market data
+                outcome_raw = m.get("outcome")
+                if outcome_raw is True or outcome_raw == "yes" or outcome_raw == "Yes":
+                    outcome = "yes"
+                elif outcome_raw is False or outcome_raw == "no" or outcome_raw == "No":
+                    outcome = "no"
+                else:
+                    # Infer from probability (1.0 = yes, 0.0 = no)
+                    prob = float(m.get("current_probability", 0.5))
+                    if prob >= 0.99:
+                        outcome = "yes"
+                    elif prob <= 0.01:
+                        outcome = "no"
+                    else:
+                        continue  # Not clearly resolved
+                self._paper_portfolio.settle(mid, outcome)
+            except Exception as e:
+                logger.debug("Could not check resolution for %s: %s", mid, e)
+
+    def get_paper_summary(self) -> Optional[dict]:
+        """Return paper portfolio summary, or None if not in paper mode.
+
+        Returns:
+            Dict with starting_balance, balance, total_pnl, open_positions,
+            settled_positions, and per-market position details.
+        """
+        if self._paper_portfolio is None:
+            return None
+        self._settle_paper_positions()
+        return self._paper_portfolio.summary()
 
     def prepare_real_trade(
         self,
@@ -1104,6 +1245,9 @@ class SimmerClient:
         """
         Get all positions for this agent.
 
+        In paper mode, returns simulated positions from the in-memory
+        portfolio and auto-settles any markets that have resolved.
+
         Args:
             venue: Filter by venue ("sim" or "polymarket"). If None, returns both.
             source: Filter by trade source (e.g., "weather", "copytrading"). Partial match.
@@ -1111,12 +1255,17 @@ class SimmerClient:
         Returns:
             List of Position objects with P&L info
         """
+        # Paper mode: return in-memory positions (auto-settle first)
+        if not self.live and self._paper_portfolio is not None:
+            self._settle_paper_positions()
+            return self._get_paper_positions()
+
         params = {}
         if venue:
             params["venue"] = venue
         if source:
             params["source"] = source
-            
+
         data = self._request("GET", "/api/sdk/positions", params=params if params else None)
 
         positions = []
@@ -1184,6 +1333,9 @@ class SimmerClient:
 
     def get_total_pnl(self) -> float:
         """Get total unrealized P&L across all positions."""
+        if not self.live and self._paper_portfolio is not None:
+            self._settle_paper_positions()
+            return self._paper_portfolio.total_pnl
         data = self._request("GET", "/api/sdk/positions")
         return data.get("total_pnl", 0.0)
 

--- a/simmer_sdk/paper.py
+++ b/simmer_sdk/paper.py
@@ -3,10 +3,22 @@ Paper trading portfolio tracker.
 
 Tracks simulated positions in memory for the duration of a single run.
 No file I/O — positions reset when the process exits.
+
+Supports:
+- Balance tracking (starting capital, realized P&L)
+- Auto-settlement on market resolution
+- Position queries compatible with SimmerClient.get_positions() format
+- Venue-aware position tracking (sim vs polymarket)
 """
 
-from dataclasses import dataclass
-from typing import Dict
+import time
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STARTING_BALANCE = 10_000.0
 
 
 @dataclass
@@ -16,19 +28,52 @@ class PaperPosition:
     shares_yes: float = 0.0
     shares_no: float = 0.0
     total_cost: float = 0.0
+    venue: str = "sim"  # Venue this position was opened on
+
+
+@dataclass
+class PaperSettlement:
+    """Record of a settled paper position."""
+    market_id: str
+    outcome: str  # "yes" or "no"
+    shares_won: float
+    shares_lost: float
+    payout: float  # Amount credited to balance
+    cost_basis: float  # Original cost of the position
+    pnl: float  # payout - cost_basis
+    venue: str = "sim"
+    settled_at: float = field(default_factory=time.time)
 
 
 class PaperPortfolio:
-    """In-memory paper portfolio for a single run."""
+    """In-memory paper portfolio for a single run.
 
-    def __init__(self):
+    Tracks a virtual balance, simulated positions, and auto-settles
+    when markets resolve.
+
+    Args:
+        starting_balance: Initial virtual capital (default: 10,000).
+    """
+
+    def __init__(self, starting_balance: float = DEFAULT_STARTING_BALANCE):
+        self.starting_balance = starting_balance
+        self.balance = starting_balance
         self.positions: Dict[str, PaperPosition] = {}
+        self.settlements: List[PaperSettlement] = []
+        self._trade_log: List[dict] = []
+
+    @property
+    def total_pnl(self) -> float:
+        """Total realized P&L from settlements."""
+        return sum(s.pnl for s in self.settlements)
 
     def _apply_trade(self, trade: dict):
         """Update in-memory position from a trade record."""
         mid = trade["market_id"]
         if mid not in self.positions:
-            self.positions[mid] = PaperPosition(market_id=mid)
+            self.positions[mid] = PaperPosition(
+                market_id=mid, venue=trade.get("venue", "sim")
+            )
         pos = self.positions[mid]
         shares = trade.get("shares_filled", 0)
         cost = trade.get("cost", 0)
@@ -37,19 +82,22 @@ class PaperPortfolio:
         if trade["action"] == "buy":
             setattr(pos, side_attr, getattr(pos, side_attr) + shares)
             pos.total_cost += cost
+            self.balance -= cost
         else:
             old_shares = getattr(pos, side_attr)
             removed = min(shares, old_shares)
             if old_shares > 0:
                 pos.total_cost -= pos.total_cost * (removed / old_shares)
             setattr(pos, side_attr, max(0, old_shares - removed))
+            self.balance += cost
 
     def get_position(self, market_id: str) -> PaperPosition:
         """Get current paper position for a market."""
         return self.positions.get(market_id, PaperPosition(market_id=market_id))
 
     def log_trade(self, market_id: str, side: str, action: str,
-                  shares: float, cost: float, price: float):
+                  shares: float, cost: float, price: float,
+                  venue: str = "sim"):
         """Record trade in memory and update positions."""
         entry = {
             "market_id": market_id,
@@ -58,5 +106,82 @@ class PaperPortfolio:
             "shares_filled": shares,
             "cost": cost,
             "price": price,
+            "venue": venue,
+            "timestamp": time.time(),
         }
+        self._trade_log.append(entry)
         self._apply_trade(entry)
+
+    def settle(self, market_id: str, outcome: str) -> Optional[PaperSettlement]:
+        """Settle a paper position when the market resolves.
+
+        Args:
+            market_id: The resolved market's ID.
+            outcome: Resolution outcome — "yes" or "no".
+
+        Returns:
+            PaperSettlement record, or None if no position to settle.
+        """
+        pos = self.positions.get(market_id)
+        if pos is None or (pos.shares_yes <= 0 and pos.shares_no <= 0):
+            return None
+
+        # Winning shares pay $1 each, losing shares pay $0
+        if outcome == "yes":
+            payout = pos.shares_yes
+            shares_won = pos.shares_yes
+            shares_lost = pos.shares_no
+        else:
+            payout = pos.shares_no
+            shares_won = pos.shares_no
+            shares_lost = pos.shares_yes
+
+        pnl = payout - pos.total_cost
+        self.balance += payout
+
+        settlement = PaperSettlement(
+            market_id=market_id,
+            outcome=outcome,
+            shares_won=shares_won,
+            shares_lost=shares_lost,
+            payout=round(payout, 4),
+            cost_basis=round(pos.total_cost, 4),
+            pnl=round(pnl, 4),
+            venue=pos.venue,
+        )
+        self.settlements.append(settlement)
+        del self.positions[market_id]
+
+        logger.info(
+            "Paper settlement: market=%s outcome=%s payout=%.2f pnl=%+.2f",
+            market_id, outcome, payout, pnl
+        )
+        return settlement
+
+    def get_open_market_ids(self) -> List[str]:
+        """Return market IDs with open paper positions."""
+        return [
+            mid for mid, pos in self.positions.items()
+            if pos.shares_yes > 0 or pos.shares_no > 0
+        ]
+
+    def summary(self) -> dict:
+        """Return a summary of the paper portfolio state."""
+        open_positions = {
+            mid: {
+                "shares_yes": pos.shares_yes,
+                "shares_no": pos.shares_no,
+                "cost_basis": round(pos.total_cost, 4),
+                "venue": pos.venue,
+            }
+            for mid, pos in self.positions.items()
+            if pos.shares_yes > 0 or pos.shares_no > 0
+        }
+        return {
+            "starting_balance": self.starting_balance,
+            "balance": round(self.balance, 4),
+            "total_pnl": round(self.total_pnl, 4),
+            "open_positions": len(open_positions),
+            "settled_positions": len(self.settlements),
+            "positions": open_positions,
+        }

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -1,0 +1,208 @@
+"""Tests for simmer_sdk.paper — Paper trading portfolio tracker."""
+
+import pytest
+from simmer_sdk.paper import PaperPortfolio, PaperPosition, PaperSettlement, DEFAULT_STARTING_BALANCE
+
+
+# --- PaperPortfolio initialization ---
+
+def test_default_starting_balance():
+    p = PaperPortfolio()
+    assert p.balance == DEFAULT_STARTING_BALANCE
+    assert p.starting_balance == DEFAULT_STARTING_BALANCE
+
+def test_custom_starting_balance():
+    p = PaperPortfolio(starting_balance=5000)
+    assert p.balance == 5000
+
+def test_no_positions_initially():
+    p = PaperPortfolio()
+    assert len(p.positions) == 0
+    assert p.get_open_market_ids() == []
+
+
+# --- Buying ---
+
+def test_buy_creates_position():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=100, cost=50, price=0.50)
+    pos = p.get_position("m1")
+    assert pos.shares_yes == 100
+    assert pos.shares_no == 0
+    assert pos.total_cost == 50
+
+def test_buy_deducts_balance():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=100, cost=50, price=0.50)
+    assert p.balance == 950
+
+def test_buy_no_side():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "no", "buy", shares=200, cost=80, price=0.40)
+    pos = p.get_position("m1")
+    assert pos.shares_no == 200
+    assert pos.shares_yes == 0
+    assert p.balance == 920
+
+
+# --- Selling ---
+
+def test_sell_credits_balance():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=100, cost=50, price=0.50)
+    p.log_trade("m1", "yes", "sell", shares=50, cost=30, price=0.60)
+    assert p.balance == 980  # -50 + 30
+    pos = p.get_position("m1")
+    assert pos.shares_yes == 50
+
+def test_sell_more_than_held_capped():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50)
+    p.log_trade("m1", "yes", "sell", shares=100, cost=50, price=0.50)
+    pos = p.get_position("m1")
+    assert pos.shares_yes == 0
+
+
+# --- Settlement ---
+
+def test_settle_yes_outcome():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=100, cost=60, price=0.60)
+    # Balance after buy: 940
+    s = p.settle("m1", "yes")
+    assert s is not None
+    assert s.payout == 100  # 100 shares * $1
+    assert s.pnl == 40  # 100 - 60
+    assert p.balance == 1040  # 940 + 100
+    assert "m1" not in p.positions
+
+def test_settle_no_outcome():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=100, cost=60, price=0.60)
+    s = p.settle("m1", "no")
+    assert s is not None
+    assert s.payout == 0  # YES shares worthless
+    assert s.pnl == -60  # 0 - 60
+    assert p.balance == 940  # no payout
+
+def test_settle_mixed_position():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=50, cost=30, price=0.60)
+    p.log_trade("m1", "no", "buy", shares=40, cost=16, price=0.40)
+    # Balance: 1000 - 30 - 16 = 954
+    s = p.settle("m1", "yes")
+    assert s.shares_won == 50  # yes shares won
+    assert s.shares_lost == 40  # no shares lost
+    assert s.payout == 50
+    assert p.balance == 1004  # 954 + 50
+
+def test_settle_nonexistent_market():
+    p = PaperPortfolio(starting_balance=1000)
+    assert p.settle("nonexistent", "yes") is None
+
+def test_settle_empty_position():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50)
+    p.log_trade("m1", "yes", "sell", shares=10, cost=5, price=0.50)
+    assert p.settle("m1", "yes") is None
+
+
+# --- total_pnl ---
+
+def test_total_pnl_accumulates():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=100, cost=60, price=0.60)
+    p.log_trade("m2", "no", "buy", shares=50, cost=20, price=0.40)
+    p.settle("m1", "yes")  # pnl = +40
+    p.settle("m2", "no")  # pnl = 50 - 20 = +30 (no shares win)
+    assert p.total_pnl == pytest.approx(70)
+
+
+# --- summary ---
+
+def test_summary_structure():
+    p = PaperPortfolio(starting_balance=500)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50)
+    s = p.summary()
+    assert s["starting_balance"] == 500
+    assert s["balance"] == 495
+    assert s["open_positions"] == 1
+    assert s["settled_positions"] == 0
+    assert "m1" in s["positions"]
+
+
+# --- get_open_market_ids ---
+
+def test_open_market_ids():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50)
+    p.log_trade("m2", "no", "buy", shares=20, cost=8, price=0.40)
+    ids = p.get_open_market_ids()
+    assert set(ids) == {"m1", "m2"}
+
+def test_open_market_ids_after_settle():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50)
+    p.settle("m1", "yes")
+    assert p.get_open_market_ids() == []
+
+
+# --- get_position for unknown market ---
+
+def test_get_position_unknown_market():
+    p = PaperPortfolio()
+    pos = p.get_position("unknown")
+    assert pos.market_id == "unknown"
+    assert pos.shares_yes == 0
+    assert pos.shares_no == 0
+
+
+# --- Venue tracking ---
+
+def test_position_tracks_venue():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50, venue="polymarket")
+    pos = p.get_position("m1")
+    assert pos.venue == "polymarket"
+
+def test_position_default_venue_sim():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50)
+    pos = p.get_position("m1")
+    assert pos.venue == "sim"
+
+def test_settlement_tracks_venue():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50, venue="polymarket")
+    s = p.settle("m1", "yes")
+    assert s.venue == "polymarket"
+
+def test_summary_includes_venue():
+    p = PaperPortfolio(starting_balance=1000)
+    p.log_trade("m1", "yes", "buy", shares=10, cost=5, price=0.50, venue="polymarket")
+    s = p.summary()
+    assert s["positions"]["m1"]["venue"] == "polymarket"
+
+
+# --- Polymarket spread simulation (unit-level) ---
+
+def test_spread_affects_shares_received():
+    """Buying at a higher price (ask) yields fewer shares per dollar."""
+    p = PaperPortfolio(starting_balance=10000)
+    # No spread: 100 / 0.50 = 200 shares
+    p.log_trade("m1", "yes", "buy", shares=200, cost=100, price=0.50)
+    # With spread: 100 / 0.51 ≈ 196.08 shares (ask price)
+    p.log_trade("m2", "yes", "buy", shares=196.08, cost=100, price=0.51)
+    pos1 = p.get_position("m1")
+    pos2 = p.get_position("m2")
+    assert pos1.shares_yes > pos2.shares_yes
+
+def test_spread_sell_at_bid():
+    """Selling at bid price (lower) yields less proceeds."""
+    p = PaperPortfolio(starting_balance=10000)
+    # Buy 100 shares
+    p.log_trade("m1", "yes", "buy", shares=100, cost=50, price=0.50)
+    # Sell at bid (0.49) instead of mid (0.50) — receives less
+    p.log_trade("m1", "yes", "sell", shares=100, cost=49, price=0.49)
+    # Balance: 10000 - 50 + 49 = 9999 (loss from spread)
+    assert p.balance == pytest.approx(9999)


### PR DESCRIPTION
## Summary
- Enhances `live=False` with CLOB spread modeling, balance tracking, and auto-settlement for Polymarket paper trading (SIM-568)
- Removes redundant `paper_mode` parameter — improvements activate automatically when `live=False`
- 24 new tests covering balance, settlement, venue tracking, and spread mechanics

## What changed
- `paper.py`: Balance tracking, `PaperSettlement`, auto-settle on resolution, venue-aware positions
- `client.py`: Spread-aware fills for Polymarket (`_paper_trade`), `starting_balance` param, `get_paper_summary()`, `_settle_paper_positions()`
- `README.md`: New "Paper trading on real venues" section with graduation path
- `tests/test_paper.py`: 24 new tests, all passing

## Test plan
- [x] `pytest tests/test_paper.py` — 24/24 pass
- [x] No `paper_mode` references remain in codebase
- [x] Rebased on current main (venue-aware reads, reactor mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)