### PR TITLE
fix: reject invalid decimal precision instead of silent rounding

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -846,25 +846,20 @@ class SimmerClient:
         if not is_sell and amount <= 0:
             raise ValueError("amount required for buy orders")
 
-        # Round to API decimal limits before submission.
+        # Validate decimal precision before submission.
         # Maker (USDC) supports max 2 decimals; shares support max 5.
-        # Log a warning so callers know rounding occurred.
         if not is_sell:
-            rounded = round(amount, 2)
-            if rounded != amount:
-                logger.warning(
-                    "amount %.8f rounded to %.2f (maker amount max 2 decimal places)",
-                    amount, rounded
+            if round(amount, 2) != amount:
+                raise ValueError(
+                    f"amount {amount} has too many decimal places (max 2). "
+                    f"Use {round(amount, 2)} instead."
                 )
-                amount = rounded
         else:
-            rounded = round(shares, 5)
-            if rounded != shares:
-                logger.warning(
-                    "shares %.10f rounded to %.5f (taker amount max 5 decimal places)",
-                    shares, rounded
+            if round(shares, 5) != shares:
+                raise ValueError(
+                    f"shares {shares} has too many decimal places (max 5). "
+                    f"Use {round(shares, 5)} instead."
                 )
-                shares = rounded
 
         # Paper trading: simulate with real prices (no live API calls)
         if not self.live:

--- a/tests/test_decimal_validation.py
+++ b/tests/test_decimal_validation.py
@@ -1,8 +1,4 @@
-"""Tests for pre-submission decimal rounding in SimmerClient.trade()."""
-
-import logging
-import unittest
-from unittest.mock import MagicMock, patch
+"""Tests for pre-submission decimal validation in SimmerClient.trade()."""
 
 import pytest
 
@@ -23,136 +19,66 @@ def _make_client():
     return client
 
 
-class TestAmountDecimalRounding:
-    """amount (maker USDC) must be rounded to 2 d.p. before submission."""
+def _fake_request(method, path, **kwargs):
+    return {
+        "success": True, "trade_id": "t1", "market_id": "m1",
+        "side": "yes", "shares_bought": 10, "shares_requested": 10,
+        "order_status": "MATCHED", "cost": 10.00, "new_price": 0.5,
+        "position": {},
+    }
 
-    def test_exact_two_decimals_unchanged(self):
+
+class TestAmountDecimalValidation:
+    """amount (maker USDC) must have max 2 decimal places."""
+
+    def test_exact_two_decimals_accepted(self):
         client = _make_client()
-        captured = {}
+        client._request = _fake_request
+        result = client.trade("m1", "yes", amount=10.12)
+        assert result.success
 
-        def fake_request(method, path, **kwargs):
-            captured.update(kwargs.get("json", {}))
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 10, "shares_requested": 10,
-                "order_status": "MATCHED", "cost": 10.00, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        client.trade("m1", "yes", amount=10.00)
-        assert captured["amount"] == 10.00
-
-    def test_three_decimals_rounded(self, caplog):
+    def test_integer_amount_accepted(self):
         client = _make_client()
-        captured = {}
+        client._request = _fake_request
+        result = client.trade("m1", "yes", amount=10.0)
+        assert result.success
 
-        def fake_request(method, path, **kwargs):
-            captured.update(kwargs.get("json", {}))
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 10, "shares_requested": 10,
-                "order_status": "MATCHED", "cost": 10.0, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+    def test_three_decimals_rejected(self):
+        client = _make_client()
+        client._request = _fake_request
+        with pytest.raises(ValueError, match="too many decimal places.*max 2"):
             client.trade("m1", "yes", amount=10.123)
 
-        assert captured["amount"] == pytest.approx(10.12)
-        assert any("rounded" in r.message for r in caplog.records)
-
-    def test_many_decimals_rounded(self, caplog):
+    def test_many_decimals_rejected(self):
         client = _make_client()
-        captured = {}
-
-        def fake_request(method, path, **kwargs):
-            captured.update(kwargs.get("json", {}))
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 5, "shares_requested": 5,
-                "order_status": "MATCHED", "cost": 5.0, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client._request = _fake_request
+        with pytest.raises(ValueError, match="too many decimal places.*max 2"):
             client.trade("m1", "yes", amount=5.333333333)
 
-        assert captured["amount"] == pytest.approx(5.33)
-
-    def test_no_warning_when_exact(self, caplog):
+    def test_error_suggests_rounded_value(self):
         client = _make_client()
-
-        def fake_request(method, path, **kwargs):
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 10, "shares_requested": 10,
-                "order_status": "MATCHED", "cost": 10.0, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
-            client.trade("m1", "yes", amount=10.50)
-
-        assert not any("rounded" in r.message for r in caplog.records)
+        client._request = _fake_request
+        with pytest.raises(ValueError, match="Use 10.12 instead"):
+            client.trade("m1", "yes", amount=10.123)
 
 
-class TestSharesDecimalRounding:
-    """shares (taker) must be rounded to 5 d.p. before submission."""
+class TestSharesDecimalValidation:
+    """shares (taker) must have max 5 decimal places."""
 
-    def test_exact_five_decimals_unchanged(self):
+    def test_exact_five_decimals_accepted(self):
         client = _make_client()
-        captured = {}
+        client._request = _fake_request
+        result = client.trade("m1", "yes", shares=1.23456, action="sell")
+        assert result.success
 
-        def fake_request(method, path, **kwargs):
-            captured.update(kwargs.get("json", {}))
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 0, "shares_requested": 0,
-                "order_status": "MATCHED", "cost": 0, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        client.trade("m1", "yes", shares=1.23456, action="sell")
-        assert captured["shares"] == pytest.approx(1.23456)
-
-    def test_six_decimals_rounded(self, caplog):
+    def test_six_decimals_rejected(self):
         client = _make_client()
-        captured = {}
-
-        def fake_request(method, path, **kwargs):
-            captured.update(kwargs.get("json", {}))
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 0, "shares_requested": 0,
-                "order_status": "MATCHED", "cost": 0, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client._request = _fake_request
+        with pytest.raises(ValueError, match="too many decimal places.*max 5"):
             client.trade("m1", "yes", shares=1.234567, action="sell")
 
-        assert captured["shares"] == pytest.approx(1.23457)
-        assert any("rounded" in r.message for r in caplog.records)
-
-    def test_no_warning_when_exact(self, caplog):
+    def test_integer_shares_accepted(self):
         client = _make_client()
-
-        def fake_request(method, path, **kwargs):
-            return {
-                "success": True, "trade_id": "t1", "market_id": "m1",
-                "side": "yes", "shares_bought": 0, "shares_requested": 0,
-                "order_status": "MATCHED", "cost": 0, "new_price": 0.5,
-                "position": {},
-            }
-
-        client._request = fake_request
-        with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
-            client.trade("m1", "yes", shares=5.0, action="sell")
-
-        assert not any("rounded" in r.message for r in caplog.records)
+        client._request = _fake_request
+        result = client.trade("m1", "yes", shares=5.0, action="sell")
+        assert result.success


### PR DESCRIPTION
## Summary
- Changes decimal validation from silent rounding to `ValueError` rejection
- Error message shows the allowed precision and suggests the corrected value
- Trading best practice: never silently modify a user's order amount

## Why
The previous implementation (PR #24) silently rounded amounts, which changes the user's intended order without consent. Exchanges like Binance/Coinbase reject invalid precision rather than modifying it — we should too.

## Test plan
- [x] 8/8 tests pass — covers accepted values, rejection, and error message content

🤖 Generated with [Claude Code](https://claude.com/claude-code)