### PR TITLE
feat(sdk): portfolio-level concurrent-exposure cap primitive (SIM-1451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] — 2026-05-07
+
+### Added
+
+- **Portfolio-level concurrent-exposure cap primitive** under
+  `simmer_sdk.risk.check_portfolio_cap`. A pre-trade gate that, given an
+  agent's current open positions across all skills/strategies, enforces a
+  hard ceiling on total open notional as a fraction of bankroll
+  (default 15%). Returns a structured `PortfolioCapDecision`
+  (`allow` / `deny` / `trim_to`) with an `allowed_size` field the caller
+  uses for the order. Layers on top of any per-trade Kelly cap from
+  `simmer_sdk.sizing` — per-trade Kelly says how big *this* trade may be,
+  the portfolio cap says how big *all open trades together* may be.
+
+  The primitive is opt-in (off by default). It is a forward-looking
+  *entry gate* based on currently-open exposure; the SIM-1072
+  `DrawdownController` (separate, not yet shipped) is a backward-looking
+  *halt* based on realized P&L. They are complementary and may be wired
+  together.
+
+  Skills can adopt the cap by merging `PORTFOLIO_CAP_CONFIG_SCHEMA` into
+  their own `CONFIG_SCHEMA`. Reference integration:
+  `examples/portfolio_cap_skill.py`. First-party adopter:
+  `polymarket-weather-trader` v1.22.0 — see its `SKILL.md` for the
+  end-to-end wiring (sizing → snapshot positions → cap check → place
+  trimmed size).
+
+  Re-exported at the top level: `from simmer_sdk import
+  check_portfolio_cap, PortfolioCapDecision, sum_open_notional,
+  DEFAULT_TOTAL_CAP_PCT, PORTFOLIO_CAP_CONFIG_SCHEMA`.
+
+  SIM-1451.
+
 ## [0.16.0] — 2026-05-06
 
 ### Changed

