### PR TITLE
chore(skills): simmer 1.23.2 — publish result.success guidance

### DIFF
--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context. Start here.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.23.1"
+  version: "1.23.2"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"


### PR DESCRIPTION
## Summary

PR #55 added the \`if not result.success\` check to \`skills/simmer/SKILL.md\` but didn't bump the version, so ClawHub stayed at 1.23.1 (without the new copy). Bumps to 1.23.2 so \`npx clawhub publish\` picks up the doc change.

No code change; just publishes the guidance that's already in main.

## Test plan

- [ ] After merge: \`npx clawhub publish skills/simmer --version 1.23.2\` from simmer-sdk root
- [ ] Verify with \`npx clawhub inspect simmer\` — should show \`Latest: 1.23.2\`
- [ ] Sync \`website/public/skill.md\` in simmer repo (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)