### PR TITLE
feat: proxy-derive CLOB credentials when local /auth/api-key is blocked (0.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] — 2026-05-01
+
+### Fixed
+
+- **CLOB credential derivation falls back to the Simmer relay when
+  Polymarket's `/auth/api-key` route is Cloudflare-blocked from the
+  user's IP** (commonly residential AU / SE Asia ranges). Previously,
+  external-wallet users on blocked networks would land at
+  `has_credentials=false` with no recovery path — the SDK would log a
+  warning and trades would fail with `Missing Polymarket API
+  credentials`.
+
+  The new flow: `_ensure_clob_credentials()` first attempts the local
+  derive (`py_clob_client.create_or_derive_api_creds()` for raw-key,
+  `ows_derive_clob_creds()` for OWS). If that raises (network error,
+  HTTP 403, etc.), the SDK falls through to a new private method
+  `_derive_creds_via_proxy()`. It builds the L1 auth headers locally —
+  the user's private key never leaves their machine — and POSTs only
+  those headers to a new Simmer endpoint
+  (`POST /api/sdk/wallet/credentials/derive-via-proxy`), which forwards
+  to Polymarket from a non-blocked IP and stores the resulting creds.
+
+  No user action required; the fallback is transparent on first trade.
+
+- **`client.link_wallet()` now derives + registers CLOB credentials
+  after a successful link.** Before, calling `link_wallet()` on a
+  user whose wallet had been migrated managed→external left the user
+  in a state where `linked_wallet_address` was set but
+  `polymarket_api_creds_encrypted` was null — the next trade would
+  fail with `Missing Polymarket API credentials` and re-running
+  `link_wallet()` would short-circuit on "already linked" without
+  fixing it. The link flow now resets `_clob_creds_registered` and
+  calls `_ensure_clob_credentials()` (which goes through the new
+  proxy fallback if the direct derive is CF-blocked).
+
 ## [0.13.1] — 2026-05-01
 
 ### Docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.13.1"
+version = "0.13.2"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3275,7 +3275,14 @@ class SimmerClient:
                 - 2: Gnosis Safe
 
         Returns:
-            Dict with success status and wallet info
+            Dict with success status and wallet info. When `success` is True,
+            the dict additionally contains:
+              - `clob_credentials_registered` (bool): whether Polymarket CLOB
+                API credentials were derived and stored after the link. False
+                means trading will fail until creds are derived (the SDK
+                retries on the next `trade()` call automatically).
+              - `clob_credentials_error` (str, optional): the underlying
+                exception message when `clob_credentials_registered` is False.
 
         Raises:
             ValueError: If no private_key is configured
@@ -3289,6 +3296,8 @@ class SimmerClient:
             result = client.link_wallet()
             if result["success"]:
                 print(f"Linked wallet: {result['wallet_address']}")
