### PR TITLE
fix(sdk): drop stale Poly Proxy copy in V2 signing error

### DIFF
--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -334,8 +334,10 @@ def _build_and_sign_order_v2(
     if signature_type != 0:
         raise ValueError(
             f"V2 signing only supports signature_type=0 (EOA). "
-            f"Got {signature_type}. For Safe/Proxy wallets, use the "
-            f"polynode SDK's relayer path or the Simmer dashboard Migrate flow."
+            f"Got {signature_type}. Simmer's wallets are all EOAs — managed "
+            f"(server-custody) and external (user-custody via browser wallet, "
+            f"e.g. MetaMask). If you're hitting this, verify you're passing "
+            f"signature_type=0 (the default) and not overriding it."
         )
 
     # Resolve builder_code: explicit arg > env > zero bytes32


### PR DESCRIPTION
## Summary

Minor copy fix. The V2 signing path's error message for `signature_type != 0` suggested users go through a "polynode relayer path for Safe/Proxy wallets" — irrelevant for Simmer's actual user population.

## Correct framing

Simmer has exactly two wallet types:
- **Managed** — server-custody EOA, key encrypted in DB, server signs
- **External** — user-custody EOA, self-custody browser wallet (MetaMask/Rabby/etc.), user signs via `window.ethereum`

Both are `signatureType=0` (EOA). No Poly Proxy wallets. Dynamic is our auth/login layer, not the trading wallet connector.

## Before

```
V2 signing only supports signature_type=0 (EOA). Got {N}. For Safe/Proxy wallets,
use the polynode SDK's relayer path or the Simmer dashboard Migrate flow.
```

## After

```
V2 signing only supports signature_type=0 (EOA). Got {N}. Simmer's wallets are all
EOAs — managed (server-custody) and external (user-custody via browser wallet,
e.g. MetaMask). If you're hitting this, verify you're passing signature_type=0
(the default) and not overriding it.
```

## Diff

```
simmer_sdk/signing.py | 4 insertions(+), 2 deletions(-)
```

No behavior change. Error message only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)