### PR TITLE
fix: handle None unrealized_pnl from canonical P&L path (SIM-854)

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3466,10 +3466,20 @@ class SimmerClient:
             agent_id: SDK agent ID. Defaults to this client's agent_id.
 
         Returns:
-            dict with realized_pnl, unrealized_pnl, total_cost, positions
+            dict with realized_pnl, unrealized_pnl (nullable), total_cost, positions.
+
+            .. deprecated::
+                ``unrealized_pnl`` may be ``None`` and will be removed in a
+                future version.  Use ``total_pnl`` from ``/v1/trader``
+                instead.
         """
         aid = agent_id or self._agent_id
-        return self._request("GET", f"/api/sdk/agent-wallet/{aid}/pnl")
+        resp = self._request("GET", f"/api/sdk/agent-wallet/{aid}/pnl")
+        # Defensive: coerce None → 0 so callers doing arithmetic don't crash.
+        # Deprecated — will be removed in a future version. Use total_pnl from /v1/trader instead.
+        if resp.get("unrealized_pnl") is None:
+            resp["unrealized_pnl"] = 0.0
+        return resp
 
     def update_agent_wallet_creds(self, ows_wallet_name: str) -> dict:
         """Derive CLOB credentials via OWS and cache them server-side.

--- a/tests/test_agent_wallets_sdk.py
+++ b/tests/test_agent_wallets_sdk.py
@@ -110,6 +110,37 @@ class TestGetAgentWalletPnl:
 
         client._request.assert_called_once_with("GET", "/api/sdk/agent-wallet/other-agent/pnl")
 
+    def test_none_unrealized_pnl_coerced_to_zero(self):
+        """Backend returns unrealized_pnl=None on the PolyNode path (SIM-854).
+        SDK must coerce to 0.0 so callers doing arithmetic don't crash."""
+        client = _make_client(agent_id="my-agent")
+        client._request.return_value = {
+            "agent_id": "my-agent",
+            "realized_pnl": 5.0,
+            "unrealized_pnl": None,
+            "total_cost": 20.0,
+            "positions": [],
+        }
+
+        pnl = client.get_agent_wallet_pnl()
+
+        assert pnl["unrealized_pnl"] == 0.0
+        assert isinstance(pnl["unrealized_pnl"], float)
+
+    def test_missing_unrealized_pnl_key_coerced_to_zero(self):
+        """If the backend omits the key entirely, SDK must still be safe."""
+        client = _make_client(agent_id="my-agent")
+        client._request.return_value = {
+            "agent_id": "my-agent",
+            "realized_pnl": 5.0,
+            "total_cost": 20.0,
+            "positions": [],
+        }
+
+        pnl = client.get_agent_wallet_pnl()
+
+        assert pnl["unrealized_pnl"] == 0.0
+
 
 class TestUpdateAgentWalletCreds:
 


### PR DESCRIPTION
## Summary
- Coerces `unrealized_pnl: None` to `0.0` in `get_agent_wallet_pnl()` so callers doing arithmetic don't crash
- Adds deprecation notice — field will be removed in a future version, use `total_pnl` instead
- 2 new tests covering None and missing key scenarios (10/10 pass)

## Test plan
- [x] `pytest tests/test_agent_wallets_sdk.py` — 10/10 pass
- [x] Backwards compatible — existing callers get `0.0` instead of `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)