### PR TITLE
feat(sdk): SimmerClient.from_env() + with_ows_wallet() (0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] — 2026-05-01
+
+### Added
+
+- **`SimmerClient.from_env()` and `SimmerClient.with_ows_wallet()`
+  classmethods.** Two ergonomic constructors so callers never have to read
+  `os.environ` directly.
+
+  ```python
+  from simmer_sdk import SimmerClient
+
+  # Reads SIMMER_API_KEY from env. Auto-detects WALLET_PRIVATE_KEY (external
+  # EVM wallet) and OWS_WALLET (OWS-managed wallet) via the regular __init__
+  # path. Raises RuntimeError with a dashboard pointer if SIMMER_API_KEY is
+  # unset.
+  client = SimmerClient.from_env()
+
+  # Explicit OWS routing — pass the wallet name directly. api_key falls back
+  # to SIMMER_API_KEY env when None.
+  client = SimmerClient.with_ows_wallet("my-agent-wallet")
+  client = SimmerClient.with_ows_wallet("my-agent-wallet", api_key="sk_live_...")
+  ```
+
+  Both methods forward extra kwargs (`venue`, `base_url`, `live`, etc.) to
+  the regular constructor, so any existing usage pattern is reachable
+  without going through `__init__` directly.
+
+  This is sugar over the existing `SimmerClient(api_key=..., ...)`
+  constructor — no change in client behavior, just a cleaner construction
+  surface for skill bundles and bots that want to keep `import os` out of
+  their entrypoints.
+
 ## [0.12.3] — 2026-04-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.12.3"
+version = "0.13.0"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -382,6 +382,92 @@ class SimmerClient:
     def __repr__(self):
         return f"SimmerClient(venue={self.venue!r}, base_url={self.base_url!r})"
 
