### PR TITLE
fix: pre-submission decimal rounding for order amounts

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -846,6 +846,26 @@ class SimmerClient:
         if not is_sell and amount <= 0:
             raise ValueError("amount required for buy orders")
 
+        # Round to API decimal limits before submission.
+        # Maker (USDC) supports max 2 decimals; shares support max 5.
+        # Log a warning so callers know rounding occurred.
+        if not is_sell:
+            rounded = round(amount, 2)
+            if rounded != amount:
+                logger.warning(
+                    "amount %.8f rounded to %.2f (maker amount max 2 decimal places)",
+                    amount, rounded
+                )
+                amount = rounded
+        else:
+            rounded = round(shares, 5)
+            if rounded != shares:
+                logger.warning(
+                    "shares %.10f rounded to %.5f (taker amount max 5 decimal places)",
+                    shares, rounded
+                )
+                shares = rounded
+
         # Paper trading: simulate with real prices (no live API calls)
         if not self.live:
             return self._paper_trade(

--- a/tests/test_decimal_validation.py
+++ b/tests/test_decimal_validation.py
@@ -1,0 +1,158 @@
+"""Tests for pre-submission decimal rounding in SimmerClient.trade()."""
+
+import logging
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_client():
+    """Return a live-mode client with network calls stubbed out."""
+    client = SimmerClient.__new__(SimmerClient)
+    client.live = True
+    client.venue = "polymarket"
+    client._private_key = None
+    client._solana_private_key = None
+    client._held_markets_cache = None
+    client._approvals_warned = False
+    client.ORDER_TYPES = {"FAK", "FOK", "GTC", "GTD"}
+    client.VENUES = {"sim", "polymarket", "kalshi", "simmer"}
+    return client
+
+
+class TestAmountDecimalRounding:
+    """amount (maker USDC) must be rounded to 2 d.p. before submission."""
+
+    def test_exact_two_decimals_unchanged(self):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(kwargs.get("json", {}))
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 10, "shares_requested": 10,
+                "order_status": "MATCHED", "cost": 10.00, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        client.trade("m1", "yes", amount=10.00)
+        assert captured["amount"] == 10.00
+
+    def test_three_decimals_rounded(self, caplog):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(kwargs.get("json", {}))
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 10, "shares_requested": 10,
+                "order_status": "MATCHED", "cost": 10.0, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+            client.trade("m1", "yes", amount=10.123)
+
+        assert captured["amount"] == pytest.approx(10.12)
+        assert any("rounded" in r.message for r in caplog.records)
+
+    def test_many_decimals_rounded(self, caplog):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(kwargs.get("json", {}))
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 5, "shares_requested": 5,
+                "order_status": "MATCHED", "cost": 5.0, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+            client.trade("m1", "yes", amount=5.333333333)
+
+        assert captured["amount"] == pytest.approx(5.33)
+
+    def test_no_warning_when_exact(self, caplog):
+        client = _make_client()
+
+        def fake_request(method, path, **kwargs):
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 10, "shares_requested": 10,
+                "order_status": "MATCHED", "cost": 10.0, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+            client.trade("m1", "yes", amount=10.50)
+
+        assert not any("rounded" in r.message for r in caplog.records)
+
+
+class TestSharesDecimalRounding:
+    """shares (taker) must be rounded to 5 d.p. before submission."""
+
+    def test_exact_five_decimals_unchanged(self):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(kwargs.get("json", {}))
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 0, "shares_requested": 0,
+                "order_status": "MATCHED", "cost": 0, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        client.trade("m1", "yes", shares=1.23456, action="sell")
+        assert captured["shares"] == pytest.approx(1.23456)
+
+    def test_six_decimals_rounded(self, caplog):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, path, **kwargs):
+            captured.update(kwargs.get("json", {}))
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 0, "shares_requested": 0,
+                "order_status": "MATCHED", "cost": 0, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+            client.trade("m1", "yes", shares=1.234567, action="sell")
+
+        assert captured["shares"] == pytest.approx(1.23457)
+        assert any("rounded" in r.message for r in caplog.records)
+
+    def test_no_warning_when_exact(self, caplog):
+        client = _make_client()
+
+        def fake_request(method, path, **kwargs):
+            return {
+                "success": True, "trade_id": "t1", "market_id": "m1",
+                "side": "yes", "shares_bought": 0, "shares_requested": 0,
+                "order_status": "MATCHED", "cost": 0, "new_price": 0.5,
+                "position": {},
+            }
+
+        client._request = fake_request
+        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+            client.trade("m1", "yes", shares=5.0, action="sell")
+
+        assert not any("rounded" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Rounds `amount` (maker USDC) to 2 d.p. and `shares` (taker) to 5 d.p. before API submission
- Logs a WARNING when rounding occurs so callers can detect it
- Prevents `ORDER_REJECTED: invalid amounts` errors from Polymarket

## Changes
- `simmer_sdk/client.py` — 20 lines in `trade()`, after validation, before any trade path
- `tests/test_decimal_validation.py` — 7 new tests covering both paths

## Test plan
- [x] 7/7 tests pass (buy rounding, sell rounding, no-warning cases)
- [x] AI review: SHIP
- [x] CTO review: SHIP

Closes SIM-180

🤖 Generated with [Claude Code](https://claude.com/claude-code)