### PR TITLE
SIM-1078: DrawdownController primitive with sticky auto-halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`simmer_sdk.risk`** — new module for portfolio-level risk
+  primitives.
+  - **`DrawdownController`** — stateful peak-trough tracker with sticky
+    auto-halt. Bot calls `update(new_bankroll)` after every realized
+    PnL event and `can_trade()` before every new order. Halts at a
+    caller-configured `max_drawdown_pct` (default 15%); halt is sticky
+    until the operator explicitly calls `resume()`. Distinct from the
+    per-trade simulate-before-execute guardian — this is portfolio-level
+    and time-invariant. Refs SIM-1072.
+
 ## [0.10.0] — 2026-04-28
 
 ### Polymarket V2 migration support

--- a/simmer_sdk/__init__.py
+++ b/simmer_sdk/__init__.py
@@ -101,6 +101,8 @@ __all__ = [
     "expected_value",
     "size_position",
     "SIZING_CONFIG_SCHEMA",
+    # Risk primitives (portfolio-level circuit breakers)
+    "DrawdownController",
 ]
 
 # Convenience aliases for skill config
@@ -110,3 +112,6 @@ from .skill import get_config_path as get_skill_config_path
 
 # Position sizing utilities
 from .sizing import kelly_fraction, expected_value, size_position, SIZING_CONFIG_SCHEMA
+
+# Risk primitives
+from .risk import DrawdownController

--- a/simmer_sdk/risk/__init__.py
+++ b/simmer_sdk/risk/__init__.py
@@ -1,0 +1,15 @@
+"""
+Risk primitives for Simmer SDK.
+
+Portfolio-level risk controls that a trading skill composes on top of
+per-trade sizing. These primitives are intentionally stateless about the
+Simmer backend — they track local bot state and decide whether the bot
+should keep trading.
+
+Currently exports:
+    DrawdownController — peak-trough tracker with sticky auto-halt.
+"""
+
+from .drawdown import DrawdownController, DrawdownState
+
+__all__ = ["DrawdownController", "DrawdownState"]

