### PR TITLE
SIM-890 P1.8-P1.11: Polymarket V2 SDK support (bump to 0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,74 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] — 2026-04-28
+
+### Polymarket V2 migration support
+
+Polymarket cuts over to V2 on **2026-04-28 ~11:00 UTC**. V2 uses **pUSD**
+(1:1 wrapper around USDC.e) as exchange collateral and introduces a new
+order struct. See https://docs.simmer.markets/v2-migration.
+
+**0.10.0 defaults to V2.** To pin V1 temporarily (rare — V1 CLOB is
+retired), set `SIMMER_POLYMARKET_EXCHANGE_VERSION=v1` env, or pin
+`simmer-sdk<0.10.0`.
+
+### Added
+
+- **`simmer_sdk.polymarket_contracts`** — new module mirroring the
+  server-side contract registry. Exports `is_v2_enabled()`,
+  `active_spenders()`, `collateral_token()`, `exchange_version_str()`,
+  V1/V2 addresses, and CollateralOnramp/Offramp. Use these instead of
+  hardcoding addresses.
+- **`simmer_sdk.approvals`** — flag-aware approval tx generation.
+  - V2: 4 V2 spenders × pUSD + CTF = 8 approvals
+  - V1 (if pinned): 3 V1 spenders × (USDC + USDC.e) + CTF = 9 approvals
+- **`build_and_sign_order()`** — now dispatches to V2 path (via
+  `py-clob-client-v2`) when flag on, V1 path otherwise. New optional
+  `builder_code` and `metadata` args for V2 attribution. `fee_rate_bps`
+  arg kept for V1 compat but ignored on V2 (fees are match-time,
+  not embedded in the signed order).
+- **`SignedOrder`** — now supports both V1 and V2 shape via optional
+  fields. `to_dict()` emits only the fields relevant to each version.
+  Adds `exchange_version` meta field (`"v1"` or `"v2"`).
+
+### Changed
+
+- **Polymarket collateral** — server-signed trades through
+  `client.place_order()` route via pUSD post-cutover (no SDK code
+  change needed — the backend handles it via flag).
+- **Wallet status response** (from `client.get_wallet_status()` and
+  friends) — now includes `balance_pusd`, `balance_usdc_bridged`, and
+  `spendable_pusd_balance` fields. Use `spendable_pusd_balance` (raw
+  pUSD × (1 − fee buffer, default 5%)) to size orders on V2 — leaves
+  headroom for the 2-5% match-time fee that V2 charges but doesn't
+  embed in the signed order.
+- **V2 "insufficient balance" errors** on `client.place_order()` now
+  point to the migration URL if the user still holds USDC.e
+  post-cutover.
+
+### Dependencies
+
+- Added `py-clob-client-v2>=1.0.0` (V2 signing path). V1 deps
+  `py-clob-client` and `py-order-utils` retained for flag-off users.
+
+### Migration notes
+
+**Server-signed paths** (managed wallets, SDK keys — the default):
+Just `pip install -U simmer-sdk`. Trades route through pUSD
+automatically post-cutover — no code change required.
+
+**External wallet paths** (you build orders locally via
+`build_and_sign_order()`): upgrade to 0.10.0, call
+`get_approval_transactions()` to get the V2 spender set, optionally
+mint a V2 builder code at
+[polymarket.com/settings?tab=builder](https://polymarket.com/settings?tab=builder)
+and pass it as `builder_code` (or set `POLY_BUILDER_CODE` env).
+
+**Direct Polymarket CLOB users** (bypassing simmer-sdk): see the
+[Integrator section](https://docs.simmer.markets/v2-migration#for-integrators)
+of our migration guide.
+
 ## [0.9.21] — 2026-04-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.9.23"
+version = "0.10.0"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [
@@ -31,6 +31,9 @@ dependencies = [
     "eth-account>=0.13.0",
     "py-order-utils>=0.3.0",
     "py-clob-client>=0.30.0",
+    # V2 CLOB client for Polymarket V2 (2026-04-28 cutover). V1 deps
+    # retained for users who pin SIMMER_POLYMARKET_EXCHANGE_VERSION=v1.
+    "py-clob-client-v2>=1.0.0",
 ]
 
 [project.urls]

--- a/simmer_sdk/approvals.py
+++ b/simmer_sdk/approvals.py
@@ -4,17 +4,23 @@ Polymarket Approval Utilities
 Helps users set up the required token approvals for Polymarket trading.
 External wallets need to approve several spender contracts before trading.
 
-Required approvals:
-1. USDC.e (bridged) → CTF Exchange, Neg Risk CTF Exchange, Neg Risk Adapter
-2. CTF Token (ERC1155) → Same 3 spenders
+**V1 required approvals (pre-2026-04-28 cutover):**
+1. USDC.e (bridged) + USDC (native) → 3 V1 spenders (CTF, NegRisk CTF, NegRisk Adapter)
+2. CTF Token (ERC1155) → same 3 spenders
+
+**V2 required approvals (starting 2026-04-28):**
+1. pUSD → 4 V2 spenders (CTF V2, NegRisk A, NegRisk B, NegRisk Adapter)
+2. CTF Token (ERC1155) → same 4 spenders
+3. pUSD → CollateralOfframp (for withdrawals that unwrap back to USDC.e)
+
+Flag: `SIMMER_POLYMARKET_EXCHANGE_VERSION` env (default `v2` on 0.10.0+).
 
 Usage:
     from simmer_sdk.approvals import get_approval_transactions, get_missing_approval_transactions
 
-    # Check what's missing
+    # Check what's missing (server returns V1 or V2 allowance shape per its flag)
     approvals = client.check_approvals()
     if not approvals["all_set"]:
-        # Get transaction data for missing approvals only
         txs = get_missing_approval_transactions(approvals)
         for tx in txs:
             print(f"Approve {tx['description']}")
@@ -23,32 +29,81 @@ Usage:
 
 from typing import List, Dict, Any
 
-# Polygon Mainnet Chain ID
-POLYGON_CHAIN_ID = 137
+from simmer_sdk.polymarket_contracts import (
+    POLYGON_CHAIN_ID,
+    USDC_E,
+    USDC_NATIVE,
+    PUSD,
+    CONDITIONAL_TOKENS as CTF_TOKEN,
+    V1_CTF_EXCHANGE,
+    V1_NEG_RISK_CTF_EXCHANGE,
+    NEG_RISK_ADAPTER,
+    V2_CTF_EXCHANGE,
+    V2_NEG_RISK_EXCHANGE_A,
+    V2_NEG_RISK_EXCHANGE_B,
+    is_v2_enabled,
+    active_spenders,
+)
 
-# Token addresses on Polygon
-USDC_BRIDGED = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"  # USDC.e
-USDC_NATIVE = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"  # Native USDC (Circle-issued)
-CTF_TOKEN = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"  # Polymarket CTF
+# Back-compat re-exports for existing 0.9.x integrators
+USDC_BRIDGED = USDC_E  # legacy alias
 
-# Spender contracts that need approval
-SPENDERS = {
+# ============================================================
+# Flag-aware spender tables
+# ============================================================
+_V1_SPENDERS = {
     "ctf_exchange": {
-        "address": "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E",
+        "address": V1_CTF_EXCHANGE,
         "name": "CTF Exchange",
         "description": "Main Polymarket exchange for standard markets",
     },
     "neg_risk_ctf_exchange": {
-        "address": "0xC5d563A36AE78145C45a50134d48A1215220f80a",
+        "address": V1_NEG_RISK_CTF_EXCHANGE,
         "name": "Neg Risk CTF Exchange",
         "description": "Exchange for negative risk markets",
     },
     "neg_risk_adapter": {
-        "address": "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
+        "address": NEG_RISK_ADAPTER,
         "name": "Neg Risk Adapter",
         "description": "Adapter for negative risk market positions",
     },
 }
+
+_V2_SPENDERS = {
+    "ctf_exchange_v2": {
+        "address": V2_CTF_EXCHANGE,
+        "name": "CTF Exchange V2",
+        "description": "Main V2 Polymarket exchange for standard markets (pUSD collateral)",
+    },
+    "neg_risk_exchange_a": {
+        "address": V2_NEG_RISK_EXCHANGE_A,
+        "name": "Neg Risk Exchange A",
+        "description": "Primary V2 neg-risk exchange",
+    },
+    "neg_risk_exchange_b": {
+        "address": V2_NEG_RISK_EXCHANGE_B,
+        "name": "Neg Risk Exchange B",
+        "description": "Secondary V2 neg-risk exchange (additional multi-outcome capacity)",
+    },
+    "neg_risk_adapter": {
+        "address": NEG_RISK_ADAPTER,
+        "name": "Neg Risk Adapter",
+        "description": "Adapter for negative risk market positions (unchanged in V2)",
+    },
+}
+
+
+def _spenders() -> Dict[str, Dict[str, str]]:
+    """Active spender table based on exchange version flag."""
+    return _V2_SPENDERS if is_v2_enabled() else _V1_SPENDERS
+
+
+# Legacy export — existing code that iterates SPENDERS directly stays working.
+# Reads the flag lazily via a module-level access pattern. New code should call
+# `_spenders()` or read `active_spenders()` from polymarket_contracts instead.
+SPENDERS = _V1_SPENDERS  # default binding, overridden below if V2
+if is_v2_enabled():
+    SPENDERS = _V2_SPENDERS
 
 # Max uint256 for unlimited approval
 MAX_UINT256 = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -62,7 +117,7 @@ ERC1155_SET_APPROVAL_SELECTOR = "0xa22cb465"
 # Boolean true encoded as 32-byte hex (for setApprovalForAll)
 BOOL_TRUE_ENCODED = "0000000000000000000000000000000000000000000000000000000000000001"
 
-# Length of address prefix used in allowance keys (0x + 6 hex chars, matching backend)
+# Length of address prefix used in allowance keys (0x + 6 hex chars, matches backend)
 ADDRESS_PREFIX_LENGTH = 8
 
 # EVM word size in hex characters (32 bytes = 64 hex chars)
@@ -70,58 +125,64 @@ EVM_WORD_SIZE_HEX = 64
 
 
 def _build_approval_info(spender_info: Dict[str, str], token: str) -> Dict[str, Any]:
-    """Build approval info dict for a token/spender pair."""
-    if token == "USDC.e":
+    """Build approval info dict for a token/spender pair.
+
+    `token` values:
+    - "USDC.e" — V1 collateral
+    - "USDC" — native USDC (V1 only)
+    - "pUSD" — V2 collateral
+    - "CTF" — ERC1155 outcome tokens (both versions)
+    """
+    token_map = {
+        "USDC.e": (USDC_E, "Allow {name} to spend USDC.e"),
+        "USDC": (USDC_NATIVE, "Allow {name} to spend USDC"),
+        "pUSD": (PUSD, "Allow {name} to spend pUSD"),
+    }
+    if token in token_map:
+        addr, desc_tpl = token_map[token]
         return {
-            "token": "USDC.e",
-            "token_address": USDC_BRIDGED,
+            "token": token,
+            "token_address": addr,
             "spender": spender_info["name"],
             "spender_address": spender_info["address"],
             "type": "ERC20",
-            "description": f"Allow {spender_info['name']} to spend USDC.e",
+            "description": desc_tpl.format(name=spender_info["name"]),
         }
-    elif token == "USDC":
-        return {
-            "token": "USDC",
-            "token_address": USDC_NATIVE,
-            "spender": spender_info["name"],
-            "spender_address": spender_info["address"],
-            "type": "ERC20",
-            "description": f"Allow {spender_info['name']} to spend USDC",
-        }
-    else:
-        return {
-            "token": "CTF",
-            "token_address": CTF_TOKEN,
-            "spender": spender_info["name"],
-            "spender_address": spender_info["address"],
-            "type": "ERC1155",
-            "description": f"Allow {spender_info['name']} to transfer CTF tokens",
-        }
+    # CTF ERC1155
+    return {
+        "token": "CTF",
+        "token_address": CTF_TOKEN,
+        "spender": spender_info["name"],
+        "spender_address": spender_info["address"],
+        "type": "ERC1155",
+        "description": f"Allow {spender_info['name']} to transfer CTF tokens",
+    }
 
 
 def get_required_approvals() -> List[Dict[str, Any]]:
-    """
-    Get list of all required approvals for Polymarket trading.
+    """Get list of all required approvals for the active exchange version.
 
-    Returns:
-        List of approval requirements with token, spender, and type info
+    V1 (flag off): USDC + USDC.e + CTF per 3 spenders = 9 approvals.
+    V2 (flag on, default on 0.10.0+): pUSD + CTF per 4 spenders = 8 approvals.
     """
-    approvals = []
-    for spender_info in SPENDERS.values():
-        approvals.append(_build_approval_info(spender_info, "USDC"))
-        approvals.append(_build_approval_info(spender_info, "USDC.e"))
+    approvals: List[Dict[str, Any]] = []
+    v2 = is_v2_enabled()
+    for spender_info in _spenders().values():
+        if v2:
+            approvals.append(_build_approval_info(spender_info, "pUSD"))
+        else:
+            approvals.append(_build_approval_info(spender_info, "USDC"))
+            approvals.append(_build_approval_info(spender_info, "USDC.e"))
         approvals.append(_build_approval_info(spender_info, "CTF"))
     return approvals
 
 
 def get_approval_transactions() -> List[Dict[str, Any]]:
-    """
-    Get transaction data for all required Polymarket approvals.
+    """Get transaction data for all required Polymarket approvals.
 
     These transactions can be executed by a wallet or clawbot to set up
-    all necessary approvals for trading. The transactions are the same
-    regardless of wallet address (approval is granted by the signer).
+    all necessary approvals for trading. Selected token set + spender
+    set depend on exchange version (V1 or V2).
 
     Returns:
         List of transaction objects ready for signing/sending, each containing:
@@ -130,62 +191,70 @@ def get_approval_transactions() -> List[Dict[str, Any]]:
         - value: "0x0" (no ETH needed)
         - chainId: Polygon chain ID
         - description: Human-readable description
-        - token: Token being approved
+        - token: Token being approved (USDC, USDC.e, pUSD, or CTF)
         - spender: Spender being approved
 
     Example:
         txs = get_approval_transactions()
         for tx in txs:
-            # Using web3.py
             signed = web3.eth.account.sign_transaction(tx, private_key)
             web3.eth.send_raw_transaction(signed.rawTransaction)
     """
-    transactions = []
+    transactions: List[Dict[str, Any]] = []
+    v2 = is_v2_enabled()
 
-    for spender_info in SPENDERS.values():
+    for spender_info in _spenders().values():
         spender_addr = spender_info["address"]
         spender_name = spender_info["name"]
 
-        # ERC20 approve(spender, amount) calldata (same for both USDC tokens)
-        # Encode: selector + spender (32 bytes) + amount (32 bytes)
+        # Same calldata shape across all ERC20s — approve(spender, MAX_UINT256)
         erc20_approve_data = (
             ERC20_APPROVE_SELECTOR +
             spender_addr[2:].lower().zfill(EVM_WORD_SIZE_HEX) +
-            MAX_UINT256[2:]  # Remove 0x prefix
+            MAX_UINT256[2:]
         )
 
-        # USDC native (Circle-issued)
-        transactions.append({
-            "to": USDC_NATIVE,
-            "data": erc20_approve_data,
-            "value": "0x0",
-            "chainId": POLYGON_CHAIN_ID,
-            "description": f"Approve {spender_name} to spend USDC",
-            "token": "USDC",
-            "spender": spender_name,
-            "spender_address": spender_addr,
-        })
+        if v2:
+            # V2: pUSD only. Native USDC + USDC.e are not part of V2 trading.
+            transactions.append({
+                "to": PUSD,
+                "data": erc20_approve_data,
+                "value": "0x0",
+                "chainId": POLYGON_CHAIN_ID,
+                "description": f"Approve {spender_name} to spend pUSD",
+                "token": "pUSD",
+                "spender": spender_name,
+                "spender_address": spender_addr,
+            })
+        else:
+            # V1: both USDC variants (user may fund with either)
+            transactions.append({
+                "to": USDC_NATIVE,
+                "data": erc20_approve_data,
+                "value": "0x0",
+                "chainId": POLYGON_CHAIN_ID,
+                "description": f"Approve {spender_name} to spend USDC",
+                "token": "USDC",
+                "spender": spender_name,
+                "spender_address": spender_addr,
+            })
+            transactions.append({
+                "to": USDC_E,
+                "data": erc20_approve_data,
+                "value": "0x0",
+                "chainId": POLYGON_CHAIN_ID,
+                "description": f"Approve {spender_name} to spend USDC.e",
+                "token": "USDC.e",
+                "spender": spender_name,
+                "spender_address": spender_addr,
+            })
 
-        # USDC.e (bridged)
-        transactions.append({
-            "to": USDC_BRIDGED,
-            "data": erc20_approve_data,
-            "value": "0x0",
-            "chainId": POLYGON_CHAIN_ID,
-            "description": f"Approve {spender_name} to spend USDC.e",
-            "token": "USDC.e",
-            "spender": spender_name,
-            "spender_address": spender_addr,
-        })
-
-        # ERC1155 setApprovalForAll(operator, approved)
-        # Encode: selector + operator (32 bytes) + approved (32 bytes, 1 = true)
+        # ERC1155 setApprovalForAll(operator, approved) — same for V1 and V2
         ctf_data = (
             ERC1155_SET_APPROVAL_SELECTOR +
             spender_addr[2:].lower().zfill(EVM_WORD_SIZE_HEX) +
             BOOL_TRUE_ENCODED
         )
-
         transactions.append({
             "to": CTF_TOKEN,
             "data": ctf_data,
@@ -203,20 +272,14 @@ def get_approval_transactions() -> List[Dict[str, Any]]:
 def get_missing_approval_transactions(
     approval_status: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
-    """
-    Get transaction data only for missing approvals.
+    """Get transaction data only for missing approvals.
 
     Args:
-        approval_status: Result from client.check_approvals()
+        approval_status: Result from client.check_approvals() — server returns
+            V1 or V2 allowance shape based on the server's flag state.
 
     Returns:
-        List of transaction objects for missing approvals only
-
-    Example:
-        approvals = client.check_approvals()
-        if not approvals["all_set"]:
-            missing_txs = get_missing_approval_transactions(approvals)
-            print(f"Need to send {len(missing_txs)} approval transactions")
+        List of transaction objects for missing approvals only.
     """
     if approval_status.get("all_set", False):
         return []
@@ -226,18 +289,18 @@ def get_missing_approval_transactions(
 
     missing_txs = []
     for tx in all_txs:
-        # Build the key used in allowances dict
-        # Format: "usdc_native_{spender[:8]}", "usdc_bridged_{spender[:8]}", or "ctf_{spender[:8]}"
         spender_prefix = tx["spender_address"][:ADDRESS_PREFIX_LENGTH]
 
-        if tx["token"] == "USDC":
+        token = tx["token"]
+        if token == "USDC":
             key = f"usdc_native_{spender_prefix}"
-        elif tx["token"] == "USDC.e":
+        elif token == "USDC.e":
             key = f"usdc_bridged_{spender_prefix}"
+        elif token == "pUSD":
+            key = f"pusd_{spender_prefix}"
         else:
             key = f"ctf_{spender_prefix}"
 
-        # If not in allowances or False, it's missing
         if not allowances.get(key, False):
             missing_txs.append(tx)
 
@@ -245,46 +308,60 @@ def get_missing_approval_transactions(
 
 
 def format_approval_guide(approval_status: Dict[str, Any]) -> str:
-    """
-    Format a human-readable approval status guide.
-
-    Args:
-        approval_status: Result from client.check_approvals()
+    """Format a human-readable approval status guide.
 
     Returns:
-        Formatted string showing approval status
+        Formatted string showing what approvals are missing.
     """
     if approval_status.get("all_set", False):
         return "✅ All Polymarket approvals are set. You're ready to trade!"
 
     lines = ["⚠️ Missing Polymarket approvals:\n"]
     allowances = approval_status.get("allowances", {})
+    v2 = is_v2_enabled()
 
-    # Group by spender for readability
-    for spender_info in SPENDERS.values():
+    for spender_info in _spenders().values():
         spender_prefix = spender_info["address"][:ADDRESS_PREFIX_LENGTH]
         spender_name = spender_info["name"]
 
-        usdc_native_key = f"usdc_native_{spender_prefix}"
-        usdc_bridged_key = f"usdc_bridged_{spender_prefix}"
-        ctf_key = f"ctf_{spender_prefix}"
+        if v2:
+            pusd_key = f"pusd_{spender_prefix}"
+            ctf_key = f"ctf_{spender_prefix}"
+            pusd_ok = allowances.get(pusd_key, False)
+            ctf_ok = allowances.get(ctf_key, False)
+            if not pusd_ok or not ctf_ok:
+                lines.append(f"  {spender_name}:")
+                if not pusd_ok:
+                    lines.append(f"    ❌ pUSD approval missing")
+                if not ctf_ok:
+                    lines.append(f"    ❌ CTF approval missing")
+        else:
+            usdc_native_key = f"usdc_native_{spender_prefix}"
+            usdc_bridged_key = f"usdc_bridged_{spender_prefix}"
+            ctf_key = f"ctf_{spender_prefix}"
 
-        usdc_native_ok = allowances.get(usdc_native_key, False)
-        usdc_bridged_ok = allowances.get(usdc_bridged_key, False)
-        ctf_ok = allowances.get(ctf_key, False)
+            usdc_native_ok = allowances.get(usdc_native_key, False)
+            usdc_bridged_ok = allowances.get(usdc_bridged_key, False)
+            ctf_ok = allowances.get(ctf_key, False)
 
-        if not usdc_native_ok or not usdc_bridged_ok or not ctf_ok:
-            lines.append(f"  {spender_name}:")
-            if not usdc_native_ok:
-                lines.append(f"    ❌ USDC approval missing")
-            if not usdc_bridged_ok:
-                lines.append(f"    ❌ USDC.e approval missing")
-            if not ctf_ok:
-                lines.append(f"    ❌ CTF approval missing")
+            if not usdc_native_ok or not usdc_bridged_ok or not ctf_ok:
+                lines.append(f"  {spender_name}:")
+                if not usdc_native_ok:
+                    lines.append(f"    ❌ USDC approval missing")
+                if not usdc_bridged_ok:
+                    lines.append(f"    ❌ USDC.e approval missing")
+                if not ctf_ok:
+                    lines.append(f"    ❌ CTF approval missing")
 
     lines.append("\nTo set approvals:")
     lines.append("  1. Use get_approval_transactions() to get tx data")
     lines.append("  2. Sign and send each transaction from your wallet")
     lines.append("  3. Wait for confirmations, then retry trading")
+    if v2:
+        lines.append(
+            "\nNote: V2 uses pUSD instead of USDC.e. If you still hold USDC.e, "
+            "migrate via simmer.markets/dashboard (one click) or manually via "
+            "the Collateral Onramp. See docs.simmer.markets/v2-migration."
+        )
 
     return "\n".join(lines)

--- a/simmer_sdk/polymarket_contracts.py
+++ b/simmer_sdk/polymarket_contracts.py
@@ -1,0 +1,146 @@
+"""
+Polymarket contract addresses — V1 and V2.
+
+Mirrors the server-side `simmer_v3/polymarket_contracts.py` so SDK
+users that build orders / approvals locally use the same addresses
+the Simmer API expects. Callers should use `active_spenders()`,
+`collateral_token()`, and `get_active_addresses()` instead of picking
+V1 or V2 constants directly.
+
+Exchange version:
+- Default starting `simmer-sdk 0.10.0`: **V2** (Polymarket cut over
+  on 2026-04-28 ~11:00 UTC). Pre-cutover, pin `simmer-sdk <0.10.0`
+  for V1. Post-cutover, upgrade to 0.10.0+ for V2.
+- Override via `SIMMER_POLYMARKET_EXCHANGE_VERSION=v1` env var (use
+  with care — only applicable if you're testing against the old V1
+  CLOB, which stopped accepting orders at cutover).
+
+Sources:
+- Polymarket docs: docs.polymarket.com/v2-migration
+- PolyNode V2 guide: docs.polynode.dev/guides/v2-migration
+- Simmer migration guide: docs.simmer.markets/v2-migration
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+# ============================================================
+# Chain + shared constants (unchanged V1 → V2)
+# ============================================================
+POLYGON_CHAIN_ID = 137
+CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"  # CTF, unchanged
+NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"   # unchanged
+
+
+# ============================================================
+# V1 (pre-2026-04-28) — retained for back-compat if user pins v1
+# ============================================================
+V1_CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E"
+V1_NEG_RISK_CTF_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a"
+V1_COLLATERAL_TOKEN = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174"  # USDC.e
+V1_EIP712_ORDER_DOMAIN_VERSION = "1"
+
+
+# ============================================================
+# V2 (primary after 2026-04-28 cutover)
+# ============================================================
+V2_CTF_EXCHANGE = "0xE111180000d2663C0091e4f400237545B87B996B"
+V2_NEG_RISK_EXCHANGE_A = "0xe2222d279d744050d28e00520010520000310F59"
+V2_NEG_RISK_EXCHANGE_B = "0xe2222d002000Ba0053CEF3375333610F64600036"  # secondary
+V2_COLLATERAL_TOKEN = "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB"  # pUSD
+V2_EIP712_ORDER_DOMAIN_VERSION = "2"
+
+
+# ============================================================
+# V2 collateral infrastructure
+# ============================================================
+COLLATERAL_ONRAMP = "0x93070a847efEf7F70739046A929D47a521F5B8ee"       # USDC.e → pUSD
+COLLATERAL_OFFRAMP = "0x2957922Eb93258b93368531d39fAcCA3B4dC5854"      # pUSD → USDC.e
+
+
+# ============================================================
+# Convenience aliases
+# ============================================================
+USDC_E = V1_COLLATERAL_TOKEN    # same address, named by role
+PUSD = V2_COLLATERAL_TOKEN
+USDC_NATIVE = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"
+
+
+@dataclass(frozen=True)
+class ActiveAddresses:
+    """Addresses the SDK should use for the current exchange version."""
+    ctf_exchange: str
+    neg_risk_exchange_primary: str
+    neg_risk_exchange_secondary: str | None
+    neg_risk_adapter: str
+    collateral_token: str  # pUSD (V2) or USDC.e (V1)
+    eip712_order_domain_version: str
+    version: str  # "v1" or "v2"
+
+
+def is_v2_enabled() -> bool:
+    """True when the SDK should build V2-shaped orders / approvals.
+
+    Default: **V2** starting `simmer-sdk 0.10.0`. Override with env
+    `SIMMER_POLYMARKET_EXCHANGE_VERSION=v1` to force V1 shape (e.g., for
+    testing against the retired V1 CLOB — rare).
+    """
+    override = os.getenv("SIMMER_POLYMARKET_EXCHANGE_VERSION", "").strip().lower()
+    if override == "v1":
+        return False
+    if override == "v2":
+        return True
+    # Unset / unrecognized → v2 default on 0.10.0+
+    return True
+
+
+def get_active_addresses() -> ActiveAddresses:
+    """Return the active address set based on the exchange version flag."""
+    if is_v2_enabled():
+        return ActiveAddresses(
+            ctf_exchange=V2_CTF_EXCHANGE,
+            neg_risk_exchange_primary=V2_NEG_RISK_EXCHANGE_A,
+            neg_risk_exchange_secondary=V2_NEG_RISK_EXCHANGE_B,
+            neg_risk_adapter=NEG_RISK_ADAPTER,
+            collateral_token=V2_COLLATERAL_TOKEN,
+            eip712_order_domain_version=V2_EIP712_ORDER_DOMAIN_VERSION,
+            version="v2",
+        )
+    return ActiveAddresses(
+        ctf_exchange=V1_CTF_EXCHANGE,
+        neg_risk_exchange_primary=V1_NEG_RISK_CTF_EXCHANGE,
+        neg_risk_exchange_secondary=None,
+        neg_risk_adapter=NEG_RISK_ADAPTER,
+        collateral_token=V1_COLLATERAL_TOKEN,
+        eip712_order_domain_version=V1_EIP712_ORDER_DOMAIN_VERSION,
+        version="v1",
+    )
+
+
+def active_spenders() -> list[str]:
+    """Contract addresses that need token allowances for active trading.
+
+    V1: 3 spenders (CTF Exchange, Neg Risk CTF Exchange, Neg Risk Adapter).
+    V2: 4 spenders (adds a second Neg Risk Exchange for multi-outcome capacity).
+    """
+    addrs = get_active_addresses()
+    spenders = [
+        addrs.ctf_exchange,
+        addrs.neg_risk_exchange_primary,
+        addrs.neg_risk_adapter,
+    ]
+    if addrs.neg_risk_exchange_secondary:
+        spenders.append(addrs.neg_risk_exchange_secondary)
+    return spenders
+
+
+def collateral_token() -> str:
+    """Active collateral token address (pUSD on V2, USDC.e on V1)."""
+    return get_active_addresses().collateral_token
+
+
+def exchange_version_str() -> str:
+    """'v1' or 'v2' — matches server-side `real_trades.exchange_version`."""
+    return get_active_addresses().version

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -2,62 +2,108 @@
 Polymarket Order Signing Utilities
 
 Signs orders locally for external wallet trading.
-Uses py_order_utils for Polymarket CLOB order construction.
+
+- V1 (pre-2026-04-28): uses `py_order_utils` — the legacy path.
+- V2 (default starting `simmer-sdk 0.10.0`): uses `py_clob_client_v2`
+  which produces the V2 order shape (drops taker/nonce/feeRateBps from
+  the signed struct; adds timestamp/metadata/builder).
+
+Selected automatically via `SIMMER_POLYMARKET_EXCHANGE_VERSION` env or
+the 0.10.0-default-V2 behavior.
 
 SECURITY NOTE: The private key should NEVER be logged, transmitted, or stored
 outside of memory. It is only used for signing operations.
 """
 
-from typing import Dict, Any
-from dataclasses import dataclass
+from typing import Dict, Any, Optional
+from dataclasses import dataclass, field
 
-# Polymarket token/USDC decimals (1 share = 1e6 raw units, 1 USDC = 1e6 raw units)
+from simmer_sdk.polymarket_contracts import (
+    POLYGON_CHAIN_ID,
+    is_v2_enabled,
+)
+
+# Polymarket token/USDC decimals (1 share = 1e6 raw units, 1 USDC/pUSD = 1e6 raw units)
 POLYMARKET_DECIMAL_FACTOR = 1e6
 
 # Minimum order size (Polymarket requires >= 5 shares)
 MIN_ORDER_SIZE_SHARES = 5
 
-# Polygon mainnet chain ID
-POLYGON_CHAIN_ID = 137
-
 # Zero address for open orders (anyone can fill)
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+# Zero bytes32 — V2 default for metadata / builder when unset
+ZERO_BYTES32 = "0x" + "00" * 32
 
 
 @dataclass
 class SignedOrder:
-    """A signed Polymarket order ready for submission."""
+    """A signed Polymarket order ready for submission.
+
+    Supports both V1 and V2 order shapes via optional fields. V1 uses
+    `taker` / `nonce` / `feeRateBps` in the signed struct; V2 drops those
+    and adds `timestamp` / `metadata` / `builder` instead. `expiration`
+    is retained in the HTTP body on both versions (V2 keeps it at "0"
+    out of the signed hash).
+    """
+    # Common to both V1 and V2
     salt: str
     maker: str
     signer: str
-    taker: str
     tokenId: str
     makerAmount: str
     takerAmount: str
-    expiration: str
-    nonce: str
-    feeRateBps: str
     side: str  # "BUY" or "SELL"
     signatureType: int
     signature: str
 
+    # V1-only (absent on V2)
+    taker: Optional[str] = None
+    nonce: Optional[str] = None
+    feeRateBps: Optional[str] = None
+
+    # V2-only (absent on V1)
+    timestamp: Optional[str] = None
+    metadata: Optional[str] = None
+    builder: Optional[str] = None
+
+    # Shared: V1 in signed hash; V2 in HTTP body only, at "0"
+    expiration: Optional[str] = None
+
+    # Meta: which exchange version this order targets
+    exchange_version: str = "v1"
+
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for API submission."""
-        return {
+        """Convert to dictionary for API submission. Omits None fields so
+        V1 orders don't carry V2 fields and vice versa."""
+        out: Dict[str, Any] = {
             "salt": self.salt,
             "maker": self.maker,
             "signer": self.signer,
-            "taker": self.taker,
             "tokenId": self.tokenId,
             "makerAmount": self.makerAmount,
             "takerAmount": self.takerAmount,
-            "expiration": self.expiration,
-            "nonce": self.nonce,
-            "feeRateBps": self.feeRateBps,
             "side": self.side,
             "signatureType": self.signatureType,
             "signature": self.signature,
         }
+        # Include V1 or V2 specific fields based on what's populated
+        if self.taker is not None:
+            out["taker"] = self.taker
+        if self.nonce is not None:
+            out["nonce"] = self.nonce
+        if self.feeRateBps is not None:
+            out["feeRateBps"] = self.feeRateBps
+        if self.timestamp is not None:
+            out["timestamp"] = self.timestamp
+        if self.metadata is not None:
+            out["metadata"] = self.metadata
+        if self.builder is not None:
+            out["builder"] = self.builder
+        # expiration lives in HTTP body on both versions; default "0" on V2
+        if self.expiration is not None:
+            out["expiration"] = self.expiration
+        return out
 
 
 def build_and_sign_order(
@@ -72,6 +118,8 @@ def build_and_sign_order(
     tick_size: float = 0.01,
     fee_rate_bps: int = 0,
     order_type: str = "FAK",  # "FAK", "FOK", "GTC", "GTD"
+    builder_code: Optional[str] = None,
+    metadata: Optional[str] = None,
 ) -> SignedOrder:
     """
     Build and sign a Polymarket order.
@@ -86,14 +134,64 @@ def build_and_sign_order(
         neg_risk: Whether this is a neg-risk market
         signature_type: Signature type (0=EOA default)
         tick_size: Market tick size (e.g., 0.01 or 0.001)
+        fee_rate_bps: V1 only. Ignored on V2 (fees are match-time, not signed).
+        builder_code: V2 only. bytes32 hex for builder attribution. Reads env
+            `POLY_BUILDER_CODE` if None; defaults to zero bytes32 if unset.
+            Mint yours at polymarket.com/settings?tab=builder.
+        metadata: V2 only. bytes32 hex, default zero bytes32.
 
     Returns:
-        SignedOrder ready for API submission
+        SignedOrder ready for API submission. V1 or V2 shape based on
+        `SIMMER_POLYMARKET_EXCHANGE_VERSION` (default V2 on 0.10.0+).
 
     Raises:
-        ImportError: If py_order_utils is not installed
+        ImportError: If required signing deps aren't installed
         ValueError: If order parameters are invalid
     """
+    if is_v2_enabled():
+        return _build_and_sign_order_v2(
+            private_key=private_key,
+            wallet_address=wallet_address,
+            token_id=token_id,
+            side=side,
+            price=price,
+            size=size,
+            neg_risk=neg_risk,
+            signature_type=signature_type,
+            tick_size=tick_size,
+            order_type=order_type,
+            builder_code=builder_code,
+            metadata=metadata,
+        )
+    return _build_and_sign_order_v1(
+        private_key=private_key,
+        wallet_address=wallet_address,
+        token_id=token_id,
+        side=side,
+        price=price,
+        size=size,
+        neg_risk=neg_risk,
+        signature_type=signature_type,
+        tick_size=tick_size,
+        fee_rate_bps=fee_rate_bps,
+        order_type=order_type,
+    )
+
+
+def _build_and_sign_order_v1(
+    private_key: str,
+    wallet_address: str,
+    token_id: str,
+    side: str,
+    price: float,
+    size: float,
+    neg_risk: bool,
+    signature_type: int,
+    tick_size: float,
+    fee_rate_bps: int,
+    order_type: str,
+) -> SignedOrder:
+    """V1 signing path (legacy). Unchanged from pre-0.10.0 behavior."""
     try:
         from py_order_utils.builders import OrderBuilder
         from py_order_utils.signer import Signer
@@ -102,7 +200,7 @@ def build_and_sign_order(
         from py_clob_client.order_builder.builder import OrderBuilder as ClobOrderBuilder, ROUNDING_CONFIG
     except ImportError:
         raise ImportError(
-            "py_order_utils and py_clob_client are required for local signing. "
+            "py_order_utils and py_clob_client are required for V1 local signing. "
             "Install with: pip install py-order-utils py-clob-client"
         )
 
@@ -191,6 +289,125 @@ def build_and_sign_order(
         side=side,
         signatureType=signature_type,
         signature=order_dict["signature"],
+        exchange_version="v1",
+    )
+
+
+def _build_and_sign_order_v2(
+    private_key: str,
+    wallet_address: str,
+    token_id: str,
+    side: str,
+    price: float,
+    size: float,
+    neg_risk: bool,
+    signature_type: int,
+    tick_size: float,
+    order_type: str,
+    builder_code: Optional[str],
+    metadata: Optional[str],
+) -> SignedOrder:
+    """V2 signing path. Uses `py_clob_client_v2`'s ClobClient.create_order().
+
+    V2 drops taker/nonce/feeRateBps from the signed struct and adds
+    timestamp/metadata/builder. The HTTP POST body keeps `expiration`
+    at "0" (not part of signed hash). See docs.simmer.markets/v2-migration.
+    """
+    import os
+    try:
+        from py_clob_client_v2.client import ClobClient
+        from py_clob_client_v2.clob_types import OrderArgs, PartialCreateOrderOptions
+    except ImportError:
+        raise ImportError(
+            "py_clob_client_v2 >= 1.0.0 is required for V2 local signing. "
+            "Install with: pip install 'py-clob-client-v2>=1.0.0'. "
+            "Or pin simmer-sdk<0.10.0 to stay on V1 (V1 CLOB retired 2026-04-28)."
+        )
+
+    # Validate inputs
+    if side not in ("BUY", "SELL"):
+        raise ValueError(f"Invalid side '{side}'. Must be 'BUY' or 'SELL'")
+    if price <= 0 or price >= 1:
+        raise ValueError(f"Invalid price {price}. Must be between 0 and 1")
+    if size <= 0:
+        raise ValueError(f"Invalid size {size}. Must be positive")
+    if signature_type != 0:
+        raise ValueError(
+            f"V2 signing only supports signature_type=0 (EOA). "
+            f"Got {signature_type}. For Safe/Proxy wallets, use the "
+            f"polynode SDK's relayer path or the Simmer dashboard Migrate flow."
+        )
+
+    # Resolve builder_code: explicit arg > env > zero bytes32
+    if builder_code is None:
+        builder_code = os.getenv("POLY_BUILDER_CODE", "").strip() or ZERO_BYTES32
+    if not builder_code.startswith("0x"):
+        builder_code = "0x" + builder_code
+    if metadata is None:
+        metadata = ZERO_BYTES32
+
+    # GTC/GTD expiration is a unix-seconds int; FAK/FOK use 0
+    expiration_seconds = 0
+
+    clob_host = os.getenv("POLYMARKET_CLOB_HOST", "https://clob.polymarket.com")
+    client = ClobClient(
+        host=clob_host,
+        chain_id=POLYGON_CHAIN_ID,
+        key=private_key,
+        signature_type=0,
+        funder=wallet_address,
+    )
+
+    tick_size_str = str(tick_size)
+    order_args = OrderArgs(
+        token_id=token_id,
+        price=price,
+        size=size,
+        side=side.upper(),
+        expiration=expiration_seconds,
+        builder_code=builder_code,
+        metadata=metadata,
+    )
+    options = PartialCreateOrderOptions(
+        tick_size=tick_size_str,
+        neg_risk=neg_risk,
+    )
+    signed = client.create_order(order_args, options)
+    if hasattr(signed, "dict"):
+        order_dict = signed.dict()
+    elif hasattr(signed, "model_dump"):
+        order_dict = signed.model_dump()
+    else:
+        order_dict = {k: getattr(signed, k) for k in signed.__dataclass_fields__}
+
+    # Minimum order size check (after SDK-computed amounts)
+    maker_raw = int(order_dict["makerAmount"])
+    taker_raw = int(order_dict["takerAmount"])
+    shares_raw = taker_raw if side == "BUY" else maker_raw
+    effective_shares = shares_raw / POLYMARKET_DECIMAL_FACTOR
+    if effective_shares < MIN_ORDER_SIZE_SHARES:
+        raise ValueError(
+            f"Order too small: {effective_shares:.2f} shares after rounding "
+            f"is below minimum ({MIN_ORDER_SIZE_SHARES})"
+        )
+
+    return SignedOrder(
+        salt=str(order_dict["salt"]),
+        maker=order_dict["maker"],
+        signer=order_dict["signer"],
+        tokenId=order_dict["tokenId"],
+        makerAmount=order_dict["makerAmount"],
+        takerAmount=order_dict["takerAmount"],
+        side=side,
+        signatureType=int(order_dict.get("signatureType", 0)),
+        signature=order_dict["signature"],
+        # V2 fields
+        timestamp=str(order_dict.get("timestamp", "")),
+        metadata=str(order_dict.get("metadata", metadata)),
+        builder=str(order_dict.get("builder", builder_code)),
+        # Expiration stays in HTTP body at "0"
+        expiration="0",
+        exchange_version="v2",
     )
 
 

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -1,0 +1,157 @@
+"""Unit tests for the V1/V2 Polymarket exchange-version flag behavior.
+
+Covers the SDK surface added in 0.10.0 for the 2026-04-28 V2 cutover:
+- `simmer_sdk.polymarket_contracts` — flag + address resolution
+- `simmer_sdk.approvals` — V1 vs V2 approval tx sets
+- `simmer_sdk.signing.SignedOrder` — shape-aware `to_dict()`
+"""
+
+import os
+import importlib
+
+
+def _reload(*mod_names):
+    """Force re-import so module-level env reads pick up current state."""
+    for name in mod_names:
+        mod = importlib.import_module(name)
+        importlib.reload(mod)
+
+
+def _set_version(val):
+    """Set or clear the SIMMER_POLYMARKET_EXCHANGE_VERSION env flag."""
+    if val is None:
+        os.environ.pop("SIMMER_POLYMARKET_EXCHANGE_VERSION", None)
+    else:
+        os.environ["SIMMER_POLYMARKET_EXCHANGE_VERSION"] = val
+    _reload(
+        "simmer_sdk.polymarket_contracts",
+        "simmer_sdk.approvals",
+    )
+
+
+# ==================== polymarket_contracts ====================
+
+def test_v1_flag_returns_three_spenders_usdce():
+    _set_version("v1")
+    from simmer_sdk.polymarket_contracts import (
+        is_v2_enabled, active_spenders, collateral_token, exchange_version_str,
+    )
+    assert is_v2_enabled() is False
+    assert exchange_version_str() == "v1"
+    assert len(active_spenders()) == 3
+    # USDC.e is the V1 collateral
+    assert collateral_token().lower() == "0x2791bca1f2de4661ed88a30c99a7a9449aa84174"
+
+
+def test_v2_default_returns_four_spenders_pusd():
+    # No env override — 0.10.0 defaults to V2
+    _set_version(None)
+    from simmer_sdk.polymarket_contracts import (
+        is_v2_enabled, active_spenders, collateral_token, exchange_version_str,
+    )
+    assert is_v2_enabled() is True
+    assert exchange_version_str() == "v2"
+    # V2 adds a second NegRisk exchange
+    assert len(active_spenders()) == 4
+    # pUSD is the V2 collateral
+    assert collateral_token().lower() == "0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"
+
+
+def test_v2_explicit_matches_default():
+    _set_version("v2")
+    from simmer_sdk.polymarket_contracts import is_v2_enabled, active_spenders
+    assert is_v2_enabled() is True
+    assert len(active_spenders()) == 4
+
+
+# ==================== approvals ====================
+
+def test_v1_approvals_count_and_tokens():
+    _set_version("v1")
+    from simmer_sdk.approvals import get_approval_transactions
+    txs = get_approval_transactions()
+    # 3 spenders × (USDC + USDC.e + CTF) = 9 txs
+    assert len(txs) == 9
+    tokens = {tx["token"] for tx in txs}
+    assert tokens == {"USDC", "USDC.e", "CTF"}
+
+
+def test_v2_approvals_count_and_tokens():
+    _set_version(None)  # default V2 on 0.10.0
+    from simmer_sdk.approvals import get_approval_transactions
+    txs = get_approval_transactions()
+    # 4 spenders × (pUSD + CTF) = 8 txs
+    assert len(txs) == 8
+    tokens = {tx["token"] for tx in txs}
+    assert tokens == {"pUSD", "CTF"}
+
+
+def test_v2_get_required_approvals_tokens():
+    _set_version("v2")
+    from simmer_sdk.approvals import get_required_approvals
+    approvals = get_required_approvals()
+    tokens = {a["token"] for a in approvals}
+    # V2 should never surface USDC or USDC.e as required
+    assert "USDC" not in tokens
+    assert "USDC.e" not in tokens
+    assert tokens == {"pUSD", "CTF"}
+
+
+# ==================== SignedOrder ====================
+
+def test_signed_order_v1_shape_omits_v2_fields():
+    from simmer_sdk.signing import SignedOrder
+    order = SignedOrder(
+        salt="1",
+        maker="0x" + "aa" * 20,
+        signer="0x" + "aa" * 20,
+        tokenId="123",
+        makerAmount="1000000",
+        takerAmount="2000000",
+        side="BUY",
+        signatureType=0,
+        signature="0xdead",
+        taker="0x" + "00" * 20,
+        nonce="0",
+        feeRateBps="0",
+        expiration="0",
+        exchange_version="v1",
+    )
+    d = order.to_dict()
+    # V1 fields present
+    assert "taker" in d
+    assert "nonce" in d
+    assert "feeRateBps" in d
+    # V2 fields absent
+    assert "timestamp" not in d
+    assert "metadata" not in d
+    assert "builder" not in d
+
+
+def test_signed_order_v2_shape_omits_v1_fields():
+    from simmer_sdk.signing import SignedOrder
+    order = SignedOrder(
+        salt="2",
+        maker="0x" + "bb" * 20,
+        signer="0x" + "bb" * 20,
+        tokenId="456",
+        makerAmount="1000000",
+        takerAmount="2000000",
+        side="SELL",
+        signatureType=0,
+        signature="0xbeef",
+        timestamp="1700000000000",
+        metadata="0x" + "00" * 32,
+        builder="0x" + "11" * 32,
+        expiration="0",
+        exchange_version="v2",
+    )
+    d = order.to_dict()
+    # V2 fields present
+    assert "timestamp" in d
+    assert "metadata" in d
+    assert "builder" in d
+    # V1 fields absent
+    assert "taker" not in d
+    assert "nonce" not in d
+    assert "feeRateBps" not in d


### PR DESCRIPTION
## Summary

Polymarket V2 cutover on 2026-04-28 at ~11:00 UTC needs SDK support. This PR adds V2 order signing, flag-aware approvals, and a new contract-registry module — mirroring the server-side changes from today's simmer#295-#317 stack.

**Version: 0.10.0** (minor bump). Defaults to V2. V1 pinnable via `SIMMER_POLYMARKET_EXCHANGE_VERSION=v1` env or `simmer-sdk<0.10.0`.

## Files

| File | Change |
|---|---|
| `simmer_sdk/polymarket_contracts.py` | **NEW** — V1/V2 constants, `is_v2_enabled()`, `active_spenders()`, `collateral_token()`, `exchange_version_str()`. Mirrors `simmer_v3/polymarket_contracts.py` |
| `simmer_sdk/approvals.py` | Flag-aware. V2: 4 spenders × (pUSD + CTF) = 8 approvals. V1: 3 × (USDC + USDC.e + CTF) = 9 approvals (byte-identical to 0.9.x). |
| `simmer_sdk/signing.py` | `build_and_sign_order()` dispatches V1/V2. V2 uses `py-clob-client-v2`. New optional `builder_code` / `metadata` args for V2 attribution. `SignedOrder` supports both shapes; `to_dict()` emits only relevant fields. |
| `pyproject.toml` | `0.9.23 → 0.10.0`, adds `py-clob-client-v2>=1.0.0` |
| `CHANGELOG.md` | Full migration notes + links to docs.simmer.markets/v2-migration |

## What does NOT change

- **Server-signed paths** (managed wallets, SDK keys): no SDK code change needed — backend handles V2 routing per flag. Users just `pip install -U simmer-sdk`.
- **`client.py` response handling**: `balance_pusd`, `balance_usdc_bridged`, `spendable_pusd_balance` flow through transparently (server P1.2 added them).
- **OWS signing path (`build_and_sign_order_ows`)**: kept V1-only. OWS V2 support is a follow-up — minor surface area, low priority since OWS users are few.

## V1 compatibility

- `simmer-sdk<0.10.0` pins continue to work exactly as before
- `0.10.0` with `SIMMER_POLYMARKET_EXCHANGE_VERSION=v1`: V1 path byte-identical to 0.9.x
- 3 V1 spenders, USDC + USDC.e approvals, V1 order struct, feeRateBps in signed hash — all preserved

## V2 behavior

- 4 V2 spenders including both NegRisk Exchange A + B
- pUSD approvals (legacy USDC / USDC.e not used for V2 trading)
- V2 order struct (timestamp + metadata + builder in signed hash; taker/nonce/feeRateBps dropped)
- EIP-712 domain version 2
- signature_type must be 0 (EOA) — V2 path raises on Safe/Proxy (use dashboard Migrate flow instead)
- `builder_code` reads `POLY_BUILDER_CODE` env by default, falls back to zero bytes32

## Tests

Unit-style smoke verified:
- Flag off → 3 spenders, 9 approvals, USDC.e collateral, `exchange_version="v1"`
- Flag on (default 0.10.0) → 4 spenders, 8 approvals, pUSD collateral, `exchange_version="v2"`
- V2 `SignedOrder.to_dict()` omits V1 fields (taker/nonce/feeRateBps)
- V1 `SignedOrder.to_dict()` omits V2 fields (timestamp/metadata/builder)
- Approval token sets correct for each version

## After merge

**Adrian needs to run `python -m build` + `twine upload` with PyPI OTP** — I can't publish directly. Process:
```bash
cd simmer-sdk
python -m build
python -m twine upload dist/simmer_sdk-0.10.0*
```

Target publish time: any time Apr 23-Apr 28, pre-cutover. If published pre-cutover, users who `pip install -U simmer-sdk` before cutover get V2-ready code that then "activates" when Polymarket flips at 11:00 UTC. If published exactly at cutover, same effect.

Alternatively, publish as `0.10.0rc1` pre-cutover and bump to `0.10.0` on Apr 28 — but probably overkill.

## Related

- SIM-890 Phase 1 P1.8-P1.11
- Pairs with server-side P1.2 (pUSD balance), P1.7a/b/c (V2 order struct + builder code), P1.6 (wrap endpoint), P1.18a (withdraw Offramp)
- Docs: https://docs.simmer.markets/v2-migration
- Structural ref: deleted Cody branch `d7bad7c` (via reflog; my implementation diverges — defaults to V2 on 0.10.0 rather than pinning, matches my server-side module layout, supports both order shapes via optional fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)