+    @classmethod
+    def from_env(cls, **kwargs) -> "SimmerClient":
+        """Construct a client by reading SIMMER_API_KEY from the environment.
+
+        The standard `__init__` path already auto-detects ``WALLET_PRIVATE_KEY``
+        (external EVM wallet) and ``OWS_WALLET`` (OWS-managed wallet) when set,
+        so this classmethod only needs to surface ``SIMMER_API_KEY`` itself.
+        Calling code never has to touch ``os.environ`` directly — useful for
+        skill bundles where direct env reads trip surface-area scanners.
+
+        Args:
+            **kwargs: Optional keyword arguments forwarded to ``__init__``
+                (e.g. ``venue``, ``base_url``, ``live``, ``starting_balance``).
+                Do not pass ``api_key`` here — use the regular constructor if
+                you want to override the env var.
+
+        Returns:
+            A configured ``SimmerClient`` instance.
+
+        Raises:
+            RuntimeError: If ``SIMMER_API_KEY`` is unset or empty.
+
+        Example:
+            >>> # Sim trading (default)
+            >>> client = SimmerClient.from_env()
+            >>>
+            >>> # Polymarket with auto-detected WALLET_PRIVATE_KEY
+            >>> client = SimmerClient.from_env(venue="polymarket")
+        """
+        api_key = os.environ.get("SIMMER_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "SIMMER_API_KEY environment variable is not set. "
+                "Get an API key at simmer.markets/dashboard → SDK tab, "
+                "then export SIMMER_API_KEY=sk_live_... in your environment."
+            )
+        return cls(api_key=api_key, **kwargs)
+
+    @classmethod
+    def with_ows_wallet(
+        cls,
+        name: str,
+        *,
+        api_key: Optional[str] = None,
+        **kwargs,
+    ) -> "SimmerClient":
+        """Construct a client routed through an OWS-managed wallet.
+
+        OWS (Open Wallet Standard) keeps the private key in a vault — orders
+        are signed by the OWS daemon, never by the SDK. The wallet ``name`` is
+        passed explicitly here so callers don't have to read ``OWS_WALLET``
+        from the environment themselves.
+
+        Args:
+            name: OWS wallet name (e.g. ``"my-agent-wallet"``). Created via
+                ``ows wallet create --name <name>``.
+            api_key: Simmer SDK API key (``sk_live_...``). If ``None``, falls
+                back to ``SIMMER_API_KEY`` from the environment.
+            **kwargs: Optional keyword arguments forwarded to ``__init__``
+                (e.g. ``venue``, ``base_url``, ``live``). Do not pass
+                ``ows_wallet`` here — it is set from ``name``.
+
+        Returns:
+            A configured ``SimmerClient`` instance with ``ows_wallet=name``.
+
+        Raises:
+            RuntimeError: If ``api_key`` is None and ``SIMMER_API_KEY`` is
+                unset or empty.
+
+        Example:
+            >>> client = SimmerClient.with_ows_wallet("my-agent")
+            >>> # Or with explicit api_key:
+            >>> client = SimmerClient.with_ows_wallet(
+            ...     "my-agent", api_key="sk_live_...", venue="polymarket"
+            ... )
+        """
+        if api_key is None:
+            api_key = os.environ.get("SIMMER_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "No api_key provided and SIMMER_API_KEY environment variable "
+                "is not set. Get an API key at simmer.markets/dashboard → SDK "
+                "tab, then either pass api_key=... or export SIMMER_API_KEY."
+            )
+        return cls(api_key=api_key, ows_wallet=name, **kwargs)
+
     def _validate_and_set_wallet(self, private_key: str) -> None:
         """Validate private key format and derive wallet address."""
         if not private_key.startswith("0x"):

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -1,0 +1,148 @@
+"""Tests for SimmerClient.from_env() and SimmerClient.with_ows_wallet().
+
+These ergonomic classmethods let skill bundles construct clients without any
+direct os.environ reads — the Hermes regex scanner flags those as HIGH
+severity (tools/skills_guard.py:130) and the LLM scanner treats them as
+suspicious surface area.
+"""
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+# ---------------------------------------------------------------------------
+# from_env()
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_happy_path_all_three_vars(monkeypatch):
+    """from_env() picks up SIMMER_API_KEY and the constructor auto-detects the rest."""
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_live_test_abc")
+    monkeypatch.setenv(
+        "WALLET_PRIVATE_KEY",
+        "0x" + "a" * 64,  # 66-char EVM key (will fail validation if eth_account checks signature)
+    )
+    monkeypatch.setenv("OWS_WALLET", "test-wallet")
+
+    # OWS takes priority over WALLET_PRIVATE_KEY (per __init__ docstring), so
+    # the client will try to import ows_utils. We can't easily install OWS
+    # in the test env, but the ImportError path sets _ows_wallet to None and
+    # falls through. That's fine for this test — we just want to confirm
+    # from_env() reads the api_key correctly.
+    client = SimmerClient.from_env()
+
+    assert client.api_key == "sk_live_test_abc"
+    assert client.venue == "sim"  # default
+
+
+def test_from_env_only_api_key(monkeypatch):
+    """from_env() works with just SIMMER_API_KEY set; no wallet env vars required."""
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_live_test_xyz")
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("SIMMER_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+
+    client = SimmerClient.from_env()
+
+    assert client.api_key == "sk_live_test_xyz"
+    assert client._private_key is None
+    assert client._ows_wallet is None
+
+
+def test_from_env_raises_when_api_key_missing(monkeypatch):
+    """from_env() raises RuntimeError with a dashboard pointer when SIMMER_API_KEY is unset."""
+    monkeypatch.delenv("SIMMER_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="SIMMER_API_KEY"):
+        SimmerClient.from_env()
+
+
+def test_from_env_raises_when_api_key_empty(monkeypatch):
+    """from_env() treats empty-string SIMMER_API_KEY as missing."""
+    monkeypatch.setenv("SIMMER_API_KEY", "")
+
+    with pytest.raises(RuntimeError, match="SIMMER_API_KEY"):
+        SimmerClient.from_env()
+
+
+def test_from_env_forwards_kwargs(monkeypatch):
+    """from_env() forwards extra kwargs (venue, base_url, etc.) to __init__."""
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_live_test")
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+
+    client = SimmerClient.from_env(venue="kalshi", base_url="https://example.test")
+
+    assert client.venue == "kalshi"
+    assert client.base_url == "https://example.test"
+
+
+# ---------------------------------------------------------------------------
+# with_ows_wallet()
+# ---------------------------------------------------------------------------
+
+
+def test_with_ows_wallet_explicit_api_key(monkeypatch):
+    """with_ows_wallet() uses the explicit api_key parameter when provided."""
+    # Even if SIMMER_API_KEY is set in env, explicit param wins.
+    monkeypatch.setenv("SIMMER_API_KEY", "env_key")
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+
+    # OWS import will likely fail in test env → _ows_wallet falls back to None,
+    # but the api_key wiring is what we're testing here.
+    client = SimmerClient.with_ows_wallet("my-agent", api_key="explicit_key")
+
+    assert client.api_key == "explicit_key"
+
+
+def test_with_ows_wallet_env_fallback_api_key(monkeypatch):
+    """with_ows_wallet() falls back to SIMMER_API_KEY when api_key is None."""
+    monkeypatch.setenv("SIMMER_API_KEY", "fallback_key")
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+
+    client = SimmerClient.with_ows_wallet("my-agent")
+
+    assert client.api_key == "fallback_key"
+
+
+def test_with_ows_wallet_raises_when_api_key_missing(monkeypatch):
+    """with_ows_wallet() raises RuntimeError when neither param nor env provides an api_key."""
+    monkeypatch.delenv("SIMMER_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="SIMMER_API_KEY"):
+        SimmerClient.with_ows_wallet("my-agent")
+
+
+def test_with_ows_wallet_raises_when_api_key_empty(monkeypatch):
+    """with_ows_wallet() treats empty-string api_key arg as missing and falls back to env, then errors."""
+    monkeypatch.delenv("SIMMER_API_KEY", raising=False)
+
+    # api_key="" is falsy, but the function only falls back to env when
+    # api_key IS None (not just falsy). Empty string passed explicitly should
+    # still reach the constructor — but the constructor doesn't validate
+    # api_key emptiness, so this test asserts the env-fallback only kicks in
+    # for None. Confirm the empty-env case raises.
+    monkeypatch.setenv("SIMMER_API_KEY", "")
+    with pytest.raises(RuntimeError, match="SIMMER_API_KEY"):
+        SimmerClient.with_ows_wallet("my-agent")
+
+
+def test_with_ows_wallet_forwards_kwargs(monkeypatch):
+    """with_ows_wallet() forwards extra kwargs to __init__."""
+    monkeypatch.setenv("SIMMER_API_KEY", "k")
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+
+    client = SimmerClient.with_ows_wallet(
+        "my-agent",
+        venue="polymarket",
+        base_url="https://example.test",
+        live=False,  # avoid risk-alert network call
+    )
+
+    assert client.venue == "polymarket"
+    assert client.base_url == "https://example.test"
+    assert client.live is False


### PR DESCRIPTION
## Summary

Adds two ergonomic classmethods to `SimmerClient`:

- `SimmerClient.from_env()` — reads `SIMMER_API_KEY` from env; constructor auto-detects `WALLET_PRIVATE_KEY` and `OWS_WALLET` via existing logic. Raises `RuntimeError` with a dashboard pointer if `SIMMER_API_KEY` is unset.
- `SimmerClient.with_ows_wallet(name, *, api_key=None)` — explicit OWS routing. `api_key` falls back to `SIMMER_API_KEY` env when `None`.

Both methods forward extra kwargs (`venue`, `base_url`, `live`, etc.) to the regular constructor.

## Why

This is the structural blocker for Phase 3 (bulk Tier B slim) of the skill catalog reshape workstream. Tier B strategy skills currently have entrypoint files with many `os.environ` reads, which the Hermes regex scanner (`tools/skills_guard.py:130`) flags HIGH severity. With these helpers, skill bundles refactor to:

```python
# Before
client = SimmerClient(
    api_key=os.environ["SIMMER_API_KEY"],
    ows_wallet=os.environ.get("OWS_WALLET"),
    private_key=os.environ.get("WALLET_PRIVATE_KEY"),
)

# After
client = SimmerClient.from_env()
# Or for explicit OWS:
client = SimmerClient.with_ows_wallet("my-agent")
```

No direct `os.environ` reads in the skill bundle.

## Changes

- `simmer_sdk/client.py` — two classmethods after `__repr__`, ~85 lines including docstrings.
- `tests/test_client_constructors.py` — 10 unit tests covering happy paths, env fallback, missing/empty api_key, kwarg forwarding.
- `CHANGELOG.md` — `0.13.0` entry.
- `pyproject.toml` — version bump `0.12.3` → `0.13.0`.

## Test plan

- [x] `pytest tests/test_client_constructors.py` — 10/10 pass
- [x] `pytest tests/ --ignore=tests/test_polymarket_v2.py` — 115 pass, 10 skipped (no regressions; v2 file requires `py-clob-client-v2` which isn't installed locally — unrelated)
- [x] Manual: `git diff --stat origin/main..HEAD` shows only the 4 intentional files
- [ ] CI runs full v2 suite

Closes SIM-1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)