### PR TITLE
feat(execution): await_fill partial-fill wait wrapper (SIM-1079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`simmer_sdk.execution.await_fill()`** — execution-time partial-fill
+  wait wrapper with time-boxed escape (SIM-1079). Polls an open limit
+  order's `size_matched` and returns one of four terminal statuses:
+  `FILLED`, `PARTIAL`, `TIMEOUT_PARTIAL`, `TIMEOUT_NO_FILL`. All
+  thresholds (`accept_pct`, `partial_exit_pct`,
+  `partial_exit_time_frac`, `poll_interval`) are caller-configurable;
+  defaults are 0.95 / 0.50 / 0.70 / 2.0s. Handles cancel-failure and
+  transient poll errors gracefully. Opt-in — `client.trade()` is
+  unchanged. See https://docs.simmer.markets/sdk/execution.
+- **`simmer_sdk.execution.clob_poll_fn` / `clob_cancel_fn`** —
+  one-line wiring helpers for `py_clob_client.ClobClient`.
+
 ## [0.10.0] — 2026-04-28
 
 ### Polymarket V2 migration support

--- a/simmer_sdk/execution/__init__.py
+++ b/simmer_sdk/execution/__init__.py
@@ -1,0 +1,24 @@
+"""
+simmer_sdk.execution — execution-layer utilities for order lifecycle.
+
+Currently exposes the partial-fill wait-vs-cancel wrapper (SIM-1079). This is
+the execution-time counterpart to the SIM-917 backfill/accounting work: it
+gives SDK callers a first-class `await_fill()` primitive for structuring the
+wait-or-cancel decision on limit orders.
+"""
+
+from .partial_fill import (
+    FillStatus,
+    FillResult,
+    await_fill,
+    clob_poll_fn,
+    clob_cancel_fn,
+)
+
+__all__ = [
+    "FillStatus",
+    "FillResult",
+    "await_fill",
+    "clob_poll_fn",
+    "clob_cancel_fn",
+]

--- a/simmer_sdk/execution/partial_fill.py
+++ b/simmer_sdk/execution/partial_fill.py
@@ -52,7 +52,7 @@ class FillResult:
     order_id: str
     target_size: float
     filled_size: float
-    fill_ratio: float  # filled_size / target_size, clamped to [0, inf)
+    fill_ratio: float  # filled_size / target_size; non-negative, may exceed 1.0 if filled overshoots target
     elapsed: float  # seconds spent polling
     polls: int
     cancel_attempted: bool = False

--- a/simmer_sdk/execution/partial_fill.py
+++ b/simmer_sdk/execution/partial_fill.py
@@ -1,0 +1,296 @@
+"""
+Partial-fill wait wrapper with time-boxed escape logic (SIM-1079).
+
+`await_fill()` polls an open limit order's `size_matched` and returns one of
+four statuses, giving callers a structured wait-or-cancel decision:
+
+  1. FILLED           — filled/target >= accept_pct (default 0.95)
+  2. PARTIAL          — early exit: filled/target >= partial_exit_pct AND
+                         elapsed >= max_wait * partial_exit_time_frac
+                         (default 0.50 past 70% of timeout)
+  3. TIMEOUT_PARTIAL  — max_wait elapsed with filled > 0
+  4. TIMEOUT_NO_FILL  — max_wait elapsed with zero fill
+
+This is the execution-time counterpart to SIM-917's backfill/accounting work
+— it does not replace or touch that path, it's a separate surface for callers
+that want explicit partial-fill discipline at order-submit time.
+
+The function is duck-typed: the caller supplies a `poll` callable that
+returns the current `size_matched` (or an order dict containing it) and a
+`cancel` callable to abort the remainder. Helpers `clob_poll_fn()` and
+`clob_cancel_fn()` wire a `py_clob_client.ClobClient` in one line; see the
+test file for a mock-based example.
+
+Design intent: thin wrapper. The only logic here is the state machine that
+maps (elapsed, filled_ratio) to a FillStatus — everything else (auth,
+signing, network) stays in the existing CLOB or SDK client layer.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Optional, Union
+
+
+class FillStatus(str, Enum):
+    """Terminal status for `await_fill()`. String-valued for JSON logs."""
+
+    FILLED = "FILLED"
+    PARTIAL = "PARTIAL"
+    TIMEOUT_PARTIAL = "TIMEOUT_PARTIAL"
+    TIMEOUT_NO_FILL = "TIMEOUT_NO_FILL"
+
+
+@dataclass
+class FillResult:
+    """Result of `await_fill()`. `cancel_result` and `cancel_error` are
+    populated when a cancel was attempted."""
+
+    status: FillStatus
+    order_id: str
+    target_size: float
+    filled_size: float
+    fill_ratio: float  # filled_size / target_size, clamped to [0, inf)
+    elapsed: float  # seconds spent polling
+    polls: int
+    cancel_attempted: bool = False
+    cancel_result: Optional[Dict[str, Any]] = None
+    cancel_error: Optional[str] = None
+    last_poll_error: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "order_id": self.order_id,
+            "target_size": self.target_size,
+            "filled_size": self.filled_size,
+            "fill_ratio": self.fill_ratio,
+            "elapsed": self.elapsed,
+            "polls": self.polls,
+            "cancel_attempted": self.cancel_attempted,
+            "cancel_result": self.cancel_result,
+            "cancel_error": self.cancel_error,
+            "last_poll_error": self.last_poll_error,
+            "extra": self.extra,
+        }
+
+
+# ---- Helpers for poll-result normalisation ---------------------------------
+
+
+def _extract_filled(poll_result: Any) -> float:
+    """Normalise a poll return value to a float `size_matched`.
+
+    Accepts:
+      - float / int  — treated as already the filled size
+      - str          — parsed as float (Polymarket returns strings)
+      - dict         — reads 'size_matched' (preferred) or 'filled' / 'matched'
+    """
+    if poll_result is None:
+        return 0.0
+    if isinstance(poll_result, (int, float)):
+        return float(poll_result)
+    if isinstance(poll_result, str):
+        try:
+            return float(poll_result)
+        except ValueError:
+            return 0.0
+    if isinstance(poll_result, dict):
+        for key in ("size_matched", "filled", "matched", "sizeMatched"):
+            if key in poll_result and poll_result[key] is not None:
+                try:
+                    return float(poll_result[key])
+                except (TypeError, ValueError):
+                    continue
+        return 0.0
+    return 0.0
+
+
+def _validate_thresholds(
+    accept_pct: float, partial_exit_pct: float, partial_exit_time_frac: float
+) -> None:
+    if not 0.0 < accept_pct <= 1.0:
+        raise ValueError(f"accept_pct must be in (0, 1], got {accept_pct}")
+    if not 0.0 < partial_exit_pct <= 1.0:
+        raise ValueError(
+            f"partial_exit_pct must be in (0, 1], got {partial_exit_pct}"
+        )
+    if not 0.0 < partial_exit_time_frac <= 1.0:
+        raise ValueError(
+            f"partial_exit_time_frac must be in (0, 1], got {partial_exit_time_frac}"
+        )
+    if partial_exit_pct > accept_pct:
+        # Not illegal but nonsensical — the partial window would never trigger
+        # before the full-fill window. Warn loudly by raising.
+        raise ValueError(
+            "partial_exit_pct must be <= accept_pct "
+            f"(got {partial_exit_pct} > {accept_pct})"
+        )
+
+
+# ---- Core primitive --------------------------------------------------------
+
+
+def await_fill(
+    order_id: str,
+    target_size: float,
+    max_wait: float,
+    *,
+    poll: Callable[[str], Any],
+    cancel: Callable[[str], Any],
+    accept_pct: float = 0.95,
+    partial_exit_pct: float = 0.50,
+    partial_exit_time_frac: float = 0.70,
+    poll_interval: float = 2.0,
+    _time: Callable[[], float] = time.monotonic,
+    _sleep: Callable[[float], None] = time.sleep,
+) -> FillResult:
+    """Poll an open order and return one of four terminal `FillStatus` values.
+
+    Args:
+        order_id: Order to poll.
+        target_size: Requested size at submit time (same units as
+            `size_matched`, usually contracts).
+        max_wait: Hard timeout in seconds. Function is guaranteed to return
+            before `elapsed > max_wait + poll_interval`.
+        poll: Callable `(order_id) -> size_matched` (float) or order dict
+            containing a `size_matched` / `filled` / `matched` field. Strings
+            are accepted (Polymarket returns decimal strings). Exceptions are
+            swallowed and the last error is surfaced on the result.
+        cancel: Callable `(order_id) -> dict` invoked when the wrapper
+            decides to cancel the remainder. Its return value is propagated
+            to `FillResult.cancel_result`. Exceptions are caught and surfaced
+            on `FillResult.cancel_error`.
+        accept_pct: filled/target threshold for FILLED. Default 0.95.
+        partial_exit_pct: filled/target threshold for early PARTIAL exit.
+            Default 0.50.
+        partial_exit_time_frac: elapsed/max_wait threshold that arms the
+            PARTIAL exit window. Default 0.70 (i.e. after 70% of the timeout).
+        poll_interval: seconds between polls. Default 2.0.
+        _time, _sleep: injected for tests.
+
+    Returns:
+        FillResult with status and diagnostics.
+
+    Raises:
+        ValueError on out-of-range threshold configuration.
+    """
+    _validate_thresholds(accept_pct, partial_exit_pct, partial_exit_time_frac)
+
+    if target_size <= 0:
+        raise ValueError(f"target_size must be > 0, got {target_size}")
+    if max_wait <= 0:
+        raise ValueError(f"max_wait must be > 0, got {max_wait}")
+    if poll_interval <= 0:
+        raise ValueError(f"poll_interval must be > 0, got {poll_interval}")
+
+    start = _time()
+    deadline = start + max_wait
+    partial_arm_time = start + max_wait * partial_exit_time_frac
+
+    filled = 0.0
+    polls = 0
+    last_poll_error: Optional[str] = None
+
+    def _ratio(f: float) -> float:
+        return f / target_size if target_size > 0 else 0.0
+
+    def _elapsed() -> float:
+        return _time() - start
+
+    def _do_cancel() -> Dict[str, Any]:
+        nonlocal last_poll_error  # only referenced
+        try:
+            result = cancel(order_id)
+            return {"ok": True, "result": result, "error": None}
+        except Exception as e:  # noqa: BLE001 — intentional catch-all
+            return {"ok": False, "result": None, "error": str(e)}
+
+    def _finish(
+        status: FillStatus,
+        do_cancel: bool,
+    ) -> FillResult:
+        cancel_attempted = False
+        cancel_result: Optional[Dict[str, Any]] = None
+        cancel_error: Optional[str] = None
+        if do_cancel:
+            cancel_attempted = True
+            outcome = _do_cancel()
+            cancel_result = outcome["result"]
+            cancel_error = outcome["error"]
+        return FillResult(
+            status=status,
+            order_id=order_id,
+            target_size=target_size,
+            filled_size=filled,
+            fill_ratio=_ratio(filled),
+            elapsed=_elapsed(),
+            polls=polls,
+            cancel_attempted=cancel_attempted,
+            cancel_result=cancel_result,
+            cancel_error=cancel_error,
+            last_poll_error=last_poll_error,
+        )
+
+    while True:
+        # Poll current fill state.
+        try:
+            raw = poll(order_id)
+            filled = max(filled, _extract_filled(raw))  # monotonic
+            last_poll_error = None
+        except Exception as e:  # noqa: BLE001
+            last_poll_error = str(e)
+        polls += 1
+
+        ratio = _ratio(filled)
+        now = _time()
+
+        # Path 1: FILLED — natural termination.
+        if ratio >= accept_pct:
+            # Cancel remainder only if less than full — a 100%-filled order
+            # has no open size to cancel.
+            should_cancel_remainder = ratio < 1.0
+            return _finish(FillStatus.FILLED, do_cancel=should_cancel_remainder)
+
+        # Path 2: PARTIAL — early exit once the partial window is armed.
+        if now >= partial_arm_time and ratio >= partial_exit_pct:
+            return _finish(FillStatus.PARTIAL, do_cancel=True)
+
+        # Deadline check — done *after* one poll past the deadline so we
+        # register any last-second fills.
+        if now >= deadline:
+            if filled > 0:
+                return _finish(FillStatus.TIMEOUT_PARTIAL, do_cancel=True)
+            return _finish(FillStatus.TIMEOUT_NO_FILL, do_cancel=True)
+
+        # Sleep to the next poll, but never past the deadline.
+        remaining = deadline - now
+        _sleep(min(poll_interval, max(remaining, 0.0)))
+
+
+# ---- Convenience wiring for py_clob_client ---------------------------------
+
+
+def clob_poll_fn(clob_client: Any) -> Callable[[str], Dict[str, Any]]:
+    """Return a `poll` callable for `await_fill()` backed by a
+    `py_clob_client.ClobClient`. The CLOB returns a dict with
+    `size_matched` as a string."""
+
+    def _poll(order_id: str) -> Dict[str, Any]:
+        order = clob_client.get_order(order_id)
+        return order or {}
+
+    return _poll
+
+
+def clob_cancel_fn(clob_client: Any) -> Callable[[str], Dict[str, Any]]:
+    """Return a `cancel` callable for `await_fill()` backed by a
+    `py_clob_client.ClobClient`."""
+
+    def _cancel(order_id: str) -> Dict[str, Any]:
+        return clob_client.cancel(order_id)
+
+    return _cancel

--- a/tests/test_partial_fill_wait.py
+++ b/tests/test_partial_fill_wait.py
@@ -1,0 +1,563 @@
+"""Tests for simmer_sdk.execution.partial_fill — SIM-1079.
+
+Covers the four terminal-status paths described in the ticket:
+
+  1. FILLED           — fill reaches accept_pct
+  2. PARTIAL          — early exit at partial_exit_pct after partial_exit_time_frac
+  3. TIMEOUT_PARTIAL  — max_wait elapses with some fill
+  4. TIMEOUT_NO_FILL  — max_wait elapses with zero fill
+
+Plus edge cases: cancel failure, poll failure, poll return shapes, threshold
+validation, 100% fill skipping remainder cancel.
+
+All tests use a virtual clock (FakeClock) and a scripted poll function — no
+time.sleep calls are actually made.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import pytest
+
+from simmer_sdk.execution import (
+    FillResult,
+    FillStatus,
+    await_fill,
+    clob_poll_fn,
+    clob_cancel_fn,
+)
+
+
+# ---- Test scaffolding ------------------------------------------------------
+
+
+class FakeClock:
+    """Monotonic virtual clock. `sleep` advances it."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def scripted_poll(fills_over_time):
+    """Return a poll callable that, on the Nth call, returns the Nth entry.
+    If called more times than the list, returns the last entry forever."""
+    calls = {"n": 0}
+
+    def _poll(order_id: str):
+        i = min(calls["n"], len(fills_over_time) - 1)
+        calls["n"] += 1
+        return fills_over_time[i]
+
+    return _poll
+
+
+def counting_cancel(result=None):
+    """Return a cancel callable that records the calls made against it."""
+    calls: List[str] = []
+
+    def _cancel(order_id: str):
+        calls.append(order_id)
+        return result if result is not None else {"canceled": [order_id]}
+
+    _cancel.calls = calls  # type: ignore[attr-defined]
+    return _cancel
+
+
+# ---- Path 1: FILLED --------------------------------------------------------
+
+
+def test_filled_reaches_accept_pct():
+    clock = FakeClock()
+    poll = scripted_poll([0.0, 50.0, 96.0])  # 0%, 50%, 96% of 100 target
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_1",
+        target_size=100.0,
+        max_wait=10.0,
+        poll=poll,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.FILLED
+    assert result.filled_size == 96.0
+    assert result.fill_ratio == pytest.approx(0.96)
+    assert result.cancel_attempted is True  # 96% < 100%, remainder cancelled
+    assert cancel.calls == ["ord_1"]
+    assert result.elapsed < 10.0
+
+
+def test_filled_full_100pct_skips_remainder_cancel():
+    """If the fill hits 100%, there is no open remainder — don't cancel."""
+    clock = FakeClock()
+    poll = scripted_poll([0.0, 50.0])
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_full",
+        target_size=50.0,
+        max_wait=10.0,
+        poll=poll,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.FILLED
+    assert result.fill_ratio == pytest.approx(1.0)
+    assert result.cancel_attempted is False
+    assert cancel.calls == []
+
+
+def test_filled_first_poll_exits_immediately():
+    """If the order is already past accept_pct at the first poll, we exit."""
+    clock = FakeClock()
+    poll = scripted_poll([100.0])  # already filled
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_prefilled",
+        target_size=100.0,
+        max_wait=30.0,
+        poll=poll,
+        cancel=cancel,
+        poll_interval=2.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.FILLED
+    assert result.polls == 1
+    assert clock.now == 0.0  # never slept
+
+
+# ---- Path 2: PARTIAL (early exit) -----------------------------------------
+
+
+def test_partial_early_exit_after_time_frac():
+    """At 70% of timeout with 60% fill, PARTIAL should trigger."""
+    clock = FakeClock()
+    # target=100, max_wait=10, poll_interval=1. Fills: 0 → 30 → 60 → 60 → ...
+    # partial_arm_time = 7.0s
+    # Poll 1 @ t=0: 0 (no exit); sleep 1 → t=1
+    # Poll 2 @ t=1: 30 (no exit); sleep 1 → t=2
+    # Poll 3 @ t=2: 60 (60% >= 50% but t<7 not yet armed); sleep 1 → t=3
+    # ... continue with 60 ...
+    # Poll @ t=7: 60 (armed AND 60% >= 50%) → PARTIAL
+    poll = scripted_poll([0.0, 30.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0])
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_partial",
+        target_size=100.0,
+        max_wait=10.0,
+        poll=poll,
+        cancel=cancel,
+        partial_exit_pct=0.50,
+        partial_exit_time_frac=0.70,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.PARTIAL
+    assert result.filled_size == 60.0
+    assert result.fill_ratio == pytest.approx(0.60)
+    assert result.elapsed == pytest.approx(7.0)
+    assert result.cancel_attempted is True
+    assert cancel.calls == ["ord_partial"]
+
+
+def test_partial_below_pct_does_not_exit_early():
+    """40% fill at t=7 (armed) is below 50% threshold → keep waiting."""
+    clock = FakeClock()
+    # target=100, fills stuck at 40 → timeout_partial at t=10
+    poll = scripted_poll([0.0, 20.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0])
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_slow",
+        target_size=100.0,
+        max_wait=10.0,
+        poll=poll,
+        cancel=cancel,
+        partial_exit_pct=0.50,
+        partial_exit_time_frac=0.70,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.TIMEOUT_PARTIAL
+    assert result.filled_size == 40.0
+    assert result.elapsed >= 10.0
+
+
+def test_partial_armed_but_not_reached_until_later():
+    """At t=7 fill is 40% (no), grows to 55% at t=8 → PARTIAL."""
+    clock = FakeClock()
+    # Polls at t = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    # fills:       0  0  0  0  0  0  0  40 55 ...
+    poll = scripted_poll([0, 0, 0, 0, 0, 0, 0, 40, 55, 55, 55])
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_late_partial",
+        target_size=100.0,
+        max_wait=10.0,
+        poll=poll,
+        cancel=cancel,
+        partial_exit_pct=0.50,
+        partial_exit_time_frac=0.70,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.PARTIAL
+    assert result.filled_size == 55.0
+    assert result.elapsed == pytest.approx(8.0)
+
+
+# ---- Path 3: TIMEOUT_PARTIAL -----------------------------------------------
+
+
+def test_timeout_partial_with_small_fill():
+    """Fill stays at 20% (below both accept_pct and partial_exit_pct) → TIMEOUT_PARTIAL."""
+    clock = FakeClock()
+    poll = scripted_poll([0.0, 10.0, 20.0] + [20.0] * 20)
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_timeout_partial",
+        target_size=100.0,
+        max_wait=10.0,
+        poll=poll,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.TIMEOUT_PARTIAL
+    assert result.filled_size == 20.0
+    assert result.elapsed >= 10.0
+    assert result.cancel_attempted is True
+    assert cancel.calls == ["ord_timeout_partial"]
+
+
+# ---- Path 4: TIMEOUT_NO_FILL -----------------------------------------------
+
+
+def test_timeout_no_fill():
+    """Zero fill throughout → TIMEOUT_NO_FILL."""
+    clock = FakeClock()
+    poll = scripted_poll([0.0] * 30)
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_nofill",
+        target_size=100.0,
+        max_wait=5.0,
+        poll=poll,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.TIMEOUT_NO_FILL
+    assert result.filled_size == 0.0
+    assert result.fill_ratio == 0.0
+    assert result.elapsed >= 5.0
+    assert result.cancel_attempted is True  # still fire-and-forget cancel
+    assert cancel.calls == ["ord_nofill"]
+
+
+# ---- Cancel-failure handling ----------------------------------------------
+
+
+def test_cancel_failure_surfaces_in_result():
+    """cancel() raising → FillResult.cancel_error is populated; status unchanged."""
+    clock = FakeClock()
+    poll = scripted_poll([0.0, 30.0, 30.0] + [30.0] * 20)
+
+    def bad_cancel(order_id):
+        raise RuntimeError("CLOB 500")
+
+    result = await_fill(
+        order_id="ord_cancel_fail",
+        target_size=100.0,
+        max_wait=5.0,
+        poll=poll,
+        cancel=bad_cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.TIMEOUT_PARTIAL
+    assert result.cancel_attempted is True
+    assert result.cancel_result is None
+    assert "CLOB 500" in (result.cancel_error or "")
+
+
+# ---- Poll-error handling ---------------------------------------------------
+
+
+def test_poll_failure_continues_but_records_error():
+    """Transient poll exceptions don't abort the wait loop."""
+    clock = FakeClock()
+    call_count = {"n": 0}
+
+    def flaky_poll(order_id):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise ConnectionError("transient")
+        if call_count["n"] >= 4:
+            return {"size_matched": "100"}
+        return {"size_matched": "0"}
+
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_flaky",
+        target_size=100.0,
+        max_wait=30.0,
+        poll=flaky_poll,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.FILLED
+    # last_poll_error should be None because the final poll succeeded
+    assert result.last_poll_error is None
+
+
+def test_poll_always_fails_still_terminates():
+    """Even if every poll fails, the function must respect max_wait."""
+    clock = FakeClock()
+
+    def always_fail(order_id):
+        raise ConnectionError("network down")
+
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_offline",
+        target_size=100.0,
+        max_wait=3.0,
+        poll=always_fail,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.TIMEOUT_NO_FILL
+    assert result.last_poll_error == "network down"
+    assert result.elapsed >= 3.0
+
+
+# ---- Poll return-shape flexibility ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "poll_returns,expected_filled",
+    [
+        ([{"size_matched": "95"}], 95.0),       # CLOB dict with string (Polymarket)
+        ([{"size_matched": 95.0}], 95.0),       # dict with float
+        ([{"filled": 95.0}], 95.0),             # alternate key
+        ([{"matched": 95}], 95.0),              # alternate key
+        ([{"sizeMatched": "95"}], 95.0),        # camelCase
+        ([95.0], 95.0),                         # bare float
+        (["95"], 95.0),                         # bare string
+        ([95], 95.0),                           # bare int
+        ([None], 0.0),                          # None → 0
+        ([{"status": "live"}], 0.0),            # no relevant key → 0
+    ],
+)
+def test_poll_return_shape_flexibility(poll_returns, expected_filled):
+    clock = FakeClock()
+    # If the first poll already exceeds accept_pct, the function returns FILLED.
+    # For the 0.0 cases, pad with more zeros so the run hits TIMEOUT_NO_FILL.
+    if expected_filled >= 95.0:
+        script = poll_returns
+    else:
+        script = poll_returns + [0.0] * 20
+
+    cancel = counting_cancel()
+    result = await_fill(
+        order_id="ord_shape",
+        target_size=100.0,
+        max_wait=3.0,
+        poll=scripted_poll(script),
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+    assert result.filled_size == expected_filled
+
+
+# ---- Threshold validation --------------------------------------------------
+
+
+def test_rejects_accept_pct_out_of_range():
+    with pytest.raises(ValueError):
+        await_fill(
+            order_id="x", target_size=100, max_wait=10,
+            poll=lambda _: 0.0, cancel=lambda _: {},
+            accept_pct=1.5,
+        )
+
+
+def test_rejects_partial_pct_above_accept_pct():
+    with pytest.raises(ValueError):
+        await_fill(
+            order_id="x", target_size=100, max_wait=10,
+            poll=lambda _: 0.0, cancel=lambda _: {},
+            accept_pct=0.80,
+            partial_exit_pct=0.90,
+        )
+
+
+def test_rejects_zero_target_size():
+    with pytest.raises(ValueError):
+        await_fill(
+            order_id="x", target_size=0.0, max_wait=10,
+            poll=lambda _: 0.0, cancel=lambda _: {},
+        )
+
+
+def test_rejects_zero_max_wait():
+    with pytest.raises(ValueError):
+        await_fill(
+            order_id="x", target_size=100.0, max_wait=0.0,
+            poll=lambda _: 0.0, cancel=lambda _: {},
+        )
+
+
+# ---- Monotonicity of filled_size -------------------------------------------
+
+
+def test_filled_is_monotonic_even_if_poll_drops():
+    """If a poll transiently returns a smaller fill (CLOB bug / pagination),
+    we keep the max seen. Polymarket orders never shrink."""
+    clock = FakeClock()
+    poll = scripted_poll([50.0, 80.0, 40.0, 96.0])  # dip at poll 3
+    cancel = counting_cancel()
+
+    result = await_fill(
+        order_id="ord_monotonic",
+        target_size=100.0,
+        max_wait=30.0,
+        poll=poll,
+        cancel=cancel,
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.FILLED
+    assert result.filled_size == 96.0
+
+
+# ---- clob_poll_fn / clob_cancel_fn -----------------------------------------
+
+
+class _FakeClob:
+    """Minimal py_clob_client stand-in."""
+
+    def __init__(self, size_matched="50", cancel_result=None):
+        self._size_matched = size_matched
+        self._cancel_result = cancel_result or {"canceled": ["any"]}
+        self.get_order_calls = []
+        self.cancel_calls = []
+
+    def get_order(self, order_id):
+        self.get_order_calls.append(order_id)
+        return {"id": order_id, "size_matched": self._size_matched, "status": "live"}
+
+    def cancel(self, order_id):
+        self.cancel_calls.append(order_id)
+        return self._cancel_result
+
+
+def test_clob_helpers_wire_correctly():
+    clock = FakeClock()
+    clob = _FakeClob(size_matched="100")
+
+    result = await_fill(
+        order_id="ord_clob",
+        target_size=100.0,
+        max_wait=5.0,
+        poll=clob_poll_fn(clob),
+        cancel=clob_cancel_fn(clob),
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.FILLED
+    assert clob.get_order_calls == ["ord_clob"]
+    # Full fill → no remainder cancel.
+    assert clob.cancel_calls == []
+
+
+def test_clob_helpers_cancel_on_partial():
+    clock = FakeClock()
+    clob = _FakeClob(size_matched="0")
+
+    result = await_fill(
+        order_id="ord_clob_partial",
+        target_size=100.0,
+        max_wait=3.0,
+        poll=clob_poll_fn(clob),
+        cancel=clob_cancel_fn(clob),
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    assert result.status == FillStatus.TIMEOUT_NO_FILL
+    assert clob.cancel_calls == ["ord_clob_partial"]
+
+
+# ---- to_dict serialisation -------------------------------------------------
+
+
+def test_fill_result_to_dict_shape():
+    clock = FakeClock()
+    result = await_fill(
+        order_id="ord_dict",
+        target_size=100.0,
+        max_wait=1.0,
+        poll=scripted_poll([100.0]),
+        cancel=counting_cancel(),
+        poll_interval=1.0,
+        _time=clock.time,
+        _sleep=clock.sleep,
+    )
+
+    d = result.to_dict()
+    assert d["status"] == "FILLED"  # string-valued for JSON
+    assert d["order_id"] == "ord_dict"
+    assert d["target_size"] == 100.0
+    assert d["fill_ratio"] == 1.0
+    # Round-trip-safe for logging
+    import json
+    json.dumps(d)


### PR DESCRIPTION
## Summary

- Adds `simmer_sdk.execution.await_fill()` — thin, opt-in wrapper that polls an open limit order's `size_matched` and returns one of four terminal statuses (`FILLED` / `PARTIAL` / `TIMEOUT_PARTIAL` / `TIMEOUT_NO_FILL`). Thresholds configurable; defaults match the commodity 0.95 / 0.50 / 0.70 pattern.
- Adds `clob_poll_fn` / `clob_cancel_fn` helpers for one-line `py_clob_client.ClobClient` wiring.
- 29 new unit tests; full suite (134) still green.
- Ships alongside docs PR `simmer-docs#feat/sim-1079-execution-docs` (sdk/execution.mdx).

## Scope

- **Opt-in.** `client.trade()` default path is unchanged.
- **Does not replace SIM-917** backfill/accounting — execution-time vs post-trade are different concerns.
- Duck-typed callables keep the primitive testable with no network dependencies.

## Test plan

- [x] 29 unit tests cover all four terminal paths, cancel-failure, poll-failure, poll-return-shape flexibility, threshold validation, monotonic fill tracking
- [x] Existing SIM-917 backfill script (`scripts/backfill_sim917_partial_fills.py` in `simmer/`) continues to parse/import unchanged
- [x] `python -m pytest tests/` passes: 134 passed, 10 skipped
- [ ] Adrian to review API surface before version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)