### PR TITLE
feat(skills): balance pre-flight across 8 polymarket skills (SIM-1063)

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1877,6 +1877,140 @@ class SimmerClient:
             "GET", "/api/sdk/portfolio", params={"venue": venue}
         )
 
+    def ensure_can_trade(
+        self,
+        min_usd: float = 1.0,
+        venue: Optional[str] = None,
+        safety_buffer: float = 0.02,
+    ) -> Dict[str, Any]:
+        """
+        Pre-flight balance check for trading skills.
+
+        One status fetch replaces many failed trade round-trips when a wallet
+        is underfunded. Skills should call this once per run before discovering
+        markets / placing orders. Result is collateral-agnostic — `balance`
+        reflects the active collateral token (pUSD on V2, USDC.e on V1) per
+        the server's `exchange_version`.
+
+        Args:
+            min_usd: Minimum viable trade size in active collateral. If wallet
+                balance is below this, returns `ok=False, reason="insufficient_balance"`
+                so the skill can skip cleanly instead of looping on rejected orders.
+            venue: Venue to check. Defaults to client's venue. Only "polymarket"
+                does a balance check today; other venues short-circuit to ok=True.
+            safety_buffer: Fraction of balance to keep as fee buffer. Default 0.02
+                (2%). `max_safe_size = balance * (1 - safety_buffer)` is the
+                largest order size the skill should place to leave room for
+                Polymarket fees + price slippage.
+
+        Returns:
+            Dict containing:
+            - ok (bool): True if balance >= min_usd (or non-polymarket venue)
+            - balance (float): Active collateral balance in USD-equivalent units
+            - collateral (str): "pUSD" (V2), "USDC.e" (V1), or "" (non-polymarket)
+            - exchange_version (str): "v1" or "v2" — matches server-side flag
+            - reason (str): "ok" | "insufficient_balance" | "no_wallet" |
+              "balance_unavailable" | "skipped_non_polymarket"
+            - max_safe_size (float): balance * (1 - safety_buffer); 0 when not ok
+
+        Example:
+            preflight = client.ensure_can_trade(min_usd=2.0)
+            if not preflight["ok"]:
+                print(f"Skip: {preflight['reason']} (balance ${preflight['balance']:.2f})")
+                return  # emit automaton skip and exit
+            order_size = min(MY_MAX_BET, preflight["max_safe_size"])
+        """
+        effective_venue = venue or self.venue
+
+        # Non-polymarket venues: paper trading or kalshi. Skip the check —
+        # caller's existing flow handles balance differently (sim is virtual,
+        # kalshi uses Solana balance which has its own preflight elsewhere).
+        if effective_venue != "polymarket":
+            return {
+                "ok": True,
+                "balance": 0.0,
+                "collateral": "",
+                "exchange_version": "",
+                "reason": "skipped_non_polymarket",
+                "max_safe_size": float("inf"),
+            }
+
+        # Active collateral label — matches server-side exchange_version flag.
+        # Imported lazily so the SDK doesn't pay the cost on every import.
+        try:
+            from .polymarket_contracts import exchange_version_str
+            ev = exchange_version_str()
+        except Exception:
+            ev = "v2"  # safe default post-cutover (2026-04-28)
+        collateral_label = "pUSD" if ev == "v2" else "USDC.e"
+
+        try:
+            portfolio = self.get_portfolio(venue="polymarket")
+        except Exception as e:
+            return {
+                "ok": False,
+                "balance": 0.0,
+                "collateral": collateral_label,
+                "exchange_version": ev,
+                "reason": "balance_unavailable",
+                "max_safe_size": 0.0,
+            }
+
+        if not portfolio:
+            return {
+                "ok": False,
+                "balance": 0.0,
+                "collateral": collateral_label,
+                "exchange_version": ev,
+                "reason": "balance_unavailable",
+                "max_safe_size": 0.0,
+            }
+
+        poly_bucket = portfolio.get("polymarket") or {}
+        # Per-venue bucket is the source of truth; balance_usdc is the legacy
+        # mirror but per-venue lets us distinguish "no wallet linked" cleanly.
+        raw_balance = poly_bucket.get("balance")
+        if raw_balance is None:
+            # bucket present but balance None = wallet not linked OR RPC failed.
+            # Server returns null balance when balance fetch fails (RPC outage)
+            # vs 0.0 when wallet is genuinely empty. Distinguish:
+            balance_usdc = portfolio.get("balance_usdc")
+            if balance_usdc is None:
+                # Try to detect "no wallet" vs RPC failure: check warnings list
+                # is one heuristic, but simplest is to treat null as RPC issue.
+                # No wallet → polymarket bucket itself is None (handled above).
+                return {
+                    "ok": False,
+                    "balance": 0.0,
+                    "collateral": collateral_label,
+                    "exchange_version": ev,
+                    "reason": "balance_unavailable",
+                    "max_safe_size": 0.0,
+                }
+            balance = float(balance_usdc)
+        else:
+            balance = float(raw_balance)
+
+        max_safe = round(balance * (1.0 - safety_buffer), 2)
+        if balance < min_usd:
+            return {
+                "ok": False,
+                "balance": balance,
+                "collateral": collateral_label,
+                "exchange_version": ev,
+                "reason": "insufficient_balance",
+                "max_safe_size": 0.0,
+            }
+
+        return {
+            "ok": True,
+            "balance": balance,
+            "collateral": collateral_label,
+            "exchange_version": ev,
+            "reason": "ok",
+            "max_safe_size": max_safe,
+        }
+
     def get_market_context(
         self,
         market_id: str,

--- a/skills/polymarket-ai-divergence/ai_divergence.py
+++ b/skills/polymarket-ai-divergence/ai_divergence.py
@@ -564,6 +564,29 @@ def main():
     except Exception:
         pass  # Non-critical — don't block trading
 
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    global MAX_BET_USD, _automaton_reported
+    is_paper_venue_pre = os.environ.get("TRADING_VENUE", "polymarket") == "sim"
+    if not dry_run and not is_paper_venue_pre:
+        _preflight = client.ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            print(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                  f"(need ≥ $1.00) — skip")
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < MAX_BET_USD:
+            print(f"  💰 Capping max bet ${MAX_BET_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                  f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})")
+            MAX_BET_USD = _preflight["max_safe_size"]
+
     direction = DEFAULT_DIRECTION or None
     if args.bullish:
         direction = "bullish"
@@ -605,7 +628,6 @@ def main():
 
     # Structured report for automaton
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         report = {"signals": signals, "trades_attempted": attempted, "trades_executed": executed, "amount_usd": round(total_usd_spent, 2)}
         if signals > 0 and executed == 0 and skip_reasons:
             report["skip_reason"] = ", ".join(dict.fromkeys(skip_reasons))

--- a/skills/polymarket-copytrading/copytrading_trader.py
+++ b/skills/polymarket-copytrading/copytrading_trader.py
@@ -393,6 +393,28 @@ def run_copytrading(wallets: list, top_n: int = None, max_usd: float = 50.0, dry
     except Exception:
         pass  # Non-critical — don't block trading
 
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    global _automaton_reported
+    if not dry_run and (venue or "polymarket") == "polymarket":
+        _preflight = get_client().ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            print(f"\n  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                  f"(need ≥ $1.00) — skip")
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < max_usd:
+            print(f"  💰 Capping max per position ${max_usd:.2f} → ${_preflight['max_safe_size']:.2f} "
+                  f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})")
+            max_usd = _preflight["max_safe_size"]
+
     # Execute copytrading via SDK
     print("\n📡 Calling Simmer API...")
     try:
@@ -480,7 +502,6 @@ def run_copytrading(wallets: list, top_n: int = None, max_usd: float = 50.0, dry
 
     # Structured report for automaton
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         positions_found = result.get('positions_found', 0) if result else 0
         _trades_needed = result.get('trades_needed', 0) if result else 0
         _trades_exec = result.get('trades_executed', 0) if result else 0

--- a/skills/polymarket-elon-tweets/elon_tweets.py
+++ b/skills/polymarket-elon-tweets/elon_tweets.py
@@ -607,6 +607,10 @@ def run_strategy(dry_run=True, positions_only=False, show_config=False,
                  show_stats=False, smart_sizing=False, use_safeguards=True,
                  quiet=False):
     """Run the Elon tweet trading strategy."""
+    # Globals declared up-front: balance pre-flight (below) may cap MAX_POSITION_USD,
+    # and automaton skip reports flip _automaton_reported.
+    global MAX_POSITION_USD, _automaton_reported
+
     def log(msg, force=False):
         if not quiet or force:
             print(msg)
@@ -625,6 +629,27 @@ def run_strategy(dry_run=True, positions_only=False, show_config=False,
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
     except Exception:
         pass  # Non-critical — don't block trading
+
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    if not dry_run:
+        _preflight = client.ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            log(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                f"(need ≥ $1.00) — skip", force=True)
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < MAX_POSITION_USD:
+            log(f"  💰 Capping max bet ${MAX_POSITION_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})", force=True)
+            MAX_POSITION_USD = _preflight["max_safe_size"]
 
     if dry_run:
         log("\n  [PAPER MODE] Trades will be simulated with real prices. Use --live for real trades.")
@@ -940,7 +965,6 @@ def run_strategy(dry_run=True, positions_only=False, show_config=False,
 
     # Structured report for automaton
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         report = {"signals": opportunities_found + exits_found, "trades_attempted": opportunities_found + exits_found, "trades_executed": total_trades, "amount_usd": round(total_usd_spent, 2)}
         if (opportunities_found + exits_found) > 0 and total_trades == 0 and skip_reasons:
             report["skip_reason"] = ", ".join(dict.fromkeys(skip_reasons))

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -664,6 +664,9 @@ def calculate_position_size(max_size, smart_sizing=False):
 def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=False,
                         smart_sizing=False, quiet=False):
     """Run one cycle of the fast_market trading strategy."""
+    # Globals declared up-front: balance pre-flight (below) may cap MAX_POSITION_USD,
+    # and automaton skip reports flip _automaton_reported.
+    global MAX_POSITION_USD, _automaton_reported
 
     def log(msg, force=False):
         """Print unless quiet mode is on. force=True always prints."""
@@ -709,6 +712,27 @@ def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=Fal
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
     except Exception:
         pass  # Non-critical — don't block trading
+
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    if not dry_run:
+        _preflight = client.ensure_can_trade(min_usd=max(1.0, MIN_SHARES_PER_ORDER * 0.5))
+        if not _preflight["ok"]:
+            log(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                f"(need ≥ $1.00) — skip", force=True)
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < MAX_POSITION_USD:
+            log(f"  💰 Capping max bet ${MAX_POSITION_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})", force=True)
+            MAX_POSITION_USD = _preflight["max_safe_size"]
 
     # GTC stale order cleanup: cancel any open GTC orders from previous cycles.
     # GTC orders sit on the CLOB indefinitely — if a previous cycle's order wasn't
@@ -1131,7 +1155,6 @@ def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=Fal
 
     # Structured report for automaton (takes priority over fallback in __main__)
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         amount = round(position_size, 2) if total_trades > 0 else 0
         report = {"signals": 1, "trades_attempted": 1, "trades_executed": total_trades, "amount_usd": amount}
         if execution_error:

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -342,6 +342,9 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
                       smart_sizing=False, use_safeguards=True,
                       filter_override=None, expiry_override=None):
     """Run the Mert Sniper near-expiry strategy."""
+    # Globals declared up-front: balance pre-flight (below) may cap MAX_BET_USD,
+    # and automaton skip reports flip _automaton_reported.
+    global MAX_BET_USD, _automaton_reported
     print("🎯 Mert Sniper - Near-Expiry Conviction Trading")
     print("=" * 50)
 
@@ -359,6 +362,27 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
                 print(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
     except Exception:
         pass  # Non-critical — don't block trading
+
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    if not dry_run:
+        _preflight = client.ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            print(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                  f"(need ≥ $1.00) — skip")
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < MAX_BET_USD:
+            print(f"  💰 Capping max bet ${MAX_BET_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                  f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})")
+            MAX_BET_USD = _preflight["max_safe_size"]
 
     if dry_run:
         print("\n  [PAPER MODE] Trades will be simulated with real prices. Use --live for real trades.")
@@ -569,7 +593,6 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
 
     # Structured report for automaton
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         report = {"signals": strong_split_count, "trades_attempted": strong_split_count, "trades_executed": trades_executed, "amount_usd": round(total_usd_spent, 2)}
         if strong_split_count > 0 and trades_executed == 0 and skip_reasons:
             report["skip_reason"] = ", ".join(dict.fromkeys(skip_reasons))

--- a/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
+++ b/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
@@ -572,6 +572,29 @@ def main():
     except Exception:
         pass  # Non-critical
 
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    global MAX_BET_USD, _automaton_reported
+    is_paper_venue_pre = os.environ.get("TRADING_VENUE", "polymarket") == "sim"
+    if not dry_run and not is_paper_venue_pre:
+        _preflight = get_client().ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            print(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                  f"(need ≥ $1.00) — skip")
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < MAX_BET_USD:
+            print(f"  💰 Capping max bet ${MAX_BET_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                  f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})")
+            MAX_BET_USD = _preflight["max_safe_size"]
+
     if not args.quiet:
         print(f"Scanning Polymarket for NO opportunities (cap: {PRICE_CAP:.0%})...")
 
@@ -591,7 +614,6 @@ def main():
     )
 
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         report = {
             "signals": signals,
             "trades_attempted": attempted,

--- a/skills/polymarket-signal-sniper/signal_sniper.py
+++ b/skills/polymarket-signal-sniper/signal_sniper.py
@@ -671,6 +671,9 @@ def run_scan(
 
     Returns summary of results.
     """
+    # Globals declared up-front: balance pre-flight (below) may cap MAX_USD,
+    # and automaton skip reports flip _automaton_reported.
+    global MAX_USD, _automaton_reported
     if dry_run:
         print("\n  [PAPER MODE] Trades will be simulated with real prices. Use --live for real trades.\n")
 
@@ -688,6 +691,27 @@ def run_scan(
                 print(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
     except Exception:
         pass  # Non-critical — don't block trading
+
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    if not dry_run:
+        _preflight = client.ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            print(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                  f"(need ≥ $1.00) — skip")
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return {"skipped": _preflight["reason"], "balance_usd": _preflight["balance"]}
+        if _preflight["max_safe_size"] < MAX_USD:
+            print(f"  💰 Capping max bet ${MAX_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                  f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})")
+            MAX_USD = _preflight["max_safe_size"]
 
     if not feeds:
         print("❌ No RSS feeds configured")
@@ -929,7 +953,6 @@ def run_scan(
 
     # Structured report for automaton
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         signals_count = len(results['signals'])
         report = {"signals": signals_count, "trades_attempted": results['trades_executed'] + results['trades_skipped'], "trades_executed": results['trades_executed'], "amount_usd": round(results['total_usd_spent'], 2)}
         if signals_count > 0 and results['trades_executed'] == 0 and skip_reasons:

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -924,6 +924,10 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                          use_safeguards: bool = True, use_trends: bool = True,
                          quiet: bool = False, vol_targeting: bool = VOL_TARGETING):
     """Run the weather trading strategy."""
+    # Globals declared up-front: balance pre-flight (below) may cap MAX_POSITION_USD,
+    # and automaton skip reports flip _automaton_reported.
+    global MAX_POSITION_USD, _automaton_reported
+
     def log(msg, force=False):
         """Print unless quiet mode is on. force=True always prints."""
         if not quiet or force:
@@ -975,6 +979,27 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
     except Exception:
         pass  # Non-critical — don't block trading
+
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
+    # on V2, USDC.e on V1 per server's exchange_version.
+    if not dry_run:
+        _preflight = client.ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            log(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                f"(need ≥ $1.00) — skip", force=True)
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": _preflight["reason"],
+                    "balance_usd": round(_preflight["balance"], 2),
+                }}))
+                _automaton_reported = True
+            return
+        if _preflight["max_safe_size"] < MAX_POSITION_USD:
+            log(f"  💰 Capping max bet ${MAX_POSITION_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})", force=True)
+            MAX_POSITION_USD = _preflight["max_safe_size"]
 
     # Show portfolio if smart sizing enabled
     if smart_sizing:
@@ -1242,7 +1267,6 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
 
     # Structured report for automaton
     if os.environ.get("AUTOMATON_MANAGED"):
-        global _automaton_reported
         report = {"signals": opportunities_found + exits_found, "trades_attempted": opportunities_found + exits_found, "trades_executed": total_trades, "amount_usd": round(total_usd_spent, 2)}
         if (opportunities_found + exits_found) > 0 and total_trades == 0 and skip_reasons:
             report["skip_reason"] = ", ".join(dict.fromkeys(skip_reasons))

--- a/tests/test_ensure_can_trade.py
+++ b/tests/test_ensure_can_trade.py
@@ -1,0 +1,86 @@
+"""Tests for SimmerClient.ensure_can_trade balance pre-flight helper (SIM-1063).
+
+Contract:
+- Non-polymarket venues short-circuit to ok=True (paper/kalshi have their own checks).
+- Underfunded polymarket wallet returns ok=False with reason="insufficient_balance".
+- Funded wallet returns ok=True and max_safe_size = balance * (1 - safety_buffer).
+- Portfolio RPC failure returns ok=False with reason="balance_unavailable".
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_client(venue: str = "polymarket") -> SimmerClient:
+    # API key is required at construction; helper never makes a network call
+    # because we mock get_portfolio below.
+    return SimmerClient(api_key="test-key", venue=venue)
+
+
+def test_skipped_non_polymarket_venue():
+    client = _make_client(venue="sim")
+    result = client.ensure_can_trade(min_usd=5.0)
+    assert result["ok"] is True
+    assert result["reason"] == "skipped_non_polymarket"
+    assert result["collateral"] == ""
+
+
+def test_insufficient_balance_returns_skip():
+    client = _make_client()
+    fake_portfolio = {"polymarket": {"balance": 0.50}, "balance_usdc": 0.50}
+    with patch.object(client, "get_portfolio", return_value=fake_portfolio):
+        result = client.ensure_can_trade(min_usd=1.0)
+    assert result["ok"] is False
+    assert result["reason"] == "insufficient_balance"
+    assert result["balance"] == pytest.approx(0.50)
+    assert result["max_safe_size"] == 0.0
+
+
+def test_sufficient_balance_returns_max_safe_size():
+    client = _make_client()
+    fake_portfolio = {"polymarket": {"balance": 100.0}, "balance_usdc": 100.0}
+    with patch.object(client, "get_portfolio", return_value=fake_portfolio):
+        result = client.ensure_can_trade(min_usd=1.0, safety_buffer=0.02)
+    assert result["ok"] is True
+    assert result["reason"] == "ok"
+    assert result["balance"] == pytest.approx(100.0)
+    assert result["max_safe_size"] == pytest.approx(98.0)
+
+
+def test_custom_safety_buffer():
+    client = _make_client()
+    fake_portfolio = {"polymarket": {"balance": 50.0}, "balance_usdc": 50.0}
+    with patch.object(client, "get_portfolio", return_value=fake_portfolio):
+        result = client.ensure_can_trade(min_usd=1.0, safety_buffer=0.10)
+    assert result["ok"] is True
+    assert result["max_safe_size"] == pytest.approx(45.0)
+
+
+def test_portfolio_rpc_failure_returns_balance_unavailable():
+    client = _make_client()
+    with patch.object(client, "get_portfolio", side_effect=RuntimeError("RPC down")):
+        result = client.ensure_can_trade(min_usd=1.0)
+    assert result["ok"] is False
+    assert result["reason"] == "balance_unavailable"
+    assert result["balance"] == 0.0
+
+
+def test_null_balance_returns_balance_unavailable():
+    """Server returns null balance when RPC fetch fails — treat as unavailable, not empty."""
+    client = _make_client()
+    fake_portfolio = {"polymarket": {"balance": None}, "balance_usdc": None}
+    with patch.object(client, "get_portfolio", return_value=fake_portfolio):
+        result = client.ensure_can_trade(min_usd=1.0)
+    assert result["ok"] is False
+    assert result["reason"] == "balance_unavailable"
+
+
+def test_venue_override_argument():
+    """`venue` kwarg overrides the client's default venue."""
+    client = _make_client(venue="polymarket")
+    result = client.ensure_can_trade(min_usd=1.0, venue="sim")
+    assert result["ok"] is True
+    assert result["reason"] == "skipped_non_polymarket"


### PR DESCRIPTION
## Summary

Closes SIM-1063 — eliminates the 1,875-per-48h failure loop from underfunded wallets.

- **New SDK helper** `client.ensure_can_trade(min_usd)` — collateral-agnostic pre-flight. Returns `{ok, balance, collateral, exchange_version, reason, max_safe_size}`. Reads pUSD on V2 / USDC.e on V1 per server's `exchange_version`, so it just works across the V2 cutover.
- **8 polymarket trading skills** now call it once per run before discovery:
  - Underfunded → emit automaton skip report (`skip_reason="insufficient_balance"`) and return. Harness + reporting can distinguish underfunded from broken.
  - Sized correctly → cap per-run max bet at `balance * 0.98` (2% fee/slippage buffer).
- **polymarket-wallet-xray skipped** — read-only analytics, no `execute_trade` / `place_order` calls.

Skills updated: copytrading, fast-loop, mert-sniper, signal-sniper, weather-trader, elon-tweets, ai-divergence, nothing-ever-happens.

## Why

Three wallets (incl. `0x3f3d1e7e…` at \$18.65 USDC.e with a \$50-order skill) produced ~78% of 2,388 skill failures in a 48h window. Each cron tick round-tripped to the backend only to be rejected — zero signal, pure noise. One `get_portfolio()` call per run is cheap; thousands of rejected trades per day are not.

## Test plan

- [x] `python3 -m pytest tests/ -x -q` — 160 passed, 10 skipped (pre-existing), 0 failures
- [x] `python3 -m py_compile` all 8 modified skills + `client.py` — OK
- [x] 7 new unit tests in `tests/test_ensure_can_trade.py` covering ok / insufficient / RPC-failure / null-balance / safety_buffer / venue-override paths
- [ ] Manual harness run on one live skill after merge (recommend polymarket-fast-loop against an underfunded wallet to confirm clean skip + automaton report)

## Docs impact

**Yes** — public SDK method added. Needs Mintlify docs entry for `client.ensure_can_trade()` under the Polymarket / risk-management section once this lands.

## Skills affected

8 skills updated (listed above). Each skill’s SKILL.md does **not** need changes — behavior is additive and transparent (skip reason is surfaced in the automaton structured report, not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)