--- a/simmer_sdk/risk/drawdown.py
+++ b/simmer_sdk/risk/drawdown.py
@@ -1,0 +1,155 @@
+"""
+DrawdownController — portfolio-level circuit breaker.
+
+Stateful peak-trough tracker. After every realized PnL event, a bot
+calls `update(new_bankroll)`. Before placing a new order, the bot calls
+`can_trade()`. When the drawdown from peak exceeds the configured
+threshold, the controller latches into a halted state and stays halted
+until the operator explicitly calls `resume()`.
+
+Distinct from per-trade guardians (e.g. simulate-before-execute) — this
+is portfolio-level and time-invariant. A bounce back to the peak does
+NOT un-halt the controller; that decision is deliberately operator-gated.
+
+Usage:
+    from simmer_sdk.risk import DrawdownController
+
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+
+    # After every realized PnL event
+    state = dc.update(current_bankroll)
+    if state["halted"]:
+        notify_operator(f"Halted at {state['drawdown']:.1%} drawdown")
+
+    # Before every new order
+    if not dc.can_trade():
+        return  # skip trading this cycle
+
+    # Operator-initiated recovery
+    dc.resume()
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class DrawdownState(TypedDict):
+    """Return shape of `DrawdownController.update()`."""
+
+    drawdown: float
+    halted: bool
+
+
+class DrawdownController:
+    """Portfolio-level drawdown circuit breaker with sticky halt.
+
+    Args:
+        bankroll: Starting bankroll. Used as the initial peak.
+        max_drawdown_pct: Drawdown fraction (0 < x < 1) that triggers the
+            halt. Halt triggers when `drawdown >= max_drawdown_pct`, so
+            the boundary is inclusive. Default 0.15 (= 15%).
+
+    Raises:
+        ValueError: if `bankroll <= 0` or `max_drawdown_pct` is outside
+            the open interval (0, 1).
+    """
+
+    def __init__(self, bankroll: float, max_drawdown_pct: float = 0.15) -> None:
+        if bankroll <= 0:
+            raise ValueError(f"bankroll must be positive, got {bankroll!r}")
+        if not (0 < max_drawdown_pct < 1):
+            raise ValueError(
+                f"max_drawdown_pct must be in (0, 1), got {max_drawdown_pct!r}"
+            )
+
+        self._peak: float = float(bankroll)
+        self._current: float = float(bankroll)
+        self._max_drawdown_pct: float = float(max_drawdown_pct)
+        self._halted: bool = False
+
+    @property
+    def peak(self) -> float:
+        """Highest bankroll observed since construction (monotonic)."""
+        return self._peak
+
+    @property
+    def current(self) -> float:
+        """Most recent bankroll passed to `update()`."""
+        return self._current
+
+    @property
+    def max_drawdown_pct(self) -> float:
+        """The configured drawdown threshold."""
+        return self._max_drawdown_pct
+
+    @property
+    def halted(self) -> bool:
+        """Whether the controller is currently halted."""
+        return self._halted
+
+    @property
+    def drawdown(self) -> float:
+        """Current drawdown fraction from peak, in [0, 1]."""
+        if self._peak <= 0:
+            return 0.0
+        dd = (self._peak - self._current) / self._peak
+        # Clamp floor at 0 — new highs have no drawdown, not negative.
+        return dd if dd > 0 else 0.0
+
+    def update(self, new_bankroll: float) -> DrawdownState:
+        """Record a new bankroll reading and recompute halt state.
+
+        Bumps the peak on new highs. Triggers halt when drawdown from
+        peak reaches or exceeds `max_drawdown_pct`. Once halted, stays
+        halted — this method will not un-halt even if the bankroll
+        recovers.
+
+        Args:
+            new_bankroll: Current total bankroll after the latest PnL
+                event. Must be non-negative.
+
+        Returns:
+            A dict with `drawdown` (current drawdown fraction from peak,
+            >= 0) and `halted` (bool).
+
+        Raises:
+            ValueError: if `new_bankroll` is negative.
+        """
+        if new_bankroll < 0:
+            raise ValueError(
+                f"new_bankroll must be non-negative, got {new_bankroll!r}"
+            )
+
+        self._current = float(new_bankroll)
+        if self._current > self._peak:
+            self._peak = self._current
+
+        dd = self.drawdown
+        if not self._halted and dd >= self._max_drawdown_pct:
+            self._halted = True
+
+        return {"drawdown": dd, "halted": self._halted}
+
+    def can_trade(self) -> bool:
+        """Return True iff the controller is not halted."""
+        return not self._halted
+
+    def resume(self) -> None:
+        """Explicitly clear the halt flag.
+
+        Operator-initiated recovery. Does NOT reset the peak — the next
+        drawdown is still measured against the all-time high. To start
+        fresh from the current bankroll as a new peak, instantiate a
+        new controller.
+        """
+        self._halted = False
+
+    def __repr__(self) -> str:
+        return (
+            f"DrawdownController(peak={self._peak:.2f}, "
+            f"current={self._current:.2f}, "
+            f"drawdown={self.drawdown:.4f}, "
+            f"max_drawdown_pct={self._max_drawdown_pct:.4f}, "
+            f"halted={self._halted})"
+        )

--- a/tests/test_drawdown_controller.py
+++ b/tests/test_drawdown_controller.py
@@ -1,0 +1,209 @@
+"""
+Unit tests for simmer_sdk.risk.DrawdownController.
+
+Covers: peak-climbing, drawdown computation, halt threshold (inclusive
+boundary), sticky-halt behavior, operator-explicit resume, input
+validation.
+"""
+
+import pytest
+
+from simmer_sdk.risk import DrawdownController
+
+
+# --- construction ---------------------------------------------------------
+
+
+def test_init_sets_peak_equal_to_bankroll():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    assert dc.peak == 1000.0
+    assert dc.current == 1000.0
+    assert dc.halted is False
+    assert dc.can_trade() is True
+    assert dc.drawdown == 0.0
+
+
+def test_init_default_max_drawdown_is_15_percent():
+    dc = DrawdownController(bankroll=1000.0)
+    assert dc.max_drawdown_pct == 0.15
+
+
+def test_init_rejects_non_positive_bankroll():
+    with pytest.raises(ValueError):
+        DrawdownController(bankroll=0, max_drawdown_pct=0.15)
+    with pytest.raises(ValueError):
+        DrawdownController(bankroll=-1, max_drawdown_pct=0.15)
+
+
+@pytest.mark.parametrize("bad_pct", [0, 1, -0.1, 1.5])
+def test_init_rejects_out_of_range_drawdown_pct(bad_pct):
+    with pytest.raises(ValueError):
+        DrawdownController(bankroll=1000.0, max_drawdown_pct=bad_pct)
+
+
+# --- peak climbing --------------------------------------------------------
+
+
+def test_peak_climbs_on_new_high():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(1200.0)
+    assert dc.peak == 1200.0
+    assert dc.drawdown == 0.0
+
+
+def test_peak_does_not_drop_when_bankroll_falls():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(1200.0)
+    dc.update(1100.0)
+    assert dc.peak == 1200.0
+
+
+def test_peak_is_monotonic_through_mixed_sequence():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.5)
+    for b in [1100, 900, 1200, 800, 1150]:
+        dc.update(b)
+    assert dc.peak == 1200
+
+
+# --- drawdown computation -------------------------------------------------
+
+
+def test_drawdown_is_fraction_of_peak():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.5)
+    state = dc.update(900.0)
+    assert state["drawdown"] == pytest.approx(0.10)
+    assert state["halted"] is False
+
+
+def test_drawdown_resets_toward_zero_on_recovery_but_halt_stays():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(800.0)  # 20% drawdown — halts
+    assert dc.halted is True
+    dc.update(1000.0)  # recovered
+    assert dc.drawdown == 0.0
+    assert dc.halted is True  # sticky
+
+
+def test_drawdown_never_negative_on_new_high():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    state = dc.update(1500.0)
+    assert state["drawdown"] == 0.0
+
+
+# --- halt threshold (inclusive boundary) ----------------------------------
+
+
+def test_halt_triggers_exactly_at_threshold():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    state = dc.update(850.0)  # exactly 15% drawdown
+    assert state["drawdown"] == pytest.approx(0.15)
+    assert state["halted"] is True
+    assert dc.can_trade() is False
+
+
+def test_halt_does_not_trigger_just_below_threshold():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    state = dc.update(851.0)  # 14.9% drawdown
+    assert state["halted"] is False
+    assert dc.can_trade() is True
+
+
+def test_halt_triggers_well_past_threshold():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    state = dc.update(500.0)  # 50% drawdown
+    assert state["halted"] is True
+
+
+def test_halt_triggers_relative_to_new_peak_not_initial_bankroll():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(2000.0)  # peak = 2000
+    state = dc.update(1700.0)  # 15% off the new peak, not off 1000
+    assert state["drawdown"] == pytest.approx(0.15)
+    assert state["halted"] is True
+
+
+# --- sticky halt ----------------------------------------------------------
+
+
+def test_halt_is_sticky_across_many_updates():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(800.0)
+    assert dc.halted is True
+    for b in [900, 1000, 1100, 1200, 2000]:
+        state = dc.update(b)
+        assert state["halted"] is True
+        assert dc.can_trade() is False
+
+
+def test_halt_is_sticky_even_when_new_peak_is_set_after_halt():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(800.0)
+    assert dc.halted is True
+    state = dc.update(2000.0)  # new high after halt
+    assert dc.peak == 2000.0
+    assert state["halted"] is True  # does not un-halt automatically
+
+
+# --- resume ---------------------------------------------------------------
+
+
+def test_resume_clears_halt_flag():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(800.0)
+    assert dc.halted is True
+    dc.resume()
+    assert dc.halted is False
+    assert dc.can_trade() is True
+
+
+def test_resume_does_not_reset_peak():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(1500.0)  # peak climbs
+    dc.update(1200.0)  # 20% drawdown, halts
+    assert dc.halted is True
+    assert dc.peak == 1500.0
+    dc.resume()
+    assert dc.peak == 1500.0  # peak preserved
+
+
+def test_can_re_halt_after_resume():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    dc.update(800.0)
+    dc.resume()
+    state = dc.update(700.0)  # 30% off the 1000 peak, re-halts
+    assert state["halted"] is True
+
+
+def test_resume_on_non_halted_controller_is_noop():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    assert dc.halted is False
+    dc.resume()  # should not raise, should not change state
+    assert dc.halted is False
+
+
+# --- input validation on update ------------------------------------------
+
+
+def test_update_rejects_negative_bankroll():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    with pytest.raises(ValueError):
+        dc.update(-1.0)
+
+
+def test_update_accepts_zero_bankroll():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    state = dc.update(0.0)
+    assert state["drawdown"] == pytest.approx(1.0)
+    assert state["halted"] is True
+
+
+# --- can_trade semantics --------------------------------------------------
+
+
+def test_can_trade_tracks_halted_flag():
+    dc = DrawdownController(bankroll=1000.0, max_drawdown_pct=0.15)
+    assert dc.can_trade() is True
+    dc.update(800.0)
+    assert dc.can_trade() is False
+    dc.resume()
+    assert dc.can_trade() is True


### PR DESCRIPTION
## Summary

- New `simmer_sdk.risk` module with `DrawdownController` — portfolio-level circuit breaker that latches into halted state when drawdown from peak reaches a caller-configured threshold (default 15%).
- Halt is sticky — a bounce back does NOT auto-un-halt; operator must call `resume()` explicitly.
- 26 unit tests covering peak-climbing, drawdown math, inclusive halt boundary, sticky behavior, resume semantics.
- Top-level export: `from simmer_sdk import DrawdownController`.

## Design decisions

- **Sticky halt** is deliberate — a bot that drew down 15% had a reason (stale prices, bad model, market regime change); a human should confirm before re-engaging.
- **Resume preserves the peak** — future drawdowns still measured against the all-time high. To reset, construct a new controller.
- **Halt threshold is inclusive** (`drawdown >= max_drawdown_pct`) — matches the spec; exact 15% on 15% halts.
- **No coupling to SimmerClient** — pure primitive, bot-level state. Works for external-wallet and managed-wallet skills alike.

## Test plan

- [x] `python -m pytest tests/test_drawdown_controller.py -v` → 26 passed
- [x] Full SDK suite → 131 passed, 10 skipped
- [x] Top-level import smoke test works
- [ ] Docs PR: SpartanLabsXyz/simmer-docs#TBD

## Refs

- Paperclip: SIM-1078
- Source: SIM-1072 + research/2026-04-23-stacyonchain-32-snippets-polymarket.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)