--- a/examples/portfolio_cap_skill.py
+++ b/examples/portfolio_cap_skill.py
@@ -1,0 +1,163 @@
+"""
+Reference integration for the portfolio-level concurrent-exposure cap (SIM-1451).
+
+Shows the canonical pattern for a multi-strategy agent that wants to bound
+its total open notional across all skills:
+
+    1. Compute a candidate trade size with the existing per-trade Kelly cap
+       (``simmer_sdk.sizing.size_position`` — fractional Kelly, default 0.25x,
+       hard-capped via ``max_fraction``).
+    2. Snapshot current open positions across all skills/strategies via
+       ``client.get_positions()`` (or any other source you trust).
+    3. Call ``check_portfolio_cap`` with the candidate, bankroll, and the
+       snapshot. The primitive returns ``allow`` / ``deny`` / ``trim_to``
+       and the size you may safely place.
+    4. Use ``decision.allowed_size`` for the trade. ``deny`` → skip;
+       ``trim_to`` → place a smaller-than-requested order.
+
+The cap is a *cross-skill* ceiling: every strategy run by the same agent
+sees the same total open notional, so a 92¢ scalp + 1¢ reversal + 49¢ MM
+together cannot breach (within the limits noted under "Concurrency" in
+``simmer_sdk.risk.portfolio_cap``).
+
+Distinction from drawdown control
+---------------------------------
+The portfolio cap gates *new entries* based on currently open exposure:
+
+    open_notional / bankroll ≤ total_cap_pct   →  may add more
+                              >  total_cap_pct →  trim or skip
+
+A drawdown controller (see SIM-1072 ``DrawdownController`` — separate
+ticket, separate concern) gates *new entries* based on realized P&L:
+
+    peak_equity - current_equity ≥ Y%  →  halt new entries for Z hours
+
+Both are pre-trade gates, but they answer different questions and are
+complementary. Wire both if you need both.
+
+Usage:
+    export SIMMER_API_KEY="sk_live_..."
+    python portfolio_cap_skill.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+from simmer_sdk import (
+    SimmerClient,
+    check_portfolio_cap,
+    size_position,
+)
+
+
+def run_one_market_with_portfolio_cap(
+    client: SimmerClient,
+    market_id: str,
+    p_win: float,
+    market_price: float,
+    bankroll: float,
+    *,
+    # Per-trade cap from the existing Kelly machinery — 8% hard cap as in
+    # the SIM-1451 ticket spec (max_fraction=0.08).
+    kelly_multiplier: float = 0.25,
+    per_trade_max_fraction: float = 0.08,
+    # Portfolio-level cap layered on top — 15% of bankroll across all
+    # skills/strategies for this agent.
+    total_cap_pct: float = 0.15,
+    agent_id: str | None = None,
+) -> float:
+    """Decide and (optionally) trim a trade size for one market.
+
+    Returns the dollar amount the strategy should actually allocate.
+    ``0.0`` means skip — either the per-trade Kelly returned zero, the
+    portfolio is already at cap, or the candidate was trimmed to a value
+    too small to be useful.
+    """
+    # 1. Per-trade Kelly sizing (this is the existing primitive).
+    candidate = size_position(
+        p_win=p_win,
+        market_price=market_price,
+        bankroll=bankroll,
+        method="fractional_kelly",
+        kelly_multiplier=kelly_multiplier,
+        max_fraction=per_trade_max_fraction,
+    )
+    if candidate <= 0.0:
+        # Negative-EV or below threshold; nothing to gate.
+        return 0.0
+
+    # 2. Snapshot open positions across ALL skills for this agent.
+    # client.get_positions() returns the canonical Position dataclass,
+    # which the cap primitive accepts directly.
+    open_positions = client.get_positions()
+
+    # 3. Apply the portfolio-level cap BEFORE order placement.
+    decision = check_portfolio_cap(
+        candidate_size=candidate,
+        bankroll=bankroll,
+        open_positions=open_positions,
+        total_cap_pct=total_cap_pct,
+        agent_id=agent_id,
+    )
+
+    if decision.decision == "deny":
+        print(
+            f"[portfolio-cap] skip market={market_id} "
+            f"reason={decision.reason} "
+            f"open={decision.current_open_notional:.2f} "
+            f"cap={decision.cap_notional:.2f}"
+        )
+        return 0.0
+
+    if decision.decision == "trim_to":
+        print(
+            f"[portfolio-cap] trim market={market_id} "
+            f"candidate={decision.candidate_size:.2f} "
+            f"allowed={decision.allowed_size:.2f} "
+            f"headroom={decision.headroom:.2f} "
+            f"cap={decision.cap_notional:.2f}"
+        )
+
+    # 4. Place the trade at the (possibly trimmed) size.
+    return decision.allowed_size
+
+
+def run_multi_strategy_demo(client: SimmerClient, bankroll: float) -> None:
+    """Demonstrates the cap acting across three concurrent strategies.
+
+    The three calls share the same ``client`` (same agent, same positions
+    store), so each call sees the cumulative open notional from prior
+    fills. With a 15% total cap, the third strategy will typically be
+    trimmed or denied even though each one's per-trade Kelly was modest.
+    """
+    candidates: Sequence[tuple[str, float, float]] = [
+        ("market_92c_scalp", 0.95, 0.92),       # high-prob scalp
+        ("market_1c_reversal", 0.05, 0.01),     # tail-reversal
+        ("market_49c_mm", 0.55, 0.49),          # mean-reverting MM
+    ]
+    for mkt, p_win, price in candidates:
+        size = run_one_market_with_portfolio_cap(
+            client,
+            market_id=mkt,
+            p_win=p_win,
+            market_price=price,
+            bankroll=bankroll,
+            agent_id="demo",
+        )
+        print(f"  -> placing {size:.2f} on {mkt}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual driver
+    api_key = os.environ.get("SIMMER_API_KEY")
+    if not api_key:
+        raise SystemExit("Set SIMMER_API_KEY to run this example")
+
+    client = SimmerClient(api_key=api_key)
+    summary = client.get_portfolio() or {}
+    bankroll = float(summary.get("balance_usdc") or summary.get("sim_balance") or 0.0)
+    if bankroll <= 0:
+        raise SystemExit("No bankroll available; fund your account before running")
+
+    run_multi_strategy_demo(client, bankroll=bankroll)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.16.0"
+version = "0.16.1"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/__init__.py
+++ b/simmer_sdk/__init__.py
@@ -101,6 +101,12 @@ __all__ = [
     "expected_value",
     "size_position",
     "SIZING_CONFIG_SCHEMA",
+    # Risk management — portfolio-level concurrent-exposure cap
+    "check_portfolio_cap",
+    "sum_open_notional",
+    "PortfolioCapDecision",
+    "DEFAULT_TOTAL_CAP_PCT",
+    "PORTFOLIO_CAP_CONFIG_SCHEMA",
 ]
 
 # Convenience aliases for skill config
@@ -110,3 +116,12 @@ from .skill import get_config_path as get_skill_config_path
 
 # Position sizing utilities
 from .sizing import kelly_fraction, expected_value, size_position, SIZING_CONFIG_SCHEMA
+
+# Risk-management primitives (portfolio-level exposure cap, etc.)
+from .risk import (
+    check_portfolio_cap,
+    sum_open_notional,
+    PortfolioCapDecision,
+    DEFAULT_TOTAL_CAP_PCT,
+    PORTFOLIO_CAP_CONFIG_SCHEMA,
+)

--- a/simmer_sdk/risk/__init__.py
+++ b/simmer_sdk/risk/__init__.py
@@ -1,0 +1,64 @@
+"""
+Risk-management primitives for Simmer SDK skills.
+
+A *risk primitive* is a pre-trade guard: before a strategy places an order,
+it asks the primitive whether the candidate size is admissible given the
+agent's current state (open exposure, recent drawdown, daily loss, …).
+Each primitive returns a structured decision (allow / deny / trim) so the
+caller can act deterministically without implementing its own risk math.
+
+Currently provides:
+
+- ``check_portfolio_cap`` — portfolio-level concurrent-exposure cap.
+  Sums current open notional across all skills/strategies for an agent and
+  enforces a hard ceiling as a fraction of bankroll. Returns
+  ``allow`` / ``deny`` / ``trim_to``. This is a *cross-skill* ceiling that
+  layers on top of any per-trade Kelly cap from ``simmer_sdk.sizing`` —
+  per-trade Kelly says how big *this* trade may be, the portfolio cap says
+  how big *all open trades together* may be.
+
+Distinction from drawdown control (see SIM-1072 ``DrawdownController``,
+not yet shipped): the portfolio cap is a *forward-looking entry gate*
+("sum of open exposure ≤ X% of bankroll") — it gates new entries based on
+already-open positions. A drawdown controller is a *backward-looking halt*
+("peak-to-trough loss ≥ Y% halts new trades for Z hours") — it gates new
+entries based on realized P&L. They are complementary and live separately.
+
+Example:
+    from simmer_sdk.risk import check_portfolio_cap
+    from simmer_sdk.sizing import size_position
+
+    candidate = size_position(p_win=0.62, market_price=0.55, bankroll=10_000.0)
+
+    decision = check_portfolio_cap(
+        candidate_size=candidate,
+        bankroll=10_000.0,
+        open_positions=client.get_positions(),
+        total_cap_pct=0.15,
+        agent_id="agent_123",
+    )
+    if decision.decision == "deny":
+        return  # at cap — skip
+    final_size = decision.allowed_size  # candidate, or trimmed to fit
+
+The primitive is opt-in (off by default). Skills wire it explicitly before
+order placement; nothing inside the SDK calls it implicitly.
+"""
+
+from __future__ import annotations
+
+from .portfolio_cap import (
+    DEFAULT_TOTAL_CAP_PCT,
+    PORTFOLIO_CAP_CONFIG_SCHEMA,
+    PortfolioCapDecision,
+    check_portfolio_cap,
+    sum_open_notional,
+)
+
+__all__ = [
+    "PortfolioCapDecision",
+    "check_portfolio_cap",
+    "sum_open_notional",
+    "DEFAULT_TOTAL_CAP_PCT",
+    "PORTFOLIO_CAP_CONFIG_SCHEMA",
+]

--- a/simmer_sdk/risk/portfolio_cap.py
+++ b/simmer_sdk/risk/portfolio_cap.py
@@ -1,0 +1,343 @@
+"""
+Portfolio-level concurrent-exposure cap.
+
+Enforces a hard ceiling on the total open notional an agent may hold across
+all skills/strategies, expressed as a fraction of bankroll. Returns one of
+three decisions for any candidate trade:
+
+    "allow"   — candidate fits under the cap; place at requested size.
+    "deny"    — agent is already at or above the cap; skip the trade.
+    "trim_to" — candidate would breach the cap; place at the largest size
+                that still fits (``allowed_size`` < ``candidate_size``).
+
+This complements per-trade sizing in :mod:`simmer_sdk.sizing` (Kelly and
+fractional-Kelly cap how big *this* trade may be) by adding a cross-skill
+ceiling on *all* open trades. A multi-strategy agent running, for example,
+a 92¢ scalp + a 1¢ reversal + a 49¢ market-maker can use the per-trade cap
+on each leg and still bound total open exposure.
+
+Distinct from the SIM-1072 ``DrawdownController`` (not yet shipped):
+
+    portfolio cap         — forward-looking entry gate (open exposure ≤ X% bankroll)
+    DrawdownController    — backward-looking halt (peak-to-trough loss ≥ Y% halts entries)
+
+Both can be wired in the same skill; they answer different questions.
+
+Concurrency
+-----------
+The primitive itself is pure: given the same inputs it always returns the
+same decision. There is no shared mutable state, so it is safe to call
+from many threads/processes concurrently. What it *cannot* do at the
+primitive layer is solve TOCTOU between fetching positions, deciding, and
+placing the order — two concurrent skills can each see the same snapshot
+and each place a "fits" trade that together breach the cap. Callers that
+need stricter guarantees should hold a lock around fetch → decide → place,
+or accept eventual breach within a small window. The cap is designed for
+the common case where each skill places trades serially and breaches are
+small relative to the cap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+# Default portfolio-level concurrent-exposure cap as a fraction of bankroll.
+# 15% mirrors the cross-strategy ceiling stacyonchain runs on top of an 8%
+# per-trade Kelly hard cap; operators SHOULD tune per agent risk appetite.
+DEFAULT_TOTAL_CAP_PCT = 0.15
+
+_VALID_DECISIONS = ("allow", "deny", "trim_to")
+
+
+@dataclass(frozen=True)
+class PortfolioCapDecision:
+    """Result of a portfolio-level exposure-cap check.
+
+    Attributes:
+        decision: One of ``"allow"``, ``"deny"``, ``"trim_to"``.
+        allowed_size: The size the caller may place. Equal to
+            ``candidate_size`` for ``allow``, ``0.0`` for ``deny``, and
+            ``cap_notional - current_open_notional`` for ``trim_to``.
+        candidate_size: The size the caller proposed (echoed back).
+        current_open_notional: Sum of open notional across all positions
+            considered. Source of the cross-skill aggregation.
+        cap_notional: ``bankroll * total_cap_pct`` — the absolute ceiling.
+        headroom: ``cap_notional - current_open_notional``. Negative values
+            mean the agent is already over-cap (typically yields ``deny``).
+        reason: Short machine-readable code explaining the decision
+            (e.g. ``"under_cap"``, ``"at_cap"``, ``"would_exceed_cap"``,
+            ``"invalid_bankroll"``).
+        agent_id: Optional caller-provided identifier, echoed back unchanged
+            for log correlation. Not used in the decision.
+    """
+
+    decision: str
+    allowed_size: float
+    candidate_size: float
+    current_open_notional: float
+    cap_notional: float
+    headroom: float
+    reason: str
+    agent_id: Optional[str] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - guard only
+        if self.decision not in _VALID_DECISIONS:
+            raise ValueError(
+                f"PortfolioCapDecision.decision must be one of "
+                f"{_VALID_DECISIONS!r}, got {self.decision!r}"
+            )
+
+
+def _position_notional(pos: Any) -> float:
+    """Best-effort extraction of open notional from a position-like object.
+
+    Accepts:
+        - ``simmer_sdk.client.Position`` (or any object with a
+          ``current_value`` attribute).
+        - ``dict`` with a ``"current_value"`` (preferred) or
+          ``"notional"`` key.
+        - ``int`` / ``float`` raw notional.
+
+    Returns ``0.0`` for anything we cannot interpret or that yields a
+    non-finite / non-numeric value. Closed positions (``status`` ==
+    ``"closed"`` or zero shares) contribute ``0.0`` if those fields are
+    present and unambiguous.
+    """
+    if pos is None:
+        return 0.0
+
+    # Raw numeric — caller already aggregated.
+    if isinstance(pos, (int, float)) and not isinstance(pos, bool):
+        return float(pos) if _is_finite_nonneg(pos) else 0.0
+
+    # dict-style position payload.
+    if isinstance(pos, dict):
+        status = pos.get("status")
+        if status == "closed":
+            return 0.0
+        for key in ("current_value", "notional", "open_notional"):
+            if key in pos and pos[key] is not None:
+                val = pos[key]
+                if isinstance(val, (int, float)) and _is_finite_nonneg(val):
+                    return float(val)
+                return 0.0
+        return 0.0
+
+    # Object-style position (e.g. SDK Position dataclass) — duck-typed.
+    status = getattr(pos, "status", None)
+    if status == "closed":
+        return 0.0
+    val = getattr(pos, "current_value", None)
+    if val is None:
+        return 0.0
+    if isinstance(val, (int, float)) and _is_finite_nonneg(val):
+        return float(val)
+    return 0.0
+
+
+def _is_finite_nonneg(x: float) -> bool:
+    """True for finite, non-negative numbers (rejects NaN, inf, negatives)."""
+    try:
+        xf = float(x)
+    except (TypeError, ValueError):
+        return False
+    if xf != xf:  # NaN check (NaN != NaN)
+        return False
+    if xf in (float("inf"), float("-inf")):
+        return False
+    return xf >= 0.0
+
+
+def sum_open_notional(positions: Iterable[Any]) -> float:
+    """Sum open notional across a sequence of position-like records.
+
+    See :func:`_position_notional` for accepted shapes. Records that cannot
+    be interpreted contribute ``0.0`` (fail-quiet) — this primitive must
+    not raise on unfamiliar payloads, since callers may aggregate positions
+    from multiple venues with slightly different shapes. If you need strict
+    parsing, pre-process positions yourself and pass the sum via
+    ``current_open_notional`` to :func:`check_portfolio_cap`.
+    """
+    if positions is None:
+        return 0.0
+    total = 0.0
+    for p in positions:
+        total += _position_notional(p)
+    return total
+
+
+def check_portfolio_cap(
+    candidate_size: float,
+    bankroll: float,
+    *,
+    open_positions: Optional[Iterable[Any]] = None,
+    current_open_notional: Optional[float] = None,
+    total_cap_pct: float = DEFAULT_TOTAL_CAP_PCT,
+    agent_id: Optional[str] = None,
+) -> PortfolioCapDecision:
+    """Decide whether ``candidate_size`` is admissible under the portfolio cap.
+
+    Args:
+        candidate_size: Dollar size the strategy proposes to allocate to
+            the next trade. Must be ``>= 0``. Negative values are treated
+            as ``0`` (no trade).
+        bankroll: Available capital denominated in the same units as
+            positions' ``current_value``. Must be ``> 0``; otherwise the
+            primitive returns ``deny`` with reason ``"invalid_bankroll"``.
+        open_positions: Iterable of position records (SDK ``Position``
+            objects, dicts with ``current_value``, or pre-summed numbers).
+            Mutually exclusive with ``current_open_notional``.
+        current_open_notional: Pre-aggregated open notional across all
+            skills/strategies. Use when you already summed positions
+            yourself (e.g. for a custom venue or a cached value). Mutually
+            exclusive with ``open_positions``.
+        total_cap_pct: Fraction of bankroll allowed as total open notional.
+            Defaults to :data:`DEFAULT_TOTAL_CAP_PCT` (0.15). Must be in
+            ``(0, 1]``; outside this range the primitive returns ``deny``
+            with reason ``"invalid_cap_pct"``.
+        agent_id: Optional identifier echoed back on the decision for log
+            correlation. Not used in the decision.
+
+    Returns:
+        A :class:`PortfolioCapDecision` describing the verdict and the
+        size the caller may safely place.
+
+    Raises:
+        ValueError: If both ``open_positions`` and ``current_open_notional``
+            are supplied (the inputs are ambiguous).
+
+    Example:
+        >>> from simmer_sdk.risk import check_portfolio_cap
+        >>> d = check_portfolio_cap(
+        ...     candidate_size=200.0,
+        ...     bankroll=10_000.0,
+        ...     current_open_notional=1_400.0,  # 14% of bankroll already open
+        ...     total_cap_pct=0.15,
+        ... )
+        >>> d.decision, round(d.allowed_size, 2)
+        ('trim_to', 100.0)
+    """
+    if open_positions is not None and current_open_notional is not None:
+        raise ValueError(
+            "check_portfolio_cap: pass either open_positions or "
+            "current_open_notional, not both"
+        )
+
+    # Validate bankroll first — without it we cannot compute a cap.
+    if not _is_finite_nonneg(bankroll) or bankroll <= 0.0:
+        return PortfolioCapDecision(
+            decision="deny",
+            allowed_size=0.0,
+            candidate_size=max(0.0, float(candidate_size) if _is_finite_nonneg(candidate_size) else 0.0),
+            current_open_notional=0.0,
+            cap_notional=0.0,
+            headroom=0.0,
+            reason="invalid_bankroll",
+            agent_id=agent_id,
+        )
+
+    # Validate cap pct — must be in (0, 1].
+    if not _is_finite_nonneg(total_cap_pct) or total_cap_pct <= 0.0 or total_cap_pct > 1.0:
+        return PortfolioCapDecision(
+            decision="deny",
+            allowed_size=0.0,
+            candidate_size=max(0.0, float(candidate_size) if _is_finite_nonneg(candidate_size) else 0.0),
+            current_open_notional=0.0,
+            cap_notional=0.0,
+            headroom=0.0,
+            reason="invalid_cap_pct",
+            agent_id=agent_id,
+        )
+
+    # Normalize candidate (negatives / NaN -> 0).
+    cand = float(candidate_size) if _is_finite_nonneg(candidate_size) else 0.0
+
+    # Aggregate open notional.
+    if current_open_notional is not None:
+        if not _is_finite_nonneg(current_open_notional):
+            open_notional = 0.0
+        else:
+            open_notional = float(current_open_notional)
+    else:
+        open_notional = sum_open_notional(open_positions or ())
+
+    cap_notional = float(bankroll) * float(total_cap_pct)
+    headroom = cap_notional - open_notional
+
+    # Candidate of zero is a no-op; report allow with reason "no_candidate"
+    # so the caller can distinguish from a trimmed-to-zero outcome.
+    if cand <= 0.0:
+        return PortfolioCapDecision(
+            decision="allow",
+            allowed_size=0.0,
+            candidate_size=0.0,
+            current_open_notional=open_notional,
+            cap_notional=cap_notional,
+            headroom=headroom,
+            reason="no_candidate",
+            agent_id=agent_id,
+        )
+
+    # Already at or above cap -> deny outright. Headroom <= 0 means no
+    # bytes left to allocate. Use a small tolerance to absorb fp noise.
+    EPSILON = 1e-9
+    if headroom <= EPSILON:
+        return PortfolioCapDecision(
+            decision="deny",
+            allowed_size=0.0,
+            candidate_size=cand,
+            current_open_notional=open_notional,
+            cap_notional=cap_notional,
+            headroom=headroom,
+            reason="at_cap" if abs(headroom) <= EPSILON else "over_cap",
+            agent_id=agent_id,
+        )
+
+    # Candidate fits entirely under the cap.
+    if cand <= headroom + EPSILON:
+        return PortfolioCapDecision(
+            decision="allow",
+            allowed_size=cand,
+            candidate_size=cand,
+            current_open_notional=open_notional,
+            cap_notional=cap_notional,
+            headroom=headroom,
+            reason="under_cap",
+            agent_id=agent_id,
+        )
+
+    # Candidate would breach -> trim to remaining headroom.
+    return PortfolioCapDecision(
+        decision="trim_to",
+        allowed_size=max(0.0, headroom),
+        candidate_size=cand,
+        current_open_notional=open_notional,
+        cap_notional=cap_notional,
+        headroom=headroom,
+        reason="would_exceed_cap",
+        agent_id=agent_id,
+    )
+
+
+# Config schema skills can merge into their CONFIG_SCHEMA to expose the cap
+# as a config-driven knob. Default is `enabled=False` (opt-in per ticket).
+#
+# Usage in a skill:
+#     from simmer_sdk.risk import PORTFOLIO_CAP_CONFIG_SCHEMA
+#     CONFIG_SCHEMA = {
+#         "my_param": {"env": "MY_PARAM", "default": 42, "type": int},
+#         **PORTFOLIO_CAP_CONFIG_SCHEMA,
+#     }
+PORTFOLIO_CAP_CONFIG_SCHEMA = {
+    "portfolio_cap_enabled": {
+        "env": "SIMMER_PORTFOLIO_CAP_ENABLED",
+        "default": False,
+        "type": bool,
+    },
+    "portfolio_cap_pct": {
+        "env": "SIMMER_PORTFOLIO_CAP_PCT",
+        "default": DEFAULT_TOTAL_CAP_PCT,
+        "type": float,
+    },
+}

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.21.0"
+  version: "1.22.0"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).
@@ -97,6 +97,19 @@ Then `pip install --upgrade simmer-sdk` (>=0.13.0) and configure tunables below.
 | Vol min alloc | `SIMMER_WEATHER_VOL_MIN_ALLOC` | 0.2 | Min allocation floor in volatile markets (0.2 = 20%) |
 | Vol EWMA span | `SIMMER_WEATHER_VOL_SPAN` | 10 | EWMA span for vol calculation (lower = more responsive) |
 | Order type | `SIMMER_WEATHER_ORDER_TYPE` | GTC | GTC (limit, waits for fill) or FAK (cancel if not filled). GTC recommended. |
