### PR TITLE
fix(sdk): V2 FAK/FOK BUY maker precision (0.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] — 2026-04-30
+
+### Fixed
+
+- **Polymarket V2 FAK/FOK BUY: maker amount precision rejection on
+  non-cent-aligned prices.** `client.trade(action="buy",
+  order_type="FAK")` was producing `makerAmount` values with
+  4–5 decimals of USDC precision (e.g. `$5.99767` for a `$6.00` BUY
+  on a `tick_size=0.001` market). Polymarket CLOB enforces "FAK/FOK
+  maker max 2 decimals" and rejected these orders with `Order
+  rejected: invalid amounts, the market buy orders maker amount
+  supports a max accuracy of 2 decimals`.
+
+  The V2 path now routes FAK/FOK orders through Polymarket's
+  canonical market-order builder (`MarketOrderArgsV2` →
+  `OrderBuilder.build_market_order`), which rounds maker (USDC for
+  BUY, shares for SELL) down to 2 decimals by construction across
+  all tick sizes (`0.01`, `0.001`, `0.0001`). GTC/GTD limit orders
+  continue using `OrderArgsV2` → `build_order` and preserve full
+  `price × size = maker` precision (CLOB validates that exactly for
+  limit orders).
+
+  `build_and_sign_order(...)` gains an optional `amount_usdc` kwarg
+  (the original USDC dollar amount for FAK/FOK BUY) so the signed
+  maker matches what the caller asked for, not a derived
+  `size × price` which can shave a cent under float drift.
+  `client._execute_polymarket_byow_trade` plumbs it through
+  automatically — most callers do not need to touch this.
+
+  V1 signing path was already correct (post-hoc 2-dec rounding step
+  has been there since Feb 17). OWS path remains V1-only and is
+  out of scope for this fix; tracked separately in the
+  wallet-custody-migration workstream.
+
+  External-wallet users on V2 (default since 2026-04-28 cutover)
+  hitting precision rejections on non-cent-aligned prices should
+  `pip install -U simmer-sdk` to pick up 0.12.3.
+
 ## [0.12.2] — 2026-04-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.12.2"
+version = "0.12.3"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2900,6 +2900,10 @@ class SimmerClient:
         fee_rate_bps = market_data.get("fee_rate_bps", 0)
 
         # Build and sign the order
+        # For V2 FAK/FOK BUY, pass the original USDC `amount` so the
+        # market-order builder rounds maker to 2 decimals on a value the
+        # caller asked for, not a derived size*price that may shave a cent.
+        amount_usdc = float(amount) if (not is_sell and amount > 0) else None
         if self._ows_wallet:
             signed = build_and_sign_order_ows(
                 ows_wallet=self._ows_wallet,
@@ -2926,6 +2930,7 @@ class SimmerClient:
                 tick_size=tick_size,
                 fee_rate_bps=fee_rate_bps,
                 order_type=order_type,
+                amount_usdc=amount_usdc,
             )
 
         return signed.to_dict()

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -145,6 +145,11 @@ def build_and_sign_order(
             this amount as maker (CLOB requires maker max 2 dec on FAK/FOK).
             If None, the V2 path derives it from `size * price`. Ignored
             for SELL (uses `size` as shares) and for GTC/GTD (uses `size`).
+            **OWS path scope:** `build_and_sign_order_ows` is still V1-only
+            and does not accept this kwarg. OWS BYOW users on V2-default
+            configs hit a different rejection (V1-shape order at V2 CLOB)
+            that this fix does not address; tracked separately in
+            `_dev/active/_wallet-custody-migration/`.
 
     Returns:
         SignedOrder ready for API submission. V1 or V2 shape based on

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -120,6 +120,7 @@ def build_and_sign_order(
     order_type: str = "FAK",  # "FAK", "FOK", "GTC", "GTD"
     builder_code: Optional[str] = None,
     metadata: Optional[str] = None,
+    amount_usdc: Optional[float] = None,
 ) -> SignedOrder:
     """
     Build and sign a Polymarket order.
@@ -139,6 +140,11 @@ def build_and_sign_order(
             `POLY_BUILDER_CODE` if None; defaults to zero bytes32 if unset.
             Mint yours at polymarket.com/settings?tab=builder.
         metadata: V2 only. bytes32 hex, default zero bytes32.
+        amount_usdc: V2 FAK/FOK BUY only. Original USDC dollar amount. If
+            provided, the V2 path routes through `build_market_order` with
+            this amount as maker (CLOB requires maker max 2 dec on FAK/FOK).
+            If None, the V2 path derives it from `size * price`. Ignored
+            for SELL (uses `size` as shares) and for GTC/GTD (uses `size`).
 
     Returns:
         SignedOrder ready for API submission. V1 or V2 shape based on
@@ -162,6 +168,7 @@ def build_and_sign_order(
             order_type=order_type,
             builder_code=builder_code,
             metadata=metadata,
+            amount_usdc=amount_usdc,
         )
     return _build_and_sign_order_v1(
         private_key=private_key,
@@ -306,17 +313,48 @@ def _build_and_sign_order_v2(
     order_type: str,
     builder_code: Optional[str],
     metadata: Optional[str],
+    amount_usdc: Optional[float] = None,
 ) -> SignedOrder:
-    """V2 signing path. Uses `py_clob_client_v2`'s ClobClient.create_order().
+    """V2 signing path. Uses `py_clob_client_v2.OrderBuilder` directly.
+
+    For FAK/FOK orders we route through ``build_market_order`` with
+    ``MarketOrderArgsV2`` (canonical pattern per Polymarket V2 docs):
+    BUY ``amount`` is USDC, SELL ``amount`` is shares. The library's
+    ``get_market_order_amounts`` rounds maker (USDC for BUY, shares for
+    SELL) down to ``round_config.size=2`` decimals, satisfying the
+    CLOB's "FAK/FOK maker max 2 decimals" rule for all tick sizes.
+
+    For GTC/GTD orders we use ``build_order`` with ``OrderArgsV2``,
+    where the library's ``get_order_amounts`` preserves full precision —
+    GTC/GTD must satisfy ``price × size = amount`` exactly, so we never
+    re-round.
+
+    Bypassing ``ClobClient.create_order/create_market_order`` avoids
+    network calls (`get_tick_size`, `get_version`, `get_clob_market_info`)
+    that the high-level helpers make on every order. We sign locally and
+    let `local_dev_server` route the signed order to CLOB.
 
     V2 drops taker/nonce/feeRateBps from the signed struct and adds
     timestamp/metadata/builder. The HTTP POST body keeps `expiration`
     at "0" (not part of signed hash). See docs.simmer.markets/v2-migration.
+
+    See ``_dev/active/_polymarket-rounding-precision/HISTORY.md`` for
+    the full rationale: V1 used post-hoc maker rounding, but V2's
+    ``OrderArgsV2`` path produces sub-cent maker on tick=0.01 BUYs at
+    most prices and on tick=0.001 BUYs at virtually all prices — the
+    canonical fix is the market-order builder, not post-hoc rounding.
     """
     import os
     try:
-        from py_clob_client_v2.client import ClobClient
-        from py_clob_client_v2.clob_types import OrderArgs, PartialCreateOrderOptions
+        from py_clob_client_v2.order_builder.builder import OrderBuilder, ROUNDING_CONFIG
+        from py_clob_client_v2.clob_types import (
+            OrderArgsV2,
+            MarketOrderArgsV2,
+            CreateOrderOptions,
+            OrderType,
+        )
+        from py_clob_client_v2.signer import Signer
+        from py_clob_client_v2.order_utils import SignatureTypeV2
     except ImportError:
         raise ImportError(
             "py_clob_client_v2 >= 1.0.0 is required for V2 local signing. "
@@ -337,6 +375,10 @@ def _build_and_sign_order_v2(
             f"Got {signature_type}. For Safe/Proxy wallets, use the "
             f"polynode SDK's relayer path or the Simmer dashboard Migrate flow."
         )
+    if order_type not in ("FAK", "FOK", "GTC", "GTD"):
+        raise ValueError(
+            f"Invalid order_type '{order_type}'. Must be FAK, FOK, GTC, or GTD."
+        )
 
     # Resolve builder_code: explicit arg > env > zero bytes32
     if builder_code is None:
@@ -349,38 +391,62 @@ def _build_and_sign_order_v2(
     # GTC/GTD expiration is a unix-seconds int; FAK/FOK use 0
     expiration_seconds = 0
 
-    clob_host = os.getenv("POLYMARKET_CLOB_HOST", "https://clob.polymarket.com")
-    client = ClobClient(
-        host=clob_host,
-        chain_id=POLYGON_CHAIN_ID,
-        key=private_key,
-        signature_type=0,
+    tick_size_str = str(tick_size)
+    if tick_size_str not in ROUNDING_CONFIG:
+        # Safe fallback to most common tick. Mirrors V1 behavior.
+        tick_size_str = "0.01"
+    options = CreateOrderOptions(tick_size=tick_size_str, neg_risk=neg_risk)
+
+    signer = Signer(private_key=private_key, chain_id=POLYGON_CHAIN_ID)
+    order_builder = OrderBuilder(
+        signer=signer,
+        signature_type=SignatureTypeV2.EOA,
         funder=wallet_address,
     )
 
-    tick_size_str = str(tick_size)
-    order_args = OrderArgs(
-        token_id=token_id,
-        price=price,
-        size=size,
-        side=side.upper(),
-        expiration=expiration_seconds,
-        builder_code=builder_code,
-        metadata=metadata,
-    )
-    options = PartialCreateOrderOptions(
-        tick_size=tick_size_str,
-        neg_risk=neg_risk,
-    )
-    signed = client.create_order(order_args, options)
+    is_market = order_type in ("FAK", "FOK")
+    if is_market:
+        # FAK/FOK: amount in USDC for BUY, shares for SELL.
+        # For BUY, prefer caller-provided USDC amount; fall back to size*price
+        # (lossy: round_down inside helper may shave a cent due to float drift).
+        if side == "BUY":
+            market_amount = (
+                float(amount_usdc) if amount_usdc is not None else float(size) * float(price)
+            )
+        else:
+            market_amount = float(size)
+        market_args = MarketOrderArgsV2(
+            token_id=token_id,
+            amount=market_amount,
+            side=side.upper(),
+            price=price,
+            order_type=getattr(OrderType, order_type),
+            builder_code=builder_code,
+            metadata=metadata,
+        )
+        signed = order_builder.build_market_order(market_args, options, version=2)
+    else:
+        # GTC/GTD: size in shares; library preserves price × size = amount.
+        order_args = OrderArgsV2(
+            token_id=token_id,
+            price=price,
+            size=size,
+            side=side.upper(),
+            expiration=expiration_seconds,
+            builder_code=builder_code,
+            metadata=metadata,
+        )
+        signed = order_builder.build_order(order_args, options, version=2)
+
     if hasattr(signed, "dict"):
         order_dict = signed.dict()
     elif hasattr(signed, "model_dump"):
         order_dict = signed.model_dump()
     else:
-        order_dict = {k: getattr(signed, k) for k in signed.__dataclass_fields__}
+        import dataclasses
+        order_dict = dataclasses.asdict(signed)
 
-    # Minimum order size check (after SDK-computed amounts)
+    # Minimum order size check (after library-computed amounts)
     maker_raw = int(order_dict["makerAmount"])
     taker_raw = int(order_dict["takerAmount"])
     shares_raw = taker_raw if side == "BUY" else maker_raw

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -296,13 +296,16 @@ def test_v2_fak_buy_tick_001_subcent_prices_round_to_cents():
 
 
 def test_v2_fak_sell_maker_is_2dec_shares():
-    """SELL FAK: maker=shares, must be 2-dec aligned (cents-of-share)."""
+    """SELL FAK: maker=shares, must be 2-dec aligned (cents-of-share).
+    Use an adversarial size with extra decimals to verify round_down kicks
+    in — 10.5 alone is already 2-dec aligned and trivially passes."""
     d = _v2_signed(
-        side="SELL", price=0.421, size=10.5,
-        tick_size=0.01, order_type="FAK",
+        side="SELL", price=0.421, size=10.555,
+        tick_size=0.001, order_type="FAK",
     )
     maker = int(d["makerAmount"])
-    assert maker == 10_500_000, f"expected 10.50 shares maker, got {maker / 1e6}"
+    # round_down(10.555, 2) = 10.55 → 10_550_000 raw
+    assert maker == 10_550_000, f"expected 10.55 shares maker, got {maker / 1e6}"
     assert maker % 10000 == 0
 
 

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -241,3 +241,89 @@ def test_signed_order_v2_shape_omits_v1_fields():
     assert "taker" not in d
     assert "nonce" not in d
     assert "feeRateBps" not in d
+
+
+# ==================== V2 maker-precision regression ====================
+# CLOB rejects FAK/FOK orders whose makerAmount has more than 2 decimals
+# (raw not divisible by 10000). For tick=0.001 BUYs and many tick=0.01
+# BUYs at non-cent-aligned prices, the OrderArgsV2/get_order_amounts path
+# produces sub-cent maker. Routing FAK/FOK through MarketOrderArgsV2/
+# build_market_order is the canonical pattern per Polymarket V2 docs.
+# See _dev/active/_polymarket-rounding-precision/HISTORY.md.
+
+_TEST_KEY = "0x" + "a" * 64
+_TEST_TOKEN = "71321045679252212594626385532706912750332728571942532289631379312455583992563"
+
+
+def _v2_signed(**kwargs):
+    """Build a V2-signed order with a throwaway key. V2 forced via env."""
+    _set_version("v2")
+    from simmer_sdk.signing import build_and_sign_order
+    return build_and_sign_order(
+        private_key=_TEST_KEY,
+        wallet_address="0x" + "11" * 20,
+        token_id=_TEST_TOKEN,
+        **kwargs,
+    ).to_dict()
+
+
+def test_v2_fak_buy_tick_0001_user_reported_case():
+    """User TG report: \\$6.00 BUY on tick=0.001 NO market produced
+    makerAmount=5.99767 → CLOB rejects (>2 dec). Fix routes through
+    create_market_order so maker is exactly the user's intended USDC."""
+    d = _v2_signed(
+        side="BUY", price=0.949, size=6.0 / 0.949,
+        tick_size=0.001, order_type="FAK", amount_usdc=6.0,
+    )
+    maker = int(d["makerAmount"])
+    assert maker == 6_000_000, f"expected $6.00 maker, got {maker / 1e6}"
+    assert maker % 10000 == 0, "maker must be 2-dec aligned for FAK/FOK"
+
+
+def test_v2_fak_buy_tick_001_subcent_prices_round_to_cents():
+    """Pre-fix, ~80% of FAK BUYs at non-cent prices produced sub-cent
+    makerAmount on tick=0.01. Spot-check the worst offenders."""
+    for amount, price in [(5, 0.47), (6, 0.19), (10, 0.33), (25, 0.89), (100, 0.68)]:
+        d = _v2_signed(
+            side="BUY", price=price, size=amount / price,
+            tick_size=0.01, order_type="FAK", amount_usdc=float(amount),
+        )
+        maker = int(d["makerAmount"])
+        assert maker == amount * 1_000_000, (
+            f"amount=${amount} price={price}: expected {amount * 1_000_000} maker, got {maker}"
+        )
+        assert maker % 10000 == 0
+
+
+def test_v2_fak_sell_maker_is_2dec_shares():
+    """SELL FAK: maker=shares, must be 2-dec aligned (cents-of-share)."""
+    d = _v2_signed(
+        side="SELL", price=0.421, size=10.5,
+        tick_size=0.01, order_type="FAK",
+    )
+    maker = int(d["makerAmount"])
+    assert maker == 10_500_000, f"expected 10.50 shares maker, got {maker / 1e6}"
+    assert maker % 10000 == 0
+
+
+def test_v2_gtc_preserves_full_precision():
+    """GTC must NOT post-round maker — CLOB validates maker = price × size
+    exactly. Per HISTORY.md, that was the regression in attempts 1-4."""
+    d = _v2_signed(
+        side="BUY", price=0.421, size=5.68,
+        tick_size=0.001, order_type="GTC",
+    )
+    maker = int(d["makerAmount"])
+    taker = int(d["takerAmount"])
+    # tick=0.001 keeps price.421 at 3 dec, so maker = 5.68 × 0.421 = 2.39128
+    assert maker == 2_391_280
+    assert taker == 5_680_000
+
+
+def test_v2_invalid_order_type_rejected():
+    import pytest
+    with pytest.raises(ValueError, match="Invalid order_type"):
+        _v2_signed(
+            side="BUY", price=0.5, size=10,
+            tick_size=0.01, order_type="GIBBERISH",
+        )


### PR DESCRIPTION
## Summary

- **Pro user TG report**: simmer-sdk 0.12.2 \`client.trade()\` produces \`makerAmount=5.99767\` on a \$6.00 BUY of a \`tick_size=0.001\` NO market — Polymarket CLOB rejects with "max accuracy of 2 decimals".
- **Root cause**: \`_build_and_sign_order_v2\` used \`OrderArgsV2\` (limit-order shape) for ALL order types. For FAK/FOK BUY, \`get_order_amounts\` produces up to \`RoundConfig.amount\` decimal maker (5 on tick=0.001, 4 on tick=0.01) but CLOB enforces FAK/FOK maker max 2 decimals.
- **Fix**: route FAK/FOK through \`MarketOrderArgsV2\` → \`OrderBuilder.build_market_order\` per Polymarket's canonical V2 docs (verified via context7 \`/polymarket/py-clob-client-v2\` README). \`get_market_order_amounts\` does \`round_down(amount, 2)\` on maker by construction, satisfying the CLOB rule across all tick sizes. GTC/GTD continue using \`OrderArgsV2\` → \`build_order\` (preserves price × size = maker exactly, which CLOB validates for limit orders).
- **Bypasses \`ClobClient.create_order\`** entirely — eliminates 2-3 unnecessary network calls per signing op.
- **API change**: \`build_and_sign_order\` gains optional \`amount_usdc: Optional[float]\` kwarg. Backwards-compatible.

## Audit (Railway + Supabase \`real_trades\`, ~42h since cutover)

| Slice | Count |
|---|---|
| V2 SDK precision rejections (this bug, verbatim CLOB error) | **46** across 5 wallets |
| Pre-0.12.2 V1-shape rejections (server guard masks the precision bug for old SDKs) | 144 |
| V2 SDK fills + partials | 389 |

Most users on V2 are getting through; the precision bug specifically hits **0.12.2+ users at non-cent-aligned prices** (very common on tick=0.001 markets, common-ish on tick=0.01). Two adjacent SDK bugs surfaced in the audit (price-not-rounded-to-tick, wrong-tick_size-sent-to-CLOB) — out of scope here, will file separately.

## Verification

- 121/121 unit tests pass (5 new regression tests pinned to the user's exact case + adversarial inputs)
- Offline stress: 200/200 random FAK BUYs across tick=0.01 and tick=0.001 produce 2-dec aligned maker. Pre-fix: 0/100 on tick=0.001, ~18/100 on tick=0.01.
- User's exact case (\$6 BUY @ 0.949 tick=0.001): maker now \`6_000_000\` (\$6.00), was \`5_997_680\` (\$5.99768).
- Independent code review (PASS gate cleared, both flagged items addressed in fdb26a2).
- Live test against staging deferred — V2 throwaway wallet's API key has a different wallet linked with open positions blocking re-link. Audit + reviewer + offline stress + canonical-pattern alignment carries the verification weight.

See \`_dev/active/_polymarket-rounding-precision/HISTORY.md\` (simmer repo) "Apr 30, 2026" entry for the 8-prior-attempts context and why the fix invariants are correct.

## Test plan
- [x] Unit tests pass (\`pytest tests/\` 121/121)
- [x] Stress repro across tick sizes (200/200 cent-aligned)
- [x] Independent code review PASS
- [ ] Post-merge: PyPI publish (\`pip install -U simmer-sdk\`)
- [ ] Post-release: re-run audit query (in PR body comment) at +24h to confirm zero new precision rejections from 0.12.3 users

## Post-release monitoring

Re-run after 24h:

\`\`\`sql
SELECT COUNT(*), COUNT(DISTINCT wallet_address), MAX(created_at)
FROM real_trades
WHERE venue='polymarket' AND exchange_version='v2' AND status='failed'
  AND source LIKE 'sdk:%'
  AND created_at >= '2026-04-30 04:00:00+00'
  AND (raw_response::text ILIKE '%max accuracy%'
       OR raw_response::text ILIKE '%invalid amounts%');
\`\`\`

Expected: 0 (or only stragglers from users who haven't \`pip install -U\` yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)