### PR TITLE
feat(sdk): surface failed trades via WARNING log + SKILL.md success-check (0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] — 2026-05-04
+
+### Added
+
+- **`client.trade()` now logs failures at `WARNING`.** When a real-trading
+  trade returns `success=False` with an `error`, the SDK emits
+  `logger.warning("Trade failed on <venue>: <error>")` before returning the
+  result. Bots that don't explicitly check `result.success` previously
+  looped silently when upstream venues rejected orders (observed
+  2026-05-04: a user's bot logged 72 failed Polymarket trades over 17h
+  without a single visible signal because the harness only printed on
+  exception). Bots that already check `result.success` see no behavior
+  change beyond the extra log line. Suppress with
+  `logging.getLogger("simmer_sdk.client").setLevel(logging.ERROR)`.
+
+### Changed
+
+- **`skills/simmer/SKILL.md`** trade example now demonstrates the
+  `if not result.success` check that idiomatic bots should perform —
+  catches the same class of silent-failure bug at the documentation
+  layer for LLM-driven agents loading the skill.
+
 ## [0.13.3] — 2026-05-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.13.3"
+version = "0.14.0"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1325,6 +1325,14 @@ class SimmerClient:
             elif action == "sell":
                 # Remove from cache so subsequent buys aren't blocked
                 self._held_markets_cache.pop(market_id, None)
+        elif not result.success and result.error:
+            # Surface failures to bots that don't check result.success themselves.
+            # A silent loop of failing trades (e.g. upstream creds rejected) can
+            # otherwise run for hours unnoticed — this gives any bot using stdlib
+            # logging a stderr signal at WARNING level on the first failure.
+            logger.warning(
+                "Trade failed on %s: %s", effective_venue, result.error
+            )
         return result
 
     # Default half-spread for Polymarket paper trades (in probability units).

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -73,6 +73,12 @@ result = client.trade(
     markets[0].id, "yes", 10.0,
     reasoning="NOAA forecasts 35°F, bucket underpriced",
 )
+
+# Always check result.success — client.trade() returns a TradeResult on
+# failure (with result.error set), it does NOT raise. A bot that skips
+# this check will loop silently when upstream venues reject orders.
+if not result.success:
+    print(f"Trade failed: {result.error}")
 ```
 
 `reasoning=` is optional in the API but expected by convention — it's displayed publicly on the trade page.

--- a/tests/test_failed_trade_logging.py
+++ b/tests/test_failed_trade_logging.py
@@ -1,0 +1,89 @@
+"""Tests for the failed-trade WARNING log added in 0.14.0.
+
+Bots that don't check `result.success` previously looped silently when the
+upstream venue rejected orders. The SDK now emits `logger.warning` whenever
+`client.trade()` returns `success=False` with an `error` set, so any bot
+using stdlib logging gets a stderr signal on the first failure.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_client(venue="polymarket"):
+    """Build a SimmerClient with mocked _request for trade() unit tests."""
+    client = SimmerClient.__new__(SimmerClient)
+    client._agent_id = "test-agent"
+    client._ows_wallet = None
+    client._wallet_address = None
+    client._private_key = None
+    client.base_url = "https://api.simmer.markets"
+    client.live = True
+    client.venue = venue
+    client._held_markets_cache = None
+    client._request = MagicMock()
+    client._get_held_markets = MagicMock(return_value={})
+    return client
+
+
+def test_logs_warning_on_failed_real_trade(caplog):
+    """A failed Polymarket trade emits one WARNING log with the venue + error."""
+    client = _make_client(venue="polymarket")
+    client._request.return_value = {
+        "success": False,
+        "market_id": "test-market",
+        "side": "yes",
+        "error": "Unauthorized/Invalid api key",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        result = client.trade("test-market", "yes", amount=10.0)
+
+    assert result.success is False
+    assert result.error == "Unauthorized/Invalid api key"
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "polymarket" in warnings[0].getMessage()
+    assert "Unauthorized/Invalid api key" in warnings[0].getMessage()
+
+
+def test_does_not_log_on_successful_trade(caplog):
+    """A successful trade emits no WARNING."""
+    client = _make_client(venue="polymarket")
+    client._request.return_value = {
+        "success": True,
+        "market_id": "test-market",
+        "side": "yes",
+        "shares_bought": 5.0,
+        "cost": 2.5,
+        "fill_status": "filled",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        result = client.trade("test-market", "yes", amount=10.0)
+
+    assert result.success is True
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == []
+
+
+def test_does_not_log_when_failure_has_no_error(caplog):
+    """If the server returns success=False without an error string, suppress
+    the log — there's nothing useful to print, and we don't want to fire on
+    any default-False response shape."""
+    client = _make_client(venue="polymarket")
+    client._request.return_value = {
+        "success": False,
+        "market_id": "test-market",
+        "side": "yes",
+        "error": None,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        result = client.trade("test-market", "yes", amount=10.0)
+
+    assert result.success is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == []


### PR DESCRIPTION
## Summary

A user (Levi / `eddie-genesis-fresh`) ran a Polymarket bot for 17 hours that logged 72 failed trades with $0 settled — and reported on Telegram that "all trades passed on Simmer." The DB knew. The user didn't. The harness only printed on exception, the SDK returned silent `success=False` results, and his agent didn't check `result.success`.

Two additive guardrails so this fails loudly next time without changing existing behavior for bots that already check `result.success`:

1. **`client.trade()` now logs failures at WARNING.** When a real-trading path returns `success=False` with an `error` set, the SDK emits `logger.warning("Trade failed on <venue>: <error>")` before returning. Stdlib logging is on by default in most harnesses, so even sloppy bots get a stderr signal on the first failure. Suppress with `logging.getLogger("simmer_sdk.client").setLevel(logging.ERROR)`.

2. **`skills/simmer/SKILL.md` trade example now demonstrates `if not result.success`.** LLM-driven agents loading the primary skill see the idiomatic check.

Bumps to **0.14.0** — minor, since the new log line is a behavioral addition even though the wire API is unchanged.

## Companion PR

`SupaFund/simmer#<TBD>` adds a `/api/sdk/briefing` warning ("X failed real trades in last 6h with 0 successes…") so heartbeat-driven bots also surface this. The two changes are independent — either ships standalone.

## Test plan

- [x] `pytest tests/` — 135 passing (3 new in `test_failed_trade_logging.py` covering warn-on-failure, no-warn-on-success, no-warn-when-error-is-None)
- [x] Pre-existing `test_client_constructors.py::test_from_env_happy_path_all_three_vars` still fails on this branch (OWS env-setup issue on `origin/main`, unrelated)
- [ ] After merge: `pip install -U simmer-sdk==0.14.0` in a real harness, run a known-failing trade (e.g. against an unfunded wallet), confirm WARNING line shows up in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)