### PR TITLE
docs(sdk): disambiguate `amount` currency per venue (SIM-1254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.4] — 2026-04-30
+
+### Docs
+
+- **`amount` parameter currency disambiguation across SDK docstrings.**
+  Per CLAUDE.md currency-formatting rule (`$SIM` for sim venue, `USDC`
+  for real venues), the `amount` parameter docstrings on `client.trade()`
+  and the internal Polymarket/Kalshi execution methods previously read
+  `Dollar amount to spend`, which is ambiguous for `venue='sim'`. Updated:
+
+  - `client.trade(amount=...)` (top-level): now `Amount to spend (for buys)
+    — USDC for polymarket/kalshi, $SIM for sim`
+  - `prepare_polymarket_order(amount=...)`: now `USDC amount to spend`
+    (Polymarket-only path)
+  - `_build_signed_order(amount=...)`: now `USDC amount (for buys)`
+    (Polymarket-only path)
+  - `_execute_kalshi_byow_trade(amount=...)`: now `USDC amount (for buys)`
+    (Kalshi-only path)
+
+  Behavior is unchanged. Follow-up to SIM-1252.
+
 ## [0.12.3] — 2026-04-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.12.3"
+version = "0.12.4"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -927,7 +927,7 @@ class SimmerClient:
         Args:
             market_id: Market ID to trade on
             side: 'yes' or 'no'
-            amount: Dollar amount to spend (for buys)
+            amount: Amount to spend (for buys) — USDC for polymarket/kalshi, $SIM for sim
             shares: Number of shares to sell (for sells)
             action: 'buy' or 'sell' (default: 'buy')
             venue: Override client's default venue for this trade.
@@ -1381,7 +1381,7 @@ class SimmerClient:
         Args:
             market_id: Market ID to trade on (must be a Polymarket market)
             side: 'yes' or 'no'
-            amount: Dollar amount to spend
+            amount: USDC amount to spend
 
         Returns:
             RealTradeResult with order_params for CLOB submission
@@ -2833,7 +2833,7 @@ class SimmerClient:
         Args:
             market_id: Market to trade on
             side: 'yes' or 'no'
-            amount: Dollar amount (for buys)
+            amount: USDC amount (for buys)
             shares: Number of shares (for sells)
             action: 'buy' or 'sell'
             order_type: Order type ('FAK', 'GTC', etc.)
@@ -2959,7 +2959,7 @@ class SimmerClient:
         Args:
             market_id: Market ID to trade on
             side: 'yes' or 'no'
-            amount: Dollar amount (for buys)
+            amount: USDC amount (for buys)
             shares: Number of shares (for sells)
             action: 'buy' or 'sell'
             reasoning: Optional trade explanation


### PR DESCRIPTION
## Summary

- Updates 4 `amount` docstring sites in `simmer_sdk/client.py` to disambiguate USDC (polymarket/kalshi) vs $SIM (sim venue) per CLAUDE.md currency-formatting rule
- Bumps to 0.12.4 (patch, docs-only)
- CHANGELOG entry under `[0.12.4]`

Behavior unchanged — pure docstring clarification. Follow-up to SIM-1251 ($SIM `amount` overshoot fix); the prior fix exposed that the docstrings still said "Dollar amount" which is misleading for the sim venue.

## Sites updated

- `:930` `client.trade()` (top-level): `Amount to spend (for buys) — USDC for polymarket/kalshi, $SIM for sim`
- `:1384` `prepare_polymarket_order()`: `USDC amount to spend` (Polymarket-only)
- `:2836` `_build_signed_order()`: `USDC amount (for buys)` (Polymarket-only)
- `:2962` `_execute_kalshi_byow_trade()`: `USDC amount (for buys)` (Kalshi-only)

## Test plan

- [x] No code changes — docstrings only
- [x] CHANGELOG entry added
- [x] Version bump in `pyproject.toml` (0.12.3 → 0.12.4)
- [ ] PyPI publish (after merge — needs Adrian)

Closes SIM-1252, SIM-1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)