+| Portfolio cap | `SIMMER_PORTFOLIO_CAP_ENABLED` | false | Enable portfolio-level concurrent-exposure cap (cross-skill open notional ceiling). Off by default. |
+| Portfolio cap pct | `SIMMER_PORTFOLIO_CAP_PCT` | 0.15 | Total open notional cap as a fraction of bankroll. Only used when the cap is enabled. |
+
+### Portfolio-level concurrent-exposure cap (v1.22.0+)
+
+Multi-strategy users can layer a *cross-skill* exposure ceiling on top of the per-trade sizing. With `SIMMER_PORTFOLIO_CAP_ENABLED=true`, before every buy the skill:
+
+1. Computes the candidate size via the existing entry/sizing logic.
+2. Snapshots open positions across **all** skills (not just weather) for the same agent.
+3. Calls `simmer_sdk.risk.check_portfolio_cap` with a `SIMMER_PORTFOLIO_CAP_PCT` × bankroll ceiling.
+4. Either places the candidate (`allow`), trims it to fit (`trim_to`), or skips (`deny`).
+
+This is the SIM-1451 primitive — see [docs.simmer.markets/sdk/risk-management/portfolio-cap](https://docs.simmer.markets/sdk/risk-management/portfolio-cap) for details. It's *opt-in*: existing installs see no behavior change. The cap is forward-looking (gates new entries based on currently-open exposure) and is distinct from the SIM-1072 `DrawdownController` (peak-trough realized-PnL halt — separate primitive, separate ticket).
 
 **Legacy env var aliases** (still accepted for backwards compatibility): `SIMMER_WEATHER_ENTRY`, `SIMMER_WEATHER_EXIT`, `SIMMER_WEATHER_MAX_POSITION`, `SIMMER_WEATHER_MAX_TRADES`
 

--- a/skills/polymarket-weather-trader/clawhub.json
+++ b/skills/polymarket-weather-trader/clawhub.json
@@ -6,7 +6,7 @@
       "SIMMER_API_KEY"
     ],
     "pip": [
-      "simmer-sdk>=0.16.0"
+      "simmer-sdk>=0.16.1"
     ]
   },
   "envVars": [

--- a/skills/polymarket-weather-trader/clawhub.json
+++ b/skills/polymarket-weather-trader/clawhub.json
@@ -6,7 +6,7 @@
       "SIMMER_API_KEY"
     ],
     "pip": [
-      "simmer-sdk>=0.13.0"
+      "simmer-sdk>=0.16.0"
     ]
   },
   "envVars": [
@@ -99,6 +99,16 @@
       "name": "SIMMER_WEATHER_VOL_SPAN",
       "required": false,
       "description": "EWMA span for vol calculation; lower = more responsive (default 10)."
+    },
+    {
+      "name": "SIMMER_PORTFOLIO_CAP_ENABLED",
+      "required": false,
+      "description": "Enable portfolio-level concurrent-exposure cap (cross-skill open notional ceiling). Default false (off). When enabled, trims or skips trades that would push total open notional across all skills above SIMMER_PORTFOLIO_CAP_PCT of bankroll."
+    },
+    {
+      "name": "SIMMER_PORTFOLIO_CAP_PCT",
+      "required": false,
+      "description": "Total open notional cap as a fraction of bankroll (default 0.15 = 15%). Only used when SIMMER_PORTFOLIO_CAP_ENABLED is true. Layers on top of per-trade sizing."
     }
   ],
   "cron": null,
