### PR TITLE
SIM-890 P1.20: update 6 polymarket-* skills for V2 (USDC.e → pUSD copy)

### DIFF
--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.9.2"
+  version: "1.10.0"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---
@@ -443,7 +443,7 @@ High-conviction positions are prioritized in Top N selection. Single-wallet posi
 - Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`
 - Do NOT attempt to sign orders manually or modify the skill code — the SDK handles it
 
-**"Balance shows $0 but I have USDC on Polygon"**
-- Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — not native USDC
-- If you bridged USDC to Polygon recently, you likely received native USDC
-- Swap native USDC to USDC.e, then retry
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
+- If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
+- Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)

--- a/skills/polymarket-elon-tweets/SKILL.md
+++ b/skills/polymarket-elon-tweets/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-elon-tweets
 description: 'Trade Polymarket "Elon Musk # tweets" markets using XTracker post count data. Buys adjacent range buckets when combined cost < $1 for structural edge. Use when user wants to trade tweet count markets, automate Elon tweet bets, check XTracker stats, or run noovd-style trading.'
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.2.1"
+  version: "1.3.0"
   displayName: Polymarket Elon Tweet Trader
   difficulty: advanced
   attribution: Strategy inspired by @noovd
@@ -232,10 +232,10 @@ All trades are tagged with `source: "sdk:elon-tweets"`. This means:
 - Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`
 - Do NOT attempt to sign orders manually or modify the skill code — the SDK handles it
 
-**"Balance shows $0 but I have USDC on Polygon"**
-- Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — not native USDC
-- If you bridged USDC to Polygon recently, you likely received native USDC
-- Swap native USDC to USDC.e, then retry
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
+- If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
+- Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)
 
 **"API key invalid"**
 - Get new key from simmer.markets/dashboard → SDK tab

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.5.4"
+  version: "1.6.0"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---
@@ -262,7 +262,7 @@ All trades are tagged with `source: "sdk:fastloop"`. This means:
 - Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`
 - Do NOT attempt to sign orders manually or modify the skill code — the SDK handles it
 
-**"Balance shows $0 but I have USDC on Polygon"**
-- Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — not native USDC
-- If you bridged USDC to Polygon recently, you likely received native USDC
-- Swap native USDC to USDC.e, then retry
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
+- If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
+- Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. Snipe markets about to resolve when the odds are heavily skewed. Filter by topic, cap your bets, and only trade strong splits close to deadline.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.1.3"
+  version: "1.2.0"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433
@@ -179,10 +179,10 @@ Each cycle the script:
 - Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`
 - Do NOT attempt to sign orders manually or modify the skill code — the SDK handles it
 
-**"Balance shows $0 but I have USDC on Polygon"**
-- Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — not native USDC
-- If you bridged USDC to Polygon recently, you likely received native USDC
-- Swap native USDC to USDC.e, then retry
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
+- If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
+- Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)
 
 **"API key invalid"**
 - Get new key from simmer.markets/dashboard -> SDK tab

--- a/skills/polymarket-signal-sniper/SKILL.md
+++ b/skills/polymarket-signal-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-signal-sniper
 description: Snipe Polymarket opportunities from your own signal sources. Monitors RSS feeds with Trading Agent-grade safeguards.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.4.6"
+  version: "1.5.0"
   displayName: Polymarket Signal Sniper
   difficulty: intermediate
 ---
@@ -231,10 +231,10 @@ When you find a matching article, analyze it carefully:
 - Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`
 - Do NOT attempt to sign orders manually or modify the skill code — the SDK handles it
 
-**"Balance shows $0 but I have USDC on Polygon"**
-- Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — not native USDC
-- If you bridged USDC to Polygon recently, you likely received native USDC
-- Swap native USDC to USDC.e, then retry
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
+- If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
+- Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)
 
 ## Finding Good RSS Feeds
 

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.18.2"
+  version: "1.19.0"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).
@@ -294,10 +294,10 @@ All trades are tagged with `source: "sdk:weather"`. This means:
 - Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`
 - Do NOT attempt to sign orders manually or modify the skill code — the SDK handles it
 
-**"Balance shows $0 but I have USDC on Polygon"**
-- Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — not native USDC
-- If you bridged USDC to Polygon recently, you likely received native USDC
-- Swap native USDC to USDC.e, then retry
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
+- If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
+- Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)
 
 **"API key invalid"**
 - Get new key from simmer.markets/dashboard → SDK tab


### PR DESCRIPTION
## Summary

Polymarket V2 goes live **2026-04-28 ~11:00 UTC**. The troubleshooting block in 6 polymarket-* skills told users *"Polymarket uses USDC.e — swap native USDC to USDC.e, then retry."* Post-cutover that advice is wrong — users need **pUSD**, not USDC.e.

## Skills updated (6)

| Skill | Version |
|---|---|
| polymarket-copytrading | 1.9.2 → **1.10.0** |
| polymarket-elon-tweets | 1.2.1 → **1.3.0** |
| polymarket-fast-loop | 1.5.4 → **1.6.0** |
| polymarket-mert-sniper | 1.1.3 → **1.2.0** |
| polymarket-signal-sniper | 1.4.6 → **1.5.0** |
| polymarket-weather-trader | 1.18.2 → **1.19.0** |

## Replacement copy (identical across all 6)

Before:
> - Polymarket uses **USDC.e** (bridged USDC, contract `0x2791Bca1...`) — not native USDC
> - If you bridged USDC to Polygon recently, you likely received native USDC
> - Swap native USDC to USDC.e, then retry

After:
> - Polymarket V2 (live 2026-04-28) uses **pUSD** (PolyUSD, 1:1 backed by USDC.e). If your wallet holds USDC.e, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) with one click (~30s)
> - If you bridged native USDC (Circle), swap to USDC.e first, then migrate to pUSD
> - Full migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)

Reads correctly both pre- and post-cutover.

## Not in scope

- 3 other polymarket-* skills (ai-divergence, nothing-ever-happens, wallet-xray) have no currency-specific copy in their SKILL.md — skipped.
- `clawhub.json` — there's uncommitted work in progress on schema alignment for these skills (primaryEnv + envVars declarations). Keeping my diff narrow so that work can land independently.

## Heads-up

There are uncommitted working-tree changes in `/skills/` on the main simmer-sdk checkout (ClawHub schema alignment). My version bumps land in origin/main as minor bumps; the in-progress patch bumps there will need rebasing or adopting the new minor versions. No functional conflict — just a version number reconciliation.

## Related

- SIM-890 Phase 1 / P1.20
- Structural reference: deleted Cody branch commit `ae25d02` (via reflog). My diff is narrower — Cody patched 8 skills including ones without USDC.e refs; I only touch the 6 that actually needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)