### PR TITLE
fix(skills): declare WALLET_PRIVATE_KEY in clawhub.json for OpenClaw moderation alignment

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,6 +7,7 @@
 #
 # Safety:
 #   - Only publishes if SKILL.md has `published: true`
+#   - Refuses if clawhub.json has `"publish": false`
 #   - Slug comes from `name:` field (no folder name guessing)
 #   - Version comes from `version:` field (matches --version flag)
 #   - Copies full directory (no missing files)
@@ -58,6 +59,19 @@ if [ "$PUBLISHED" != "true" ]; then
   echo "❌ Skill '$NAME' is not marked for publishing (published: $PUBLISHED)"
   echo "   Add 'published: true' to $SKILL_MD frontmatter to enable"
   exit 1
+fi
+
+# Second guard: honor clawhub.json "publish": false
+CLAWHUB_JSON="$SKILL_DIR/clawhub.json"
+if [ -f "$CLAWHUB_JSON" ]; then
+  PUBLISH_FLAG=$(python3 -c "import json,sys; print(json.load(open('$CLAWHUB_JSON')).get('publish', True))" 2>/dev/null || echo "True")
+  if [ "$PUBLISH_FLAG" = "False" ]; then
+    REASON=$(python3 -c "import json; print(json.load(open('$CLAWHUB_JSON')).get('publish_reason', 'no reason given'))" 2>/dev/null || echo "unknown")
+    echo "❌ Skill '$NAME' is marked 'publish: false' in clawhub.json"
+    echo "   Reason: $REASON"
+    echo "   Remove the flag from clawhub.json if you intend to publish."
+    exit 1
+  fi
 fi
 
 echo "📦 Publishing $NAME@$VERSION"

--- a/skills/polymarket-ai-divergence/SKILL.md
+++ b/skills/polymarket-ai-divergence/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-ai-divergence
 description: Find markets where Simmer's AI consensus diverges from the real market price, then trade on the mispriced side using Kelly sizing. Scans for divergence, checks fees and safeguards, and executes trades on zero-fee markets with sufficient edge.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "2.2.6"
+  version: "2.2.7"
   displayName: Polymarket AI Divergence
   difficulty: intermediate
 ---

--- a/skills/polymarket-ai-divergence/SKILL.md
+++ b/skills/polymarket-ai-divergence/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-ai-divergence
 description: Find markets where Simmer's AI consensus diverges from the real market price, then trade on the mispriced side using Kelly sizing. Scans for divergence, checks fees and safeguards, and executes trades on zero-fee markets with sufficient edge.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "2.2.5"
+  version: "2.2.6"
   displayName: Polymarket AI Divergence
   difficulty: intermediate
 ---

--- a/skills/polymarket-ai-divergence/clawhub.json
+++ b/skills/polymarket-ai-divergence/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83d\udd2e",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.9.0"
+  version: "1.9.1"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---

--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.9.1"
+  version: "1.9.2"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---

--- a/skills/polymarket-copytrading/clawhub.json
+++ b/skills/polymarket-copytrading/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83d\udc0b",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-elon-tweets/SKILL.md
+++ b/skills/polymarket-elon-tweets/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-elon-tweets
 description: 'Trade Polymarket "Elon Musk # tweets" markets using XTracker post count data. Buys adjacent range buckets when combined cost < $1 for structural edge. Use when user wants to trade tweet count markets, automate Elon tweet bets, check XTracker stats, or run noovd-style trading.'
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.2.0"
+  version: "1.2.1"
   displayName: Polymarket Elon Tweet Trader
   difficulty: advanced
   attribution: Strategy inspired by @noovd

--- a/skills/polymarket-elon-tweets/clawhub.json
+++ b/skills/polymarket-elon-tweets/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83d\udc26",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.5.0"
+  version: "1.5.1"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.5.1"
+  version: "1.5.4"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/clawhub.json
+++ b/skills/polymarket-fast-loop/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\u26a1",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. Snipe markets about to resolve when the odds are heavily skewed. Filter by topic, cap your bets, and only trade strong splits close to deadline.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.1.0"
+  version: "1.1.1"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. Snipe markets about to resolve when the odds are heavily skewed. Filter by topic, cap your bets, and only trade strong splits close to deadline.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.1.1"
+  version: "1.1.3"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/clawhub.json
+++ b/skills/polymarket-mert-sniper/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83c\udfaf",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-nothing-ever-happens/clawhub.json
+++ b/skills/polymarket-nothing-ever-happens/clawhub.json
@@ -4,7 +4,8 @@
   "emoji": "📉",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-signal-sniper/SKILL.md
+++ b/skills/polymarket-signal-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-signal-sniper
 description: Snipe Polymarket opportunities from your own signal sources. Monitors RSS feeds with Trading Agent-grade safeguards.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.4.0"
+  version: "1.4.1"
   displayName: Polymarket Signal Sniper
   difficulty: intermediate
 ---

--- a/skills/polymarket-signal-sniper/SKILL.md
+++ b/skills/polymarket-signal-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-signal-sniper
 description: Snipe Polymarket opportunities from your own signal sources. Monitors RSS feeds with Trading Agent-grade safeguards.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.4.1"
+  version: "1.4.6"
   displayName: Polymarket Signal Sniper
   difficulty: intermediate
 ---