@@ -246,6 +256,23 @@
       ],
       "step": 1,
       "label": "EWMA span for vol calculation"
+    },
+    {
+      "env": "SIMMER_PORTFOLIO_CAP_ENABLED",
+      "type": "boolean",
+      "default": false,
+      "label": "Enable portfolio cap (cross-skill exposure ceiling)"
+    },
+    {
+      "env": "SIMMER_PORTFOLIO_CAP_PCT",
+      "type": "number",
+      "default": 0.15,
+      "range": [
+        0.01,
+        1.0
+      ],
+      "step": 0.01,
+      "label": "Total open notional cap (fraction of bankroll)"
     }
   ]
 }

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -47,6 +47,7 @@ except ImportError:
 # =============================================================================
 
 from simmer_sdk.skill import load_config, update_config, get_config_path
+from simmer_sdk.risk import PORTFOLIO_CAP_CONFIG_SCHEMA, check_portfolio_cap
 
 # Configuration schema
 # Note: env var names match autotune registry. Legacy aliases (SIMMER_WEATHER_ENTRY,
@@ -74,6 +75,9 @@ CONFIG_SCHEMA = {
                           "help": "Min allocation floor from vol targeting (stay in market during high vol)."},
     "vol_span":          {"env": "SIMMER_WEATHER_VOL_SPAN",          "default": 10,    "type": int,
                           "help": "EWMA span for volatility calculation (lower = more responsive)."},