+                if not result.get("clob_credentials_registered", True):
+                    print(f"Note: creds will derive on first trade")
         """
         if not (self._ows_wallet or self._private_key) or not self._wallet_address:
             raise ValueError(
@@ -3346,6 +3355,14 @@ class SimmerClient:
         # polymarket_api_creds_encrypted, so the post-migration first link
         # needs a fresh derive — without this, link_wallet() returning success
         # leaves the user with has_credentials=false and trades will fail.
+        #
+        # The link itself either succeeded or it didn't — that's what
+        # `result["success"]` reports. Credential registration is a separate
+        # concern: it can fail independently (network, CF block on local
+        # derive AND on proxy fallback) without invalidating the wallet link.
+        # We surface the credential state in two extra fields so direct
+        # callers of link_wallet() can tell which step failed; we don't
+        # raise, because that would obscure a successful link.
         if result.get("success"):
             self._wallet_linked = True
             # Force re-derive even if a stale flag from earlier in this session
@@ -3353,11 +3370,15 @@ class SimmerClient:
             self._clob_creds_registered = False
             try:
                 self._ensure_clob_credentials()
+                result["clob_credentials_registered"] = True
             except Exception as e:
+                result["clob_credentials_registered"] = False
+                result["clob_credentials_error"] = str(e)
                 logger.warning(
                     "Wallet linked, but CLOB credential registration failed: %s. "
-                    "Trades may fail until credentials are derived. "
-                    "Try `client.trade(...)` once to retry derivation.",
+                    "Trades will fail until credentials are derived. "
+                    "Inspect `result['clob_credentials_error']` or retry by calling "
+                    "`client.trade(...)`, which re-attempts derivation.",
                     e
                 )
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -755,28 +755,36 @@ class SimmerClient:
         if self._wallet_linked is True:
             return
 
-        # Check if wallet is already linked via API
+        # Check if wallet is already linked via API. The link-status check and
+        # the credential-derivation call are kept in separate try blocks so a
+        # credential failure (which now propagates from _ensure_clob_credentials
+        # rather than being silently swallowed) doesn't fall through to the
+        # auto-link path. link_wallet() also calls _ensure_clob_credentials at
+        # the end, so re-linking would just re-attempt the same derive.
+        already_linked = False
         try:
             settings = self._request("GET", "/api/sdk/settings")
             linked_address = settings.get("linked_wallet_address") or settings.get("wallet_address")
-
             if linked_address and linked_address.lower() == self._wallet_address.lower():
-                self._wallet_linked = True
-                logger.debug("Wallet %s already linked", self._wallet_address[:10] + "...")
-                self._ensure_clob_credentials()
-                return
+                already_linked = True
         except Exception as e:
             logger.debug("Could not check wallet link status: %s", e)
 
-        # Wallet not linked - attempt to link automatically
+        if already_linked:
+            self._wallet_linked = True
+            logger.debug("Wallet %s already linked", self._wallet_address[:10] + "...")
+            self._ensure_clob_credentials()
+            return
+
+        # Wallet not linked - attempt to link automatically. link_wallet()
+        # calls _ensure_clob_credentials() internally on success, so don't
+        # call it again here.
         print(f"Auto-linking wallet {self._wallet_address[:10]}... to Simmer account...")
         try:
             result = self.link_wallet(signature_type=0)
             if result.get("success"):
                 self._wallet_linked = True
                 print("Wallet linked successfully")
-                # Derive and register CLOB credentials right after linking
-                self._ensure_clob_credentials()
             else:
                 error = result.get("error") or result.get("message") or f"Server returned: {result}"
                 print(f"ERROR: Wallet linking failed: {error}")
@@ -820,42 +828,97 @@ class SimmerClient:
         except Exception as e:
             logger.debug("Credentials check failed unexpectedly: %s — will attempt registration", e)
 
+        # Phase 1: derive creds locally against Polymarket. This can fail when
+        # Polymarket's /auth/api-key route is Cloudflare-blocked from the
+        # user's IP (commonly residential AU, SE Asia, etc.). On failure here
+        # we fall through to phase 2 (proxy derive). Phase 1 and the backend
+        # registration call (phase 1b) are kept in separate try-blocks so a
+        # registration failure does NOT silently fall through to the proxy
+        # path — that would mask a server-side bug as a CF block.
+        creds = None
         try:
             if self._ows_wallet:
-                # OWS path: derive creds directly from Polymarket CLOB
-                # Key never leaves the vault
                 from simmer_sdk.ows_utils import ows_derive_clob_creds
                 creds = ows_derive_clob_creds(self._ows_wallet)
             else:
-                # Raw key path: use py_clob_client
                 from py_clob_client.client import ClobClient
-
                 client = ClobClient(
                     host="https://clob.polymarket.com",
                     key=self._private_key,
                     chain_id=137,
                     signature_type=0,  # EOA
-                    funder=self._wallet_address
+                    funder=self._wallet_address,
                 )
                 creds = client.create_or_derive_api_creds()
+        except ImportError as e:
+            raise RuntimeError(
+                f"Cannot derive CLOB credentials: {e}. "
+                "Install with: pip install py-clob-client"
+            ) from e
+        except Exception as local_derive_err:
+            logger.info(
+                "Local CLOB credential derivation failed (%s); falling back to proxy derive",
+                local_derive_err,
+            )
+            try:
+                self._derive_creds_via_proxy()
+                return
+            except Exception as proxy_err:
+                raise RuntimeError(
+                    f"Failed to derive CLOB credentials (local: {local_derive_err}; proxy: {proxy_err})"
+                ) from proxy_err
 
-            # Register with backend
+        # Phase 1b: register the locally-derived creds with the Simmer backend.
+        try:
             self._request("POST", "/api/sdk/wallet/credentials", json={
                 "api_key": creds.api_key,
                 "api_secret": creds.api_secret,
-                "api_passphrase": creds.api_passphrase
+                "api_passphrase": creds.api_passphrase,
             })
+        except Exception as register_err:
+            raise RuntimeError(
+                f"Locally derived CLOB credentials but failed to register with Simmer backend: {register_err}"
+            ) from register_err
 
-            self._clob_creds_registered = True
-            logger.info("CLOB credentials registered for wallet %s", self._wallet_address[:10] + "...")
+        self._clob_creds_registered = True
+        logger.info("CLOB credentials registered for wallet %s", self._wallet_address[:10] + "...")
 
-        except ImportError as e:
-            logger.warning(
-                "Cannot derive CLOB credentials: %s. "
-                "Install with: pip install py-clob-client", e
-            )
-        except Exception as e:
-            logger.warning("Failed to derive/register CLOB credentials: %s", e)
+    def _derive_creds_via_proxy(self) -> None:
+        """
+        Derive CLOB credentials by forwarding locally-signed L1 headers
+        through the Simmer backend.
+
+        Used when the direct call to Polymarket's /auth/api-key fails for
+        reasons unrelated to the signature itself — most commonly a Cloudflare
+        block on residential IPs. The user's private key never leaves their
+        machine: we build the L1 auth headers locally (signature is a one-time
+        challenge bound to a timestamp + nonce, not a transaction) and POST
+        only those headers to the backend, which forwards them to Polymarket
+        from Railway and stores the resulting creds.
+        """
+        if self._ows_wallet:
+            from simmer_sdk.ows_utils import _clob_level_1_headers, get_ows_wallet_address
+            address = get_ows_wallet_address(self._ows_wallet)
+            headers = _clob_level_1_headers(self._ows_wallet, address, nonce=0)
+        else:
+            from py_clob_client.signer import Signer
+            from py_clob_client.headers.headers import create_level_1_headers
+            signer = Signer(key=self._private_key, chain_id=137)
+            headers = create_level_1_headers(signer, nonce=0)
+
+        body = {
+            "poly_address": headers["POLY_ADDRESS"],
+            "poly_signature": headers["POLY_SIGNATURE"],
+            "poly_timestamp": headers["POLY_TIMESTAMP"],
+            "poly_nonce": headers["POLY_NONCE"],
+        }
+
+        self._request("POST", "/api/sdk/wallet/credentials/derive-via-proxy", json=body)
+        self._clob_creds_registered = True
+        logger.info(
+            "CLOB credentials derived via proxy and registered for wallet %s",
+            self._wallet_address[:10] + "..."
+        )
 
     def _warn_approvals_once(self) -> None:
         """
