### PR TITLE
fix(polymarket-copytrading): assert simmer-sdk>=0.9.17 before reactor start (SIM-884)

### DIFF
--- a/skills/polymarket-copytrading/copytrading_trader.py
+++ b/skills/polymarket-copytrading/copytrading_trader.py
@@ -756,6 +756,10 @@ def _poll_reactor_once(client) -> int:
     return processed
 
 
+# Minimum SDK that supports the `signal_data` kwarg on client.trade().
+# The install hints below suggest >= 0.9.19 to nudge users to the latest
+# bugfix release (adds reactor retry + better error surfacing); the gate
+# itself only fails on < 0.9.17 so users on 0.9.17/0.9.18 keep working.
 REACTOR_MIN_SDK_VERSION = "0.9.17"
 
 

--- a/skills/polymarket-copytrading/copytrading_trader.py
+++ b/skills/polymarket-copytrading/copytrading_trader.py
@@ -756,11 +756,45 @@ def _poll_reactor_once(client) -> int:
     return processed
 
 
+REACTOR_MIN_SDK_VERSION = "0.9.17"
+
+
+def _assert_reactor_sdk_version() -> None:
+    """
+    Fail fast if the installed simmer-sdk is too old for reactor mode.
+
+    Reactor mode passes `signal_data` to `client.trade()`, a kwarg added in
+    simmer-sdk 0.9.17. Older SDKs raise TypeError on every signal; after 5
+    such failures the server-side circuit breaker trips and new whale signals
+    are silently skipped. Gate reactor startup so the user sees an explicit
+    upgrade message instead of silently burning signals.
+    """
+    try:
+        import simmer_sdk
+        from packaging.version import Version
+    except ImportError as e:
+        print(f"[reactor] ERROR: missing dependency ({e}). Run: pip install -U 'simmer-sdk>=0.9.19' packaging")
+        sys.exit(1)
+
+    have_str = getattr(simmer_sdk, "__version__", "0.0.0")
+    try:
+        have = Version(have_str)
+    except Exception:
+        print(f"[reactor] WARNING: could not parse simmer-sdk version {have_str!r} — skipping version gate")
+        return
+    minimum = Version(REACTOR_MIN_SDK_VERSION)
+    if have < minimum:
+        print(f"[reactor] ERROR: simmer-sdk {have} is too old. Reactor mode requires >= {minimum}.")
+        print("[reactor] Run: pip install -U 'simmer-sdk>=0.9.19'")
+        sys.exit(1)
+
+
 def run_reactor(once: bool = False) -> None:
     """
     Reactor entry point. `once=True` polls once and exits (cron-friendly);
     `once=False` runs a forever loop polling every REACTOR_POLL_INTERVAL_SECONDS.
     """
+    _assert_reactor_sdk_version()
     global _reactor_price_buffer
     client = get_client()
 

--- a/skills/polymarket-copytrading/requirements.txt
+++ b/skills/polymarket-copytrading/requirements.txt
@@ -1,1 +1,2 @@
 simmer-sdk>=0.9.19
+packaging>=20

--- a/tests/test_copytrading_reactor_version_gate.py
+++ b/tests/test_copytrading_reactor_version_gate.py
@@ -1,0 +1,72 @@
+"""Tests for copytrading reactor mode SDK version gate (SIM-884).
+
+Reactor mode requires simmer-sdk >= 0.9.17 because it passes `signal_data`
+to `client.trade()`. Older SDKs raise TypeError on every signal and trip
+the circuit breaker. The gate fails fast with an upgrade message instead.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+SKILL_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "skills"
+    / "polymarket-copytrading"
+    / "copytrading_trader.py"
+)
+
+
+def _load_trader_module():
+    """Load copytrading_trader.py as a module without executing CLI argparse."""
+    spec = importlib.util.spec_from_file_location("copytrading_trader_under_test", SKILL_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    # Prevent get_client() / config failures from being surfaced at import by
+    # providing a dummy SIMMER_API_KEY; the module only reads env at runtime.
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_version_gate_exits_on_old_sdk(capsys):
+    mod = _load_trader_module()
+    fake_sdk = type(sys)("simmer_sdk")
+    fake_sdk.__version__ = "0.9.16"
+    with patch.dict(sys.modules, {"simmer_sdk": fake_sdk}):
+        with pytest.raises(SystemExit) as exc:
+            mod._assert_reactor_sdk_version()
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "too old" in captured.out
+    assert "0.9.17" in captured.out
+    assert "pip install" in captured.out
+
+
+def test_version_gate_passes_on_min_version():
+    mod = _load_trader_module()
+    fake_sdk = type(sys)("simmer_sdk")
+    fake_sdk.__version__ = "0.9.17"
+    with patch.dict(sys.modules, {"simmer_sdk": fake_sdk}):
+        mod._assert_reactor_sdk_version()  # must not raise
+
+
+def test_version_gate_passes_on_newer_version():
+    mod = _load_trader_module()
+    fake_sdk = type(sys)("simmer_sdk")
+    fake_sdk.__version__ = "0.9.25"
+    with patch.dict(sys.modules, {"simmer_sdk": fake_sdk}):
+        mod._assert_reactor_sdk_version()  # must not raise
+
+
+def test_version_gate_tolerates_unparseable_version(capsys):
+    """Unparseable versions should warn, not exit — don't break dev installs."""
+    mod = _load_trader_module()
+    fake_sdk = type(sys)("simmer_sdk")
+    fake_sdk.__version__ = "not-a-version"
+    with patch.dict(sys.modules, {"simmer_sdk": fake_sdk}):
+        mod._assert_reactor_sdk_version()  # must not raise
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.out or "could not parse" in captured.out


### PR DESCRIPTION
## Summary
- Adds `_assert_reactor_sdk_version()` helper gating `run_reactor()` startup.
- Reactor mode passes `signal_data` to `client.trade()` — a kwarg added in simmer-sdk 0.9.17. With older SDKs, every signal raised `TypeError` and 5 failures tripped the server-side circuit breaker, silently dropping subsequent whale signals.
- Fails fast with an explicit upgrade message (`pip install -U 'simmer-sdk>=0.9.19'`) and `sys.exit(1)` before the first poll. Polling mode is unchanged (no gate).
- Ships 4 unit tests covering: old SDK exits, min version passes, newer version passes, unparseable version tolerates.

## Why
SIM-884. Closes the last gap after the UI + docs fixes (simmer-docs c8397db, simmer-sdk #29, simmer #281) — the skill now self-diagnoses instead of relying on release notes.

## Test plan
- [x] `pytest tests/test_copytrading_reactor_version_gate.py -v` — 4 passed
- [x] `py_compile skills/polymarket-copytrading/copytrading_trader.py`
- [ ] Manual: run `copytrading_trader.py --reactor` with simmer-sdk 0.9.16 → expect exit 1 with upgrade message
- [ ] Manual: run `copytrading_trader.py --reactor` with simmer-sdk 0.9.19 → expect normal startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)