+    # Portfolio-level concurrent-exposure cap (SIM-1451). Opt-in, default off.
+    # Layers a cross-skill total-open-notional ceiling on top of per-trade sizing.
+    **PORTFOLIO_CAP_CONFIG_SCHEMA,
 }
 
 # Backwards-compatible env var aliases (old name -> new name)
@@ -138,6 +142,13 @@ TARGET_VOL = _config["target_vol"]
 VOL_MAX_LEVERAGE = _config["vol_max_leverage"]
 VOL_MIN_ALLOCATION = _config["vol_min_allocation"]
 VOL_SPAN = _config["vol_span"]
+
+# Portfolio-level cap (SIM-1451). Opt-in cross-skill ceiling, default off.
+# When enabled, after per-trade sizing we sum open notional across ALL the
+# agent's positions (not just weather) and trim or skip if the candidate would
+# breach `portfolio_cap_pct` of bankroll. See simmer_sdk.risk.portfolio_cap.
+PORTFOLIO_CAP_ENABLED = _config["portfolio_cap_enabled"]
+PORTFOLIO_CAP_PCT = _config["portfolio_cap_pct"]
 
 # Context safeguard thresholds
 SLIPPAGE_MAX_PCT = _config["slippage_max"]  # Skip if slippage exceeds this (tunable)
@@ -1001,6 +1012,67 @@ def calculate_position_size(default_size: float, smart_sizing: bool) -> float:
     return smart_size
 
 