@@ -3277,6 +3340,26 @@ class SimmerClient:
                 "signature_type": signature_type
             }
         )
+
+        # After link (or re-link reporting "already linked"), ensure CLOB creds
+        # are registered. Server-side managed→external migration nulls
+        # polymarket_api_creds_encrypted, so the post-migration first link
+        # needs a fresh derive — without this, link_wallet() returning success
+        # leaves the user with has_credentials=false and trades will fail.
+        if result.get("success"):
+            self._wallet_linked = True
+            # Force re-derive even if a stale flag from earlier in this session
+            # would short-circuit the check.
+            self._clob_creds_registered = False
+            try:
+                self._ensure_clob_credentials()
+            except Exception as e:
+                logger.warning(
+                    "Wallet linked, but CLOB credential registration failed: %s. "
+                    "Trades may fail until credentials are derived. "
+                    "Try `client.trade(...)` once to retry derivation.",
+                    e
+                )
 
         return result
 


### PR DESCRIPTION
## Summary

External-wallet users on residential / Cloudflare-blocked IPs (commonly AU / SE Asia) couldn't register Polymarket CLOB credentials — the SDK's local call to `POST /auth/api-key` would CF-403, the SDK swallowed the warning, and every trade returned `Missing Polymarket API credentials` indefinitely.

Three fixes:

1. `_ensure_clob_credentials()` falls through to a new private method `_derive_creds_via_proxy()` when the local derive fails. The helper builds L1 auth headers locally with the user's key (key never leaves their machine) and POSTs only the headers to Simmer's new `POST /api/sdk/wallet/credentials/derive-via-proxy`, which forwards to Polymarket from a non-blocked IP and stores the resulting creds.
2. `link_wallet()` now resets `_clob_creds_registered` and calls `_ensure_clob_credentials()` after a successful link or "already linked" response. Previously, post-migration users (managed→external null'd their creds) had no way to re-derive.
3. `link_wallet()` surfaces credential-derive state in two new result fields (`clob_credentials_registered`, `clob_credentials_error`) so direct callers can tell the difference between "link failed" and "link succeeded but creds didn't".

## Backend dependency

[simmer #408](https://github.com/SupaFund/simmer/pull/408) — must merge + deploy first. The new endpoint is what `_derive_creds_via_proxy()` posts to.

## Codex review history

- Round 1 → FAIL: silent proxy-failure swallow, single broad try around derive + registration, double `_ensure_clob_credentials()` call.
- Round 2 → FAIL on one finding: `link_wallet()` returning `success=True` without surfacing credential-derive state to callers.
- Round 3 → expected to pass once the verdict lands.

## Reported by

Charles Wong (TG support, 2026-05-01), wallet `0x5a72…`.

## Test plan

- [ ] User on a non-blocked network → local derive succeeds, no proxy call.
- [ ] User on a CF-blocked network → local derive raises, proxy fallback succeeds.
- [ ] User who migrated managed→external calls `client.link_wallet()` → derives fresh creds, returns `success=True` with `clob_credentials_registered=True`.
- [ ] User on CF-blocked network calls `link_wallet()` and proxy ALSO fails → `success=True`, `clob_credentials_registered=False`, `clob_credentials_error=...`.
- [ ] Local derive succeeds but Simmer registration POST fails → `RuntimeError` raised, NO silent fall-through to proxy.
- [ ] Both local + proxy fail → `RuntimeError` includes both error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)