--- a/skills/polymarket-signal-sniper/clawhub.json
+++ b/skills/polymarket-signal-sniper/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83c\udfaf",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.18.1"
+  version: "1.18.2"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/clawhub.json
+++ b/skills/polymarket-weather-trader/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83c\udf21\ufe0f",
   "requires": {
     "env": [
-      "SIMMER_API_KEY"
+      "SIMMER_API_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "simmer-sdk"

--- a/skills/simmer-x402/SKILL.md
+++ b/skills/simmer-x402/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-x402
 description: Make x402 payments to access paid APIs and gated content. Use when a skill needs to fetch data from x402-gated endpoints (like Kaito mindshare API, Simmer premium endpoints, or any x402 provider). Handles 402 Payment Required responses automatically using USDC on Base.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.2"
+  version: "1.0.3"
   displayName: x402 Payments
   difficulty: advanced
 ---

--- a/skills/simmer-x402/SKILL.md
+++ b/skills/simmer-x402/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-x402
 description: Make x402 payments to access paid APIs and gated content. Use when a skill needs to fetch data from x402-gated endpoints (like Kaito mindshare API, Simmer premium endpoints, or any x402 provider). Handles 402 Payment Required responses automatically using USDC on Base.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.3"
+  version: "1.0.7"
   displayName: x402 Payments
   difficulty: advanced
 ---

--- a/skills/simmer-x402/clawhub.json
+++ b/skills/simmer-x402/clawhub.json
@@ -2,7 +2,8 @@
   "emoji": "\ud83d\udcb3",
   "requires": {
     "env": [
-      "EVM_PRIVATE_KEY"
+      "EVM_PRIVATE_KEY",
+      "WALLET_PRIVATE_KEY"
     ],
     "pip": [
       "x402[httpx,evm]"


### PR DESCRIPTION
## Summary

Adds \`WALLET_PRIVATE_KEY\` to \`clawhub.json\` \`requires.env\` for 8 polymarket-* + simmer-x402 skills that teach wallet signing in their SKILL.md but didn't declare the env var. Also adds a \`publish: false\` honor-check to \`scripts/publish.sh\` so skills marked "not for publishing" can't be accidentally released via the script.

## Why

Between Mar 29 and Apr 22 2026, new-agent registrations on simmer.markets fell ~80% MoM (1,248/wk → 287/wk). Root cause traced to ClawHub's OpenClaw moderation scanner activating against these skills after a mass re-scan on Mar 22-23. Every SDK republish since then has been freshly flagged.

OpenClaw's verdict (from ClawHub skill page):

> "The skill's runtime instructions require and instruct handling of sensitive credentials (API key and private key) but the skill metadata declares no required environment variables or credentials — this mismatch and the guidance to store/sign keys locally is coherent with its purpose but not proportionately declared and warrants caution."

Translation: SKILL.md teaches users to \`export WALLET_PRIVATE_KEY=0x...\` for external-wallet trading, but \`clawhub.json\` only declares \`SIMMER_API_KEY\`. The scanner reads this as a hidden-credential signal. Declare it, the verdict clears.

## Skills republished

All 8 republished directly to ClawHub with the manifest fix during the investigation session:

| Skill | Old | New |
|---|---|---|
| polymarket-ai-divergence | 2.2.6 | **2.2.7** |
| polymarket-copytrading | 1.9.1 | **1.9.2** (also ships SIM-884 reactor SDK guard) |
| polymarket-elon-tweets | 1.2.0 | **1.2.1** |
| polymarket-fast-loop | 1.5.3 | **1.5.4** |
| polymarket-mert-sniper | 1.1.2 | **1.1.3** |
| polymarket-signal-sniper | 1.4.5 | **1.4.6** |
| polymarket-weather-trader | 1.18.1 | **1.18.2** |
| simmer-x402 | 1.0.6 | **1.0.7** |

\`polymarket-nothing-ever-happens\` manifest was also fixed for correctness but not republished — it's already hidden on ClawHub (intentionally not for public distribution).

## publish.sh safety

Previous behavior: \`scripts/publish.sh\` honored SKILL.md \`published: true\` frontmatter flag only. The \`publish: false\` flag in \`clawhub.json\` was a human-readable guard that the script ignored. Result: \`polymarket-nothing-ever-happens\` was published via direct \`clawhub publish\` despite \`publish: false\`.

New behavior: script checks \`clawhub.json\` \`publish\` field and refuses with the reason string. Belt-and-suspenders for the two-flag pattern.

## Remaining blocker (not resolved by this PR)

VirusTotal Code Insight still flags most of these skills as "Suspicious" based on behavioral patterns (crypto keys + external HTTP + credential handling). That's a heuristic LLM scan that can't be fixed by code changes. Resolution requires ClawHub admin action — either \`trustedPublisher = true\` on the adlai88 user record, or per-skill manual overrides via \`setSkillManualOverride\`. Reaching out to ClawHub team separately via #clawhub on Discord.

Sibling PRs:
- Main simmer skill: SupaFund/simmer#307
- Publisher-facing docs: SpartanLabsXyz/simmer-docs#5

## Test plan

- [x] All 8 skills published successfully
- [ ] After ClawHub rescan propagates (minutes), \`npx clawhub install <slug>\` no longer hits OpenClaw "Suspicious" verdict
- [ ] VT Code Insight may still flag — tracked via ClawHub outreach
- [ ] Simmer registry sync (6h cadence) picks up new versions and updates \`install_count\` UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)