+def apply_portfolio_cap(candidate_size: float, market_id: str) -> float:
+    """Apply the portfolio-level concurrent-exposure cap (SIM-1451).
+
+    Cross-skill ceiling layered on top of per-trade sizing. Reads bankroll
+    and ALL open positions for the agent, then asks
+    ``simmer_sdk.risk.check_portfolio_cap`` whether the candidate fits
+    within ``PORTFOLIO_CAP_PCT`` of bankroll.
+
+    Returns the size the caller may safely place. ``0.0`` means skip
+    (denied or trimmed below the per-order minimum). Opt-in: returns
+    ``candidate_size`` unchanged when ``PORTFOLIO_CAP_ENABLED`` is False.
+    """
+    if not PORTFOLIO_CAP_ENABLED:
+        return candidate_size
+    if candidate_size <= 0.0:
+        return 0.0
+
+    try:
+        client = get_client()
+        portfolio = client.get_portfolio() or {}
+        # Polymarket trades → bankroll must be USDC only. Do NOT fall back to
+        # sim_balance: a user with zero USDC and a non-zero $SIM paper balance
+        # would silently size the cap against play money (CLAUDE.md: "disambiguate
+        # $SIM vs USDC"). Fail-open branch below handles the zero-bankroll case.
+        bankroll = float(portfolio.get("balance_usdc") or 0.0)
+        if bankroll <= 0:
+            print("  ⚠️  Portfolio cap: no bankroll available, skipping cap check")
+            return candidate_size
+        # Snapshot positions across ALL skills/strategies for this agent —
+        # the cap is a cross-skill ceiling, not a weather-only one.
+        open_positions = client.get_positions()
+    except Exception as e:
+        print(f"  ⚠️  Portfolio cap: position/bankroll fetch failed ({e}); proceeding without cap")
+        return candidate_size
+
+    decision = check_portfolio_cap(
+        candidate_size=candidate_size,
+        bankroll=bankroll,
+        open_positions=open_positions,
+        total_cap_pct=PORTFOLIO_CAP_PCT,
+        agent_id=SKILL_SLUG,
+    )
+
+    if decision.decision == "deny":
+        print(
+            f"  🚫 Portfolio cap: skip market={market_id} reason={decision.reason} "
+            f"open=${decision.current_open_notional:.2f} cap=${decision.cap_notional:.2f}"
+        )
+        return 0.0
+
+    if decision.decision == "trim_to":
+        print(
+            f"  ✂️  Portfolio cap: trim market={market_id} "
+            f"candidate=${decision.candidate_size:.2f} → ${decision.allowed_size:.2f} "
+            f"headroom=${decision.headroom:.2f} cap=${decision.cap_notional:.2f}"
+        )
+        return decision.allowed_size
+
+    return decision.allowed_size
+
+
 # =============================================================================
 # Exit Strategy
 # =============================================================================
@@ -1129,6 +1201,9 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         log(f"    Max leverage:  {VOL_MAX_LEVERAGE:.1f}x")
         log(f"    Min alloc:     {VOL_MIN_ALLOCATION:.0%}")
         log(f"    EWMA span:     {VOL_SPAN}")
+    log(f"  Portfolio cap:   {'✓ Enabled' if PORTFOLIO_CAP_ENABLED else '✗ Disabled'}")
+    if PORTFOLIO_CAP_ENABLED:
+        log(f"    Total cap:     {PORTFOLIO_CAP_PCT:.0%} of bankroll (cross-skill)")
 
     if show_config:
         config_path = get_config_path(__file__)
@@ -1386,6 +1461,16 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                 else:
                     log(f"  📊 Vol targeting: insufficient price data — using base size")
 
+            # Portfolio-level concurrent-exposure cap (SIM-1451). No-op when disabled.
+            # Layers a cross-skill ceiling on top of per-trade sizing — sums open
+            # notional across ALL skills and trims or skips if the candidate would
+            # breach `portfolio_cap_pct` of bankroll. Off by default; opt-in via
+            # SIMMER_PORTFOLIO_CAP_ENABLED=true (or the SDK config UI knob).
+            position_size = apply_portfolio_cap(position_size, market_id)
+            if position_size <= 0.0:
+                skip_reasons.append("portfolio cap")
+                continue
+
             min_cost_for_shares = MIN_SHARES_PER_ORDER * price
             if min_cost_for_shares > position_size:
                 log(f"  ⚠️  Position size ${position_size:.2f} too small for {MIN_SHARES_PER_ORDER} shares at ${price:.2f}")
@@ -1521,6 +1606,8 @@ if __name__ == "__main__":
             globals()["VOL_MAX_LEVERAGE"] = _config["vol_max_leverage"]
             globals()["VOL_MIN_ALLOCATION"] = _config["vol_min_allocation"]
             globals()["VOL_SPAN"] = _config["vol_span"]
+            globals()["PORTFOLIO_CAP_ENABLED"] = _config["portfolio_cap_enabled"]
+            globals()["PORTFOLIO_CAP_PCT"] = _config["portfolio_cap_pct"]
             _locations_str = _config["locations"]
             globals()["ACTIVE_LOCATIONS"] = [loc.strip().upper() for loc in _locations_str.split(",") if loc.strip()]
 

