### PR TITLE
feat(sizing): empirical Kelly CV haircut (SIM-1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- **`empirical_kelly(edge_samples, market_price, clip=0.25)`** in `simmer_sdk.sizing` — coefficient-of-variation haircut on Kelly sizing for use with Monte Carlo / bootstrap resamples of a historical analog set: `f_empirical = f_kelly × (1 − CV_edge)`. High model uncertainty → aggressive haircut; low uncertainty → closer to theoretical Kelly. Opt-in primitive alongside existing `kelly_fraction` / `size_position` — default behavior of existing callers is unchanged. Result is always clipped to `[0, clip]`. (SIM-1012)
+
 ## [0.9.21] — 2026-04-07
 
 ### Added

--- a/simmer_sdk/__init__.py
+++ b/simmer_sdk/__init__.py
@@ -100,6 +100,7 @@ __all__ = [
     "kelly_fraction",
     "expected_value",
     "size_position",
+    "empirical_kelly",
     "SIZING_CONFIG_SCHEMA",
 ]
 
@@ -109,4 +110,10 @@ from .skill import update_config as update_skill_config
 from .skill import get_config_path as get_skill_config_path
 
 # Position sizing utilities
-from .sizing import kelly_fraction, expected_value, size_position, SIZING_CONFIG_SCHEMA
+from .sizing import (
+    kelly_fraction,
+    expected_value,
+    size_position,
+    empirical_kelly,
+    SIZING_CONFIG_SCHEMA,
+)

--- a/simmer_sdk/sizing.py
+++ b/simmer_sdk/sizing.py
@@ -28,7 +28,9 @@ Sizing methods:
       Simple but ignores edge magnitude.
 """
 
-from typing import Optional
+from typing import Optional, Sequence
+import math
+import statistics
 
 
 def expected_value(p_win: float, market_price: float) -> float:
@@ -153,6 +155,113 @@ def size_position(
 
     f = min(f, max_fraction)
     return bankroll * f
+
+
+def empirical_kelly(
+    edge_samples: Sequence[float],
+    market_price: float,
+    clip: float = 0.25,
+) -> float:
+    """Coefficient-of-variation adjusted Kelly fraction for a binary market.
+
+    Textbook Kelly assumes the edge is known with certainty. In practice a
+    model's edge estimate is a point estimate over a distribution — the true
+    edge might be half or double. Treating the point estimate as fact causes
+    systematic overbetting; the standard fix is to haircut Kelly by the
+    coefficient of variation (CV) of the edge distribution::
+
+        f_empirical = f_kelly × (1 − CV_edge)
+        CV_edge     = stdev(edge_samples) / mean(edge_samples)
+
+    High model uncertainty (wide edge distribution) → aggressive haircut.
+    Low uncertainty (tight distribution) → sizing approaches theoretical Kelly.
+
+    ``edge_samples`` are typically produced by Monte Carlo resampling of a
+    historical analog set (see SIM-1011 dataset-backtest-ingest skill), but
+    any iterable of edge estimates (e.g. bootstrap resamples of a backtest)
+    works. The function takes the raw samples so callers are not required
+    to install a specific dataset.
+
+    The Kelly conversion uses the prediction-market form consistent with
+    :func:`kelly_fraction`::
+
+        f_kelly = mean(edge_samples) / (1 − market_price)
+
+    The result is clamped to ``[0, clip]``: negative point estimates,
+    CV ≥ 1 (uncertainty swamps edge), and pathological inputs all map
+    to 0. Positive values are capped at ``clip`` — an absolute cap,
+    separate from the relative ``max_fraction`` used by
+    :func:`size_position`. The default ``clip=0.25`` reflects the
+    empirical-method stance that sizing should be conservative even when
+    uncertainty is low; callers wanting a tighter cap can pass ``clip`` down.
+
+    Args:
+        edge_samples: Sequence of edge estimates (``p_win − market_price``),
+            one per Monte Carlo / bootstrap resample. Must contain at least
+            one sample. With a single sample ``stdev`` is undefined and CV
+            is treated as 0 (falls back to point-estimate Kelly).
+        market_price: Current market price / cost per YES share (0 < price < 1).
+            Called ``odds`` in the source spec — in a binary prediction market
+            this is the cost per share, which equals implied probability.
+        clip: Absolute cap on returned fraction. Defaults to 0.25 (quarter
+            of bankroll). Pass a larger value to opt out of the cap.
+
+    Returns:
+        Fraction of bankroll to wager, in ``[0, clip]``. Never negative,
+        never > ``clip``. Returns 0 for invalid inputs (empty samples,
+        non-positive mean edge, CV ≥ 1, invalid market_price).
+
+    Example:
+        >>> # 6% point estimate with 3–9% distribution (article worked example),
+        >>> # market at 50¢. Five uniformly-spaced samples.
+        >>> samples = [0.03, 0.045, 0.06, 0.075, 0.09]
+        >>> round(empirical_kelly(samples, 0.50), 4)
+        0.0726
+
+        >>> # Zero variance → matches theoretical Kelly (capped at clip).
+        >>> empirical_kelly([0.15, 0.15, 0.15], 0.55)  # f_kelly = 0.333, clipped
+        0.25
+
+        >>> # CV = 1 → full haircut.
+        >>> round(empirical_kelly([0.0, 0.2], 0.50), 6)
+        0.0
+    """
+    if not edge_samples:
+        return 0.0
+    if market_price <= 0.0 or market_price >= 1.0:
+        return 0.0
+    if clip <= 0.0:
+        return 0.0
+
+    samples = list(edge_samples)
+    for s in samples:
+        if not math.isfinite(s):
+            return 0.0
+
+    mean_edge = statistics.fmean(samples)
+    if mean_edge <= 0.0:
+        return 0.0
+
+    # stdev requires n >= 2; with a single sample there is no variance
+    # information, so CV defaults to 0 (use point-estimate Kelly).
+    if len(samples) >= 2:
+        stdev_edge = statistics.stdev(samples)
+    else:
+        stdev_edge = 0.0
+
+    cv_edge = stdev_edge / mean_edge
+    haircut = 1.0 - cv_edge
+    # Snap floating-point epsilon around CV ≈ 1 to a hard zero so
+    # "CV = 1.0 → full haircut" holds exactly.
+    if haircut <= 1e-12:
+        return 0.0
+
+    f_kelly = mean_edge / (1.0 - market_price)
+    f_empirical = f_kelly * haircut
+
+    if f_empirical <= 0.0:
+        return 0.0
+    return min(f_empirical, clip)
 
 
 # Config schema that skills can merge into their CONFIG_SCHEMA for

--- a/tests/test_empirical_kelly.py
+++ b/tests/test_empirical_kelly.py
@@ -1,0 +1,186 @@
+"""Tests for simmer_sdk.sizing.empirical_kelly — CV-haircut Kelly sizing.
+
+See SIM-1012. Covers the acceptance criteria:
+- Returns a float in [0, clip], never negative, never > clip
+- CV=0 input matches theoretical Kelly to <1e-6 (when under clip)
+- CV=1.0 input yields 0 (full haircut)
+- Zero-variance, unit-variance, wide-distribution edge cases
+- "6% point estimate with 3–9% distribution" worked example
+- Does NOT change default behavior of existing Kelly callers
+"""
+
+import math
+import statistics
+
+import pytest
+
+from simmer_sdk.sizing import (
+    empirical_kelly,
+    kelly_fraction,
+    size_position,
+)
+
+
+# --- core contract: bounds ---
+
+def test_result_never_negative():
+    assert empirical_kelly([-0.05, -0.1, 0.02], 0.55) == 0.0
+    assert empirical_kelly([0.0], 0.55) == 0.0
+
+
+def test_result_never_exceeds_clip_default():
+    # Very large edge, zero variance → raw Kelly would blow past 0.25,
+    # must be clipped.
+    result = empirical_kelly([0.40, 0.40, 0.40], 0.50)
+    assert 0.0 <= result <= 0.25
+    assert result == pytest.approx(0.25)
+
+
+def test_result_never_exceeds_custom_clip():
+    result = empirical_kelly([0.40, 0.40, 0.40], 0.50, clip=0.10)
+    assert result == pytest.approx(0.10)
+
+
+def test_result_is_float():
+    result = empirical_kelly([0.05, 0.06, 0.07], 0.50)
+    assert isinstance(result, float)
+
+
+# --- CV = 0 case ---
+
+def test_cv_zero_matches_theoretical_kelly_within_clip():
+    # All samples identical → CV = 0 → no haircut.
+    # mean_edge = 0.05, price = 0.60 → f_kelly = 0.05 / 0.40 = 0.125
+    samples = [0.05, 0.05, 0.05]
+    expected = kelly_fraction(0.65, 0.60)  # 0.125
+    result = empirical_kelly(samples, 0.60, clip=0.5)  # clip above expected
+    assert result == pytest.approx(expected, abs=1e-6)
+
+
+def test_cv_zero_single_sample_falls_back_to_point_kelly():
+    # Single sample → no stdev → treat CV as 0 → point-estimate Kelly.
+    samples = [0.10]
+    expected = 0.10 / (1.0 - 0.60)  # 0.25
+    result = empirical_kelly(samples, 0.60, clip=0.5)
+    assert result == pytest.approx(expected, abs=1e-6)
+
+
+# --- CV = 1 case ---
+
+def test_cv_exactly_one_yields_zero():
+    # Samples [0, 0.1, 0.2] → mean=0.1, stdev=0.1, CV=1.0 → haircut = 0.
+    samples = [0.0, 0.1, 0.2]
+    mean = statistics.fmean(samples)
+    stdev = statistics.stdev(samples)
+    assert stdev / mean == pytest.approx(1.0, abs=1e-12)  # precondition
+    assert empirical_kelly(samples, 0.50) == 0.0
+
+
+def test_cv_above_one_yields_zero():
+    # stdev > mean → negative haircut → output 0.
+    samples = [0.01, 0.01, 0.28]  # CV ~ 1.56
+    assert empirical_kelly(samples, 0.50) == 0.0
+
+
+# --- worked example from aleiahlock article ---
+
+def test_worked_example_6pct_with_3_to_9pct_distribution():
+    # 6% point estimate with 3–9% distribution (aleiahlock article,
+    # SIM-1007 source). Uniform sampling across the stated range.
+    samples = [0.03, 0.045, 0.06, 0.075, 0.09]
+    market_price = 0.50
+
+    mean_edge = statistics.fmean(samples)
+    assert mean_edge == pytest.approx(0.06)
+
+    stdev_edge = statistics.stdev(samples)
+    cv = stdev_edge / mean_edge
+    f_kelly = mean_edge / (1.0 - market_price)
+    expected = f_kelly * (1.0 - cv)
+
+    result = empirical_kelly(samples, market_price)
+    assert result == pytest.approx(expected, rel=1e-9)
+    # Sanity: noticeably smaller than point-estimate Kelly (0.12).
+    assert result < f_kelly
+    assert result == pytest.approx(0.0726, abs=1e-4)
+
+
+# --- wide-distribution edge cases ---
+
+def test_wide_distribution_produces_larger_haircut_than_tight():
+    tight = [0.058, 0.06, 0.062]
+    wide = [0.02, 0.06, 0.10]
+    price = 0.50
+
+    tight_result = empirical_kelly(tight, price)
+    wide_result = empirical_kelly(wide, price)
+
+    assert 0.0 < wide_result < tight_result
+
+
+def test_unit_variance_edge_samples():
+    # stdev of [0, 1, 2, 3, 4] = sqrt(2.5) ≈ 1.581 — but these aren't
+    # prediction-market edges. Use a scaled variant: mean=0.1, with
+    # n-1 variance = 1e-4 (stdev = 0.01, CV = 0.1 → haircut 0.9).
+    samples = [0.09, 0.095, 0.10, 0.105, 0.11]
+    price = 0.50
+
+    mean = statistics.fmean(samples)
+    stdev = statistics.stdev(samples)
+    expected = (mean / (1.0 - price)) * (1.0 - stdev / mean)
+
+    result = empirical_kelly(samples, price)
+    assert result == pytest.approx(expected, rel=1e-9)
+
+
+# --- boundary / invalid inputs ---
+
+def test_empty_samples_returns_zero():
+    assert empirical_kelly([], 0.50) == 0.0
+
+
+def test_invalid_market_price_returns_zero():
+    samples = [0.05, 0.06, 0.07]
+    assert empirical_kelly(samples, 0.0) == 0.0
+    assert empirical_kelly(samples, 1.0) == 0.0
+    assert empirical_kelly(samples, -0.1) == 0.0
+    assert empirical_kelly(samples, 1.5) == 0.0
+
+
+def test_non_finite_samples_return_zero():
+    assert empirical_kelly([0.05, math.nan, 0.07], 0.50) == 0.0
+    assert empirical_kelly([0.05, math.inf, 0.07], 0.50) == 0.0
+
+
+def test_non_positive_clip_returns_zero():
+    samples = [0.05, 0.06, 0.07]
+    assert empirical_kelly(samples, 0.50, clip=0.0) == 0.0
+    assert empirical_kelly(samples, 0.50, clip=-0.1) == 0.0
+
+
+def test_accepts_tuple_and_generator():
+    samples = (0.04, 0.05, 0.06)
+    tuple_result = empirical_kelly(samples, 0.50)
+    list_result = empirical_kelly(list(samples), 0.50)
+    assert tuple_result == pytest.approx(list_result)
+
+
+# --- non-regression: existing Kelly callers unchanged ---
+
+def test_kelly_fraction_behavior_unchanged():
+    assert kelly_fraction(0.70, 0.55) == pytest.approx(1 / 3, rel=1e-6)
+    assert kelly_fraction(0.55, 0.55) == pytest.approx(0.0)
+    assert kelly_fraction(0.40, 0.55) < 0
+
+
+def test_size_position_default_behavior_unchanged():
+    # Quarter-Kelly of 0.333 * 1000 = 83.33 — must not change.
+    assert size_position(0.70, 0.55, 1000.0) == pytest.approx(83.33, rel=0.01)
+
+
+def test_empirical_kelly_is_not_called_by_existing_size_position():
+    # Sanity: size_position path does not touch empirical_kelly.
+    # A very high-CV edge distribution should have no effect on
+    # size_position (it doesn't accept edge_samples).
+    amount = size_position(0.70, 0.55, 1000.0)
+    assert amount > 0


### PR DESCRIPTION
## Summary

Adds `empirical_kelly(edge_samples, market_price, clip=0.25)` to `simmer_sdk.sizing` — a coefficient-of-variation haircut on Kelly sizing for use with Monte Carlo / bootstrap resamples of an edge-estimate distribution.

    f_empirical = f_kelly × (1 − CV_edge)
    CV_edge     = stdev(edge_samples) / mean(edge_samples)

High model uncertainty → aggressive haircut; low uncertainty → near-theoretical Kelly. This is the direct math-layer fix to the retail-overbetting failure mode called out in the aleiahlock article (SIM-1007).

## Acceptance criteria

- [x] Returns a float in `[0, clip]`, never negative, never > `clip`
- [x] CV = 0 input matches theoretical Kelly within 1e-6 (when under clip)
- [x] CV = 1.0 input returns exactly 0 (full haircut; floating-point epsilon snapped)
- [x] Unit tests cover zero-variance, unit-variance, wide-distribution, CV > 1, and the "6% point estimate with 3–9% distribution" worked example
- [x] Does not change behavior of existing `kelly_fraction` / `size_position` callers — opt-in primitive

## Files

- `simmer_sdk/sizing.py` — `empirical_kelly()` added alongside existing API
- `simmer_sdk/__init__.py` — export
- `tests/test_empirical_kelly.py` — 19 new tests (43 total in sizing suite, all pass)
- `CHANGELOG.md` — Unreleased entry

Cross-reference to `shared-knowledge/patterns/prediction-market-trading-frameworks.md` committed separately in simmer-labs.

## Test plan

- [x] `pytest tests/test_empirical_kelly.py tests/test_sizing.py` — 43/43 pass
- [ ] Review docstring worked example renders correctly in docs pipeline
- [ ] Mintlify `docs/sdk/position-sizing` needs a follow-up section on `empirical_kelly` before next SDK release (flagged in docs-impact below)

## Docs impact

**Yes** — new public SDK method. Needs:
- Mintlify `sdk/position-sizing` update (follow-up)
- `website/public/skill.md` unchanged (sizing primitives already referenced generically)

## Skills affected

No existing skill uses this yet — it's a new primitive available to skill authors. Skills that want to consume SIM-1011 Monte Carlo resample output will call this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)