### PR TITLE
SIM-956: weather-trader SKILL.md honesty pass (cohort metrics + successor link)

### DIFF
--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -14,6 +14,8 @@ Trade temperature markets on Polymarket using NOAA forecast data.
 
 > **This is a template.** The default signal is NOAA temperature forecasts — remix it with other weather APIs, different forecast models, or additional market types (precipitation, wind, etc.). The skill handles all the plumbing (market discovery, NOAA parsing, trade execution, safeguards). Your agent provides the alpha.
 
+> **Looking for a more sophisticated weather strategy?** A successor skill based on AlterEgo's open-source [weatherbot](https://github.com/alteregoeth-ai/weatherbot) is in development. It adds EV-gated entry, fractional Kelly sizing, per-city-per-source sigma calibration, trailing stop-loss, forecast-change exits, and multi-source forecasts (ECMWF + HRRR + METAR) across 20 cities. Track progress in SIM-952. This skill (threshold-buy on NOAA) remains supported as the simpler, lower-ceremony option.
+
 ## When to Use This Skill
 
 Use this skill when the user wants to:
@@ -30,6 +32,18 @@ Use this skill when the user wants to:
   - `SIMMER_WEATHER_VOL_MAX_LEVERAGE` — max scale-up multiplier (default 2.0x)
   - `SIMMER_WEATHER_VOL_MIN_ALLOC` — min allocation floor (default 20%)
   - `SIMMER_WEATHER_VOL_SPAN` — EWMA responsiveness (default 10)
+
+## Cohort Performance (as of 2026-04)
+
+Honest numbers from the wallets running the pre-v1.18.0 version of this strategy:
+
+- **435 dominant wallets** using this strategy
+- **13.3% profitable** (58 of 435)
+- **-$13.6K aggregate P&L** across all wallets
+- Strategy is threshold-buy without stop-loss (v1.17.0 and earlier)
+- v1.18.0 adds stop-loss protection (default 50% drawdown) to limit downside on the 86.7% of wallets that have been losing money
+
+If you're considering running this skill, factor this cohort performance into your decision. The thresholds can be tuned (try raising `SIMMER_WEATHER_ENTRY_THRESHOLD` for fewer, higher-conviction buys), and v1.18.0's stop-loss will cap per-position drawdown — but the base strategy has been net-negative across the dominant-wallet cohort. The successor AlterEgo-based skill (see header above) is the more sophisticated alternative.
 
 ### v1.14.0
 


### PR DESCRIPTION
## Summary

Updates `skills/polymarket-weather-trader/SKILL.md` for the v1.18.0 release to be transparent about strategy performance and surface the upcoming successor skill.

- **Cohort Performance section** (after What's New in v1.17.0): real numbers from the 435 dominant wallets running this skill — 13.3% profitable, -\$13.6K aggregate P&L. Frames v1.18.0 stop-loss (default 50% drawdown) as downside protection for the 86.7% of wallets currently running net-negative.
- **Successor skill callout** (near the header, directly after the template blurb): points to the AlterEgo-based weatherbot port in development (EV-gated entry, Kelly sizing, multi-source forecasts, trailing stop-loss). Tracks SIM-952.
- **Setup Flow defaults**: already consistent with Configuration table and clawhub.json (15¢ / 45¢ / \$2.00) per SIM-955 — no changes required.

Docs-only change. No code touched.

## Test plan

- [x] Visual read of the updated SKILL.md
- [x] Setup Flow defaults (step 4) match Configuration table rows for entry/exit/max-position
- [x] Successor callout renders as a blockquote directly after the template callout
- [x] Cohort Performance section slots between "What's New in v1.17.0" and "### v1.14.0" without breaking the changelog hierarchy

## Related

- Parent: SIM-952 (Weather strategy diversification — AlterEgo skill + v1.18.0)
- Sibling: SIM-954 (stop-loss), SIM-955 (clawhub.json defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)