--- a/tests/test_portfolio_cap.py
+++ b/tests/test_portfolio_cap.py
@@ -1,0 +1,444 @@
+"""Tests for simmer_sdk.risk.portfolio_cap.
+
+Covers the three required paths:
+    - under-cap → allow
+    - at-cap   → deny
+    - would-exceed → trim
+
+Plus boundary inputs, alternate position shapes, agent_id passthrough,
+input validation, and a concurrency check that confirms the primitive is
+safe to call from many threads against shared inputs.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from simmer_sdk.risk import (
+    DEFAULT_TOTAL_CAP_PCT,
+    PORTFOLIO_CAP_CONFIG_SCHEMA,
+    PortfolioCapDecision,
+    check_portfolio_cap,
+    sum_open_notional,
+)
+from simmer_sdk.risk.portfolio_cap import _is_finite_nonneg, _position_notional
+
+
+# --- Three required paths -----------------------------------------------------
+
+def test_under_cap_allows_full_size():
+    # bankroll 10k, cap 15% = 1500, open 500, candidate 200 -> fits.
+    d = check_portfolio_cap(
+        candidate_size=200.0,
+        bankroll=10_000.0,
+        current_open_notional=500.0,
+        total_cap_pct=0.15,
+    )
+    assert d.decision == "allow"
+    assert d.allowed_size == pytest.approx(200.0)
+    assert d.reason == "under_cap"
+    assert d.cap_notional == pytest.approx(1500.0)
+    assert d.headroom == pytest.approx(1000.0)
+
+
+def test_at_cap_denies():
+    # bankroll 10k, cap 15% = 1500, open 1500 -> headroom 0, deny.
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=1500.0,
+        total_cap_pct=0.15,
+    )
+    assert d.decision == "deny"
+    assert d.allowed_size == 0.0
+    assert d.reason == "at_cap"
+    assert d.headroom == pytest.approx(0.0, abs=1e-9)
+
+
+def test_would_exceed_trims_to_headroom():
+    # bankroll 10k, cap 15% = 1500, open 1400, candidate 200 -> trim to 100.
+    d = check_portfolio_cap(
+        candidate_size=200.0,
+        bankroll=10_000.0,
+        current_open_notional=1400.0,
+        total_cap_pct=0.15,
+    )
+    assert d.decision == "trim_to"
+    assert d.allowed_size == pytest.approx(100.0)
+    assert d.candidate_size == pytest.approx(200.0)
+    assert d.reason == "would_exceed_cap"
+    assert d.headroom == pytest.approx(100.0)
+
+
+# --- Over-cap and boundary -----------------------------------------------------
+
+def test_over_cap_denies_with_over_cap_reason():
+    # Already over the cap (manual override / external move). Distinct from
+    # "at_cap" so observers can spot drift.
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=1700.0,  # > 1500 cap
+        total_cap_pct=0.15,
+    )
+    assert d.decision == "deny"
+    assert d.reason == "over_cap"
+    assert d.headroom < 0
+
+
+def test_zero_open_allows_full_candidate():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+    )
+    assert d.decision == "allow"
+    assert d.allowed_size == pytest.approx(100.0)
+    assert d.reason == "under_cap"
+
+
+def test_candidate_equal_to_headroom_allows():
+    # Exact-fit candidate == headroom -> allow (epsilon tolerance applies).
+    d = check_portfolio_cap(
+        candidate_size=500.0,
+        bankroll=10_000.0,
+        current_open_notional=1000.0,
+        total_cap_pct=0.15,
+    )
+    assert d.decision == "allow"
+    assert d.allowed_size == pytest.approx(500.0)
+
+
+def test_zero_candidate_allows_no_candidate():
+    d = check_portfolio_cap(
+        candidate_size=0.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+    )
+    assert d.decision == "allow"
+    assert d.allowed_size == 0.0
+    assert d.reason == "no_candidate"
+
+
+def test_negative_candidate_treated_as_zero():
+    d = check_portfolio_cap(
+        candidate_size=-50.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+    )
+    assert d.decision == "allow"
+    assert d.allowed_size == 0.0
+    assert d.reason == "no_candidate"
+
+
+# --- Input validation ----------------------------------------------------------
+
+def test_invalid_bankroll_zero_denies():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=0.0,
+        current_open_notional=0.0,
+    )
+    assert d.decision == "deny"
+    assert d.reason == "invalid_bankroll"
+    assert d.allowed_size == 0.0
+
+
+def test_invalid_bankroll_negative_denies():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=-1.0,
+        current_open_notional=0.0,
+    )
+    assert d.decision == "deny"
+    assert d.reason == "invalid_bankroll"
+
+
+def test_invalid_bankroll_nan_denies():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=float("nan"),
+        current_open_notional=0.0,
+    )
+    assert d.decision == "deny"
+    assert d.reason == "invalid_bankroll"
+
+
+def test_invalid_cap_pct_zero_denies():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+        total_cap_pct=0.0,
+    )
+    assert d.decision == "deny"
+    assert d.reason == "invalid_cap_pct"
+
+
+def test_invalid_cap_pct_above_one_denies():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+        total_cap_pct=1.5,
+    )
+    assert d.decision == "deny"
+    assert d.reason == "invalid_cap_pct"
+
+
+def test_cap_pct_one_is_valid_full_bankroll():
+    d = check_portfolio_cap(
+        candidate_size=10_000.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+        total_cap_pct=1.0,
+    )
+    assert d.decision == "allow"
+    assert d.allowed_size == pytest.approx(10_000.0)
+
+
+def test_both_open_inputs_raises():
+    with pytest.raises(ValueError):
+        check_portfolio_cap(
+            candidate_size=100.0,
+            bankroll=10_000.0,
+            open_positions=[],
+            current_open_notional=0.0,
+        )
+
+
+def test_no_open_inputs_treated_as_zero():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+    )
+    assert d.decision == "allow"
+    assert d.current_open_notional == 0.0
+
+
+def test_invalid_open_notional_treated_as_zero():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=float("nan"),
+    )
+    # Falls through to zero-open path.
+    assert d.decision == "allow"
+    assert d.current_open_notional == 0.0
+
+
+# --- Position shape parsing ----------------------------------------------------
+
+def test_open_positions_dict_with_current_value():
+    positions = [
+        {"market_id": "a", "current_value": 300.0, "status": "active"},
+        {"market_id": "b", "current_value": 700.0, "status": "active"},
+    ]
+    d = check_portfolio_cap(
+        candidate_size=200.0,
+        bankroll=10_000.0,
+        open_positions=positions,
+        total_cap_pct=0.15,
+    )
+    assert d.current_open_notional == pytest.approx(1000.0)
+    # cap = 1500, headroom = 500, candidate 200 -> allow.
+    assert d.decision == "allow"
+
+
+def test_open_positions_dict_with_notional_alias():
+    positions = [{"notional": 250.0}, {"open_notional": 250.0}]
+    assert sum_open_notional(positions) == pytest.approx(500.0)
+
+
+def test_open_positions_skips_closed_dict():
+    positions = [
+        {"current_value": 300.0, "status": "active"},
+        {"current_value": 999.0, "status": "closed"},
+    ]
+    assert sum_open_notional(positions) == pytest.approx(300.0)
+
+
+def test_open_positions_object_duck_typed():
+    class FakePosition:
+        def __init__(self, current_value, status="active"):
+            self.current_value = current_value
+            self.status = status
+
+    positions = [FakePosition(400.0), FakePosition(600.0), FakePosition(99.0, "closed")]
+    assert sum_open_notional(positions) == pytest.approx(1000.0)
+
+
+def test_sum_open_notional_handles_none_and_unknown():
+    assert sum_open_notional(None) == 0.0
+    assert sum_open_notional([None, object(), {}]) == 0.0
+
+
+def test_sum_open_notional_passthrough_numeric():
+    assert sum_open_notional([100, 200.5, 50]) == pytest.approx(350.5)
+
+
+def test_sum_open_notional_rejects_negative_and_nonfinite():
+    assert sum_open_notional([-100, float("inf"), float("nan"), 50]) == pytest.approx(50.0)
+
+
+def test_position_notional_returns_zero_for_missing_value():
+    assert _position_notional({"market_id": "x"}) == 0.0
+    assert _position_notional({"current_value": None}) == 0.0
+    class Bare:
+        pass
+    assert _position_notional(Bare()) == 0.0
+
+
+# --- Real SDK Position dataclass ----------------------------------------------
+
+def test_works_with_sdk_position_dataclass():
+    """Confirms the primitive accepts the canonical Position dataclass."""
+    from simmer_sdk.client import Position
+
+    positions = [
+        Position(
+            market_id="m1",
+            question="q",
+            shares_yes=100.0,
+            shares_no=0.0,
+            current_value=600.0,
+            pnl=0.0,
+            status="active",
+            venue="polymarket",
+        ),
+        Position(
+            market_id="m2",
+            question="q",
+            shares_yes=0.0,
+            shares_no=200.0,
+            current_value=900.0,
+            pnl=0.0,
+            status="active",
+            venue="sim",
+        ),
+        # Closed position should be ignored.
+        Position(
+            market_id="m3",
+            question="q",
+            shares_yes=0.0,
+            shares_no=0.0,
+            current_value=500.0,
+            pnl=0.0,
+            status="closed",
+            venue="polymarket",
+        ),
+    ]
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        open_positions=positions,
+        total_cap_pct=0.15,
+    )
+    # 600 + 900 = 1500 open (closed ignored). Cap = 1500. Already at cap.
+    assert d.current_open_notional == pytest.approx(1500.0)
+    assert d.decision == "deny"
+    assert d.reason == "at_cap"
+
+
+# --- Agent id and decision metadata -------------------------------------------
+
+def test_agent_id_echoed_back():
+    d = check_portfolio_cap(
+        candidate_size=100.0,
+        bankroll=10_000.0,
+        current_open_notional=0.0,
+        agent_id="agent_abc",
+    )
+    assert d.agent_id == "agent_abc"
+
+
+def test_decision_is_frozen_dataclass():
+    d = check_portfolio_cap(candidate_size=100.0, bankroll=10_000.0)
+    with pytest.raises(Exception):
+        d.decision = "deny"  # type: ignore[misc]
+
+
+# --- Helpers ------------------------------------------------------------------
+
+def test_is_finite_nonneg_basics():
+    assert _is_finite_nonneg(0.0)
+    assert _is_finite_nonneg(1.5)
+    assert not _is_finite_nonneg(-0.1)
+    assert not _is_finite_nonneg(float("nan"))
+    assert not _is_finite_nonneg(float("inf"))
+    assert not _is_finite_nonneg(float("-inf"))
+    assert not _is_finite_nonneg("nope")  # type: ignore[arg-type]
+
+
+# --- Defaults and config schema -----------------------------------------------
+
+def test_default_cap_pct_is_15_percent():
+    assert DEFAULT_TOTAL_CAP_PCT == 0.15
+
+
+def test_config_schema_keys():
+    assert set(PORTFOLIO_CAP_CONFIG_SCHEMA) == {
+        "portfolio_cap_enabled",
+        "portfolio_cap_pct",
+    }
+    enabled = PORTFOLIO_CAP_CONFIG_SCHEMA["portfolio_cap_enabled"]
+    assert enabled["default"] is False  # opt-in per ticket
+    assert enabled["type"] is bool
+    pct = PORTFOLIO_CAP_CONFIG_SCHEMA["portfolio_cap_pct"]
+    assert pct["default"] == DEFAULT_TOTAL_CAP_PCT
+
+
+# --- Concurrency safety -------------------------------------------------------
+
+def test_pure_function_is_thread_safe():
+    """Many threads against the same inputs must all return the same decision.
+
+    The primitive holds no mutable state, so this is really a tripwire: if
+    a future change introduces a module-level cache or a shared list, this
+    test will catch decision drift across workers.
+    """
+    positions = tuple({"current_value": v, "status": "active"} for v in (300.0, 400.0, 500.0))
+
+    def call(_i):
+        return check_portfolio_cap(
+            candidate_size=200.0,
+            bankroll=10_000.0,
+            open_positions=positions,
+            total_cap_pct=0.15,
+        )
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        results = list(ex.map(call, range(256)))
+
+    first = results[0]
+    # open = 300 + 400 + 500 = 1200, cap = 1500, headroom = 300, candidate 200 -> allow.
+    assert first.decision == "allow"
+    assert first.current_open_notional == pytest.approx(1200.0)
+    assert first.headroom == pytest.approx(300.0)
+    for r in results:
+        assert r.decision == first.decision
+        assert r.allowed_size == first.allowed_size
+        assert r.current_open_notional == first.current_open_notional
+        assert r.headroom == first.headroom
+
+
+def test_concurrent_at_cap_consistent_deny():
+    """All workers see the same at-cap state and return deny consistently."""
+    positions = ({"current_value": 1500.0, "status": "active"},)
+
+    def call(_i):
+        return check_portfolio_cap(
+            candidate_size=100.0,
+            bankroll=10_000.0,
+            open_positions=positions,
+            total_cap_pct=0.15,
+        )
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        results = list(ex.map(call, range(128)))
+
+    assert all(r.decision == "deny" for r in results)
+    assert all(r.reason == "at_cap" for r in results)
+    assert all(r.allowed_size == 0.0 for r in results)


### PR DESCRIPTION
## Summary

Adds `simmer_sdk.risk` — a portfolio-level concurrent-exposure cap that strategies call before order placement. Layered on top of the existing per-trade Kelly cap in `simmer_sdk.sizing`, the primitive sums open notional across all skills/strategies for an agent and returns `allow` / `deny` / `trim_to`.

- `simmer_sdk/risk/portfolio_cap.py` — `check_portfolio_cap(candidate_size, bankroll, *, open_positions | current_open_notional, total_cap_pct=0.15, agent_id)` returning a frozen `PortfolioCapDecision` with the size the caller may place + structured reason. Pure, fail-quiet on unfamiliar payloads (multi-venue), fail-closed on invalid bankroll/cap_pct.
- `sum_open_notional()` duck-types positions: SDK `Position` dataclass, dicts (`current_value` / `notional` / `open_notional`), raw numerics. Closed positions ignored.
- `PORTFOLIO_CAP_CONFIG_SCHEMA` — opt-in via env / config (default `False` per ticket spec).
- `tests/test_portfolio_cap.py` — 33 tests covering the three required paths + over-cap, exact-fit, NaN/inf inputs, ambiguous inputs, all position shapes, frozen-dataclass invariant, and a 16-worker `ThreadPoolExecutor` concurrency tripwire.
- `examples/portfolio_cap_skill.py` — canonical wiring pattern showing per-trade Kelly → `client.get_positions()` snapshot → `check_portfolio_cap` → place at `decision.allowed_size`. Documents the distinction from the SIM-1072 `DrawdownController` (separate ticket, separate concern).

## Distinction from `DrawdownController` (SIM-1072)

| Primitive | When | Source signal |
|---|---|---|
| `check_portfolio_cap` (this PR) | Pre-trade entry gate | Currently open notional / bankroll |
| `DrawdownController` (SIM-1072) | Pre-trade entry gate | Realized peak-to-trough P&L |

Both gate new entries; they answer different questions and are complementary. Wired explicitly in skills — neither runs implicitly inside the SDK.

## Test plan

- [x] `python3 -m pytest tests/test_portfolio_cap.py -x -q` — 33/33 pass
- [x] `python3 -m pytest tests/test_sizing.py tests/test_portfolio_cap.py -q` — 57/57 pass (no regression)
- [x] Top-level import smoke — `from simmer_sdk import check_portfolio_cap` works; round-trip via `Position` dataclass returns expected `at_cap` / `trim_to` / `under_cap` decisions
- [x] `examples/portfolio_cap_skill.py` parses and imports cleanly

Closes SIM-1451.