### PR TITLE
fix(redeem): whitelist new pUSD collateral adapters (0.13.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] — 2026-05-04
+
+### Fixed
+
+- **External-wallet auto-redeem failed with `Unsigned tx targets unknown
+  contract`.** Server-side SIM-1389/1421 (shipped 2026-05-03) routes
+  redemption through the new Polymarket collateral adapters
+  (`0xAdA100…` for binary, `0xadA200…` for neg-risk) so payouts land in
+  pUSD instead of USDC.e. The SDK's pre-flight contract whitelist on
+  `redeem()` only knew the legacy CTF + NegRiskAdapter addresses, so it
+  rejected every server-built unsigned tx targeting the new adapters.
+  Both new adapters expose the same selector (`0x01b7037c`) and ABI as
+  the legacy binary CTF, so the fix is a whitelist add — no signing
+  changes. Legacy entries stay in place so older server versions still
+  verify.
+
+  External-wallet users on `< 0.13.3` will keep hitting this until they
+  upgrade. Managed-wallet users were never affected (server signs +
+  broadcasts itself, no client-side validation).
+
 ## [0.13.2] — 2026-05-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.13.2"
+version = "0.13.3"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2555,10 +2555,20 @@ class SimmerClient:
 
         unsigned_tx = result["unsigned_tx"]
 
-        # Validate unsigned tx before signing
+        # Validate unsigned tx before signing.
+        #
+        # SIM-1389/1421 (server-side, 2026-05-03): redemption now routes through
+        # the new Polymarket collateral adapters by default — they pay out in
+        # pUSD instead of USDC.e. Both adapters expose the same selector
+        # (`0x01b7037c` — `redeemPositions(address,bytes32,bytes32,uint256[])`)
+        # as the legacy CTF, so we add their addresses with the same expected
+        # selector. The legacy CTF + legacy NegRiskAdapter entries stay so old
+        # server versions and any still-USDC.e-bound paths continue to verify.
         _REDEEM_CONTRACT_WHITELIST = {
             "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045".lower(): "0x01b7037c",   # CTF: redeemPositions(address,bytes32,bytes32,uint256[])
             "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296".lower(): "0xdbeccb23",   # NegRiskAdapter: redeemPositions(bytes32,uint256[])
+            "0xAdA100Db00Ca00073811820692005400218FcE1f".lower(): "0x01b7037c",   # CtfCollateralAdapter (SIM-1389): pays pUSD instead of USDC.e
+            "0xadA2005600Dec949baf300f4C6120000bDB6eAab".lower(): "0x01b7037c",   # NegRiskCtfCollateralAdapter (SIM-1421): same selector + ABI as binary
         }
         tx_to = unsigned_tx.get("to", "")
         if not tx_to or tx_to.lower() not in _REDEEM_CONTRACT_WHITELIST:


### PR DESCRIPTION
## Summary
External-wallet auto-redeem failing for every position with `Unsigned tx targets unknown contract`. Cody alert: $78.32 stuck across 6 wallets, growing.

**Root cause**: Server-side SIM-1389 + SIM-1421 (shipped 2026-05-03) routed redemption through the new pUSD collateral adapters by default. The SDK's pre-flight contract whitelist on `redeem()` (client.py:2559) only knew the legacy CTF + NegRiskAdapter addresses → every server-built unsigned tx targeting the new adapters was rejected before signing.

## What changed
- Add `CtfCollateralAdapter` (`0xAdA100…`) and `NegRiskCtfCollateralAdapter` (`0xadA200…`) to `_REDEEM_CONTRACT_WHITELIST`
- Both expose the same selector `0x01b7037c` and ABI as the legacy binary CTF — selector validation works unchanged
- Legacy entries stay in place so older server versions continue to verify
- Bump `0.13.2` → `0.13.3`
- CHANGELOG entry

## Scope + impact
- **External-wallet users on `< 0.13.3`** keep hitting this until they upgrade
- **Managed-wallet users** were never affected (server signs + broadcasts itself, no client-side validation)
- Funds-adjacent display: trades correct on-chain, redemption path correct on server, client refused to sign → payouts didn't happen. After upgrade + next auto-redeem cycle, stuck positions redeem normally.

## Test plan
- [ ] PyPI publish 0.13.3
- [ ] User with stuck redemptions upgrades → auto-redeem loop succeeds on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)