### PR TITLE
feat(sdk): external-wallet auto-recover from stale CLOB creds (0.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] — 2026-05-04
+
+### Added
+
+- **External-wallet auto-recovery from stale CLOB credentials.** When
+  Polymarket rejects a trade with `Unauthorized` / `Invalid api key` (most
+  often after Polymarket rotates server-side creds, as happened during
+  the 2026-04-28 V2 cutover), `client.trade()` now resets its internal
+  `_clob_creds_registered` cache, re-runs `_ensure_clob_credentials()`
+  (which derives locally with the user's private key / OWS wallet and
+  re-registers with Simmer), and retries the trade once. Single retry
+  only — if the retry also fails the original error is surfaced.
+
+  The simmer server clears its cached encrypted creds on the same
+  condition (`scripts/local_dev_server.py` external-wallet path), so the
+  re-derive's server-side existence check returns false and forces a
+  fresh derive. Previously only the managed-wallet path had this
+  recovery (line ~19940 of the same file); external wallets sat in a
+  silent retry loop, last seen 2026-05-04 with 4 wallets stuck on the
+  Polymarket V2 cutover with 0 successes in 6h.
+
+  Managed wallets unaffected (server-side recovery already exists).
+  Sim/Kalshi venues unaffected.
+
 ## [0.14.0] — 2026-05-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.14.0"
+version = "0.14.1"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1294,26 +1294,62 @@ class SimmerClient:
             json=payload
         )
 
-        # Extract balance: only meaningful for simmer venue ($SIM balance)
-        # Polymarket/Kalshi trades don't return a balance (use get_portfolio() instead)
-        position = data.get("position") or {}
-        balance = position.get("sim_balance") if effective_venue == "sim" else None
+        # Build TradeResult from a server response. Extracted as a closure so
+        # the cred-recovery retry path below can rebuild from a second response
+        # without duplicating the field mapping. Sim-venue is the only one that
+        # returns a balance (in `position.sim_balance`); real venues use
+        # get_portfolio() instead.
+        def _build_result(d):
+            _pos = d.get("position") or {}
+            _bal = _pos.get("sim_balance") if effective_venue == "sim" else None
+            return TradeResult(
+                success=d.get("success", False),
+                trade_id=d.get("trade_id"),
+                market_id=d.get("market_id", market_id),
+                side=d.get("side", side),
+                venue=effective_venue,
+                shares_bought=d.get("shares_bought", 0),
+                shares_requested=d.get("shares_requested", 0),
+                order_status=d.get("order_status"),
+                cost=d.get("cost", 0),
+                new_price=d.get("new_price", 0),
+                balance=_bal,
+                error=d.get("error"),
+                fill_status=d.get("fill_status", "unknown"),
+            )
 
-        result = TradeResult(
-            success=data.get("success", False),
-            trade_id=data.get("trade_id"),
-            market_id=data.get("market_id", market_id),
-            side=data.get("side", side),
-            venue=effective_venue,
-            shares_bought=data.get("shares_bought", 0),
-            shares_requested=data.get("shares_requested", 0),
-            order_status=data.get("order_status"),
-            cost=data.get("cost", 0),
-            new_price=data.get("new_price", 0),
-            balance=balance,
-            error=data.get("error"),
-            fill_status=data.get("fill_status", "unknown"),
-        )
+        result = _build_result(data)
+
+        # Auto-recover from stale CLOB creds (Polymarket rotated server-side or
+        # rejected our cached creds). Only relevant for external/OWS Polymarket
+        # — managed wallets re-derive server-side on the same error. The server
+        # NULLs its cached creds on this same condition, so our next call to
+        # _ensure_clob_credentials() finds has_credentials=False and triggers a
+        # local re-derive + register. We bypass the SDK's own one-shot cache
+        # (`_clob_creds_registered`) by resetting it. Single retry only — if
+        # the retry also fails, surface the original style of error.
+        if (not result.success and result.error
+                and effective_venue == "polymarket"
+                and (self._private_key or self._ows_wallet)):
+            err_lower = result.error.lower()
+            if "unauthorized" in err_lower or "invalid api key" in err_lower:
+                logger.warning(
+                    "Polymarket rejected CLOB creds — re-deriving and retrying once"
+                )
+                try:
+                    self._clob_creds_registered = False
+                    self._ensure_clob_credentials()
+                    retry_data = self._request(
+                        "POST", "/api/sdk/trade", json=payload
+                    )
+                    result = _build_result(retry_data)
+                    if result.success:
+                        logger.info("Trade succeeded after cred re-derive")
+                except Exception as retry_err:
+                    logger.warning(
+                        "Cred re-derive + retry failed: %s", retry_err
+                    )
+
         if result.success and self._held_markets_cache is not None:
             if action == "buy":
                 # Update cache locally instead of nuking — avoids a fresh GET /positions

--- a/tests/test_cred_recovery_retry.py
+++ b/tests/test_cred_recovery_retry.py
@@ -1,0 +1,139 @@
+"""Tests for the external-wallet stale-creds auto-recovery added in 0.14.1.
+
+When Polymarket rejects a trade with Unauthorized / Invalid api key, the SDK
+should reset its registered-creds cache, re-derive locally, register with
+the server, and retry the trade once.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_external_client(venue="polymarket"):
+    """SimmerClient with external private key — exercises the retry path."""
+    client = SimmerClient.__new__(SimmerClient)
+    client._agent_id = "test-agent"
+    client._ows_wallet = None
+    client._wallet_address = "0x1234567890abcdef1234567890abcdef12345678"
+    client._private_key = "0x" + "a" * 64
+    client.base_url = "https://api.simmer.markets"
+    client.live = True
+    client.venue = venue
+    client._held_markets_cache = None
+    client._clob_creds_registered = True  # simulate already-registered state
+    client._request = MagicMock()
+    client._get_held_markets = MagicMock(return_value={})
+    client._ensure_clob_credentials = MagicMock()
+    client._ensure_wallet_linked = MagicMock()
+    client._warn_approvals_once = MagicMock()
+    client._build_signed_order = MagicMock(return_value=None)  # skip signing in tests
+    client._is_agent_wallet_registered = MagicMock(return_value=False)
+    return client
+
+
+def test_retries_on_unauthorized_and_succeeds(caplog):
+    """Polymarket → Unauthorized; SDK re-derives + retries; second call succeeds."""
+    client = _make_external_client()
+    client._request.side_effect = [
+        {"success": False, "market_id": "m1", "side": "yes", "error": "Unauthorized/Invalid api key"},
+        {"success": True, "market_id": "m1", "side": "yes",
+         "shares_bought": 5.0, "cost": 2.0, "fill_status": "filled"},
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        result = client.trade("m1", "yes", amount=10.0)
+
+    # Reset + re-derive happened
+    assert client._clob_creds_registered is False
+    client._ensure_clob_credentials.assert_called_once()
+    # Two POST attempts — original + retry
+    assert client._request.call_count == 2
+    # Final result is the retry's success
+    assert result.success is True
+    assert result.shares_bought == 5.0
+    # Warning logged for the recovery attempt
+    msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("re-deriving" in m for m in msgs)
+
+
+def test_retries_on_unauthorized_and_retry_also_fails():
+    """Both attempts fail with Unauthorized — only one retry, then surface the error."""
+    client = _make_external_client()
+    client._request.side_effect = [
+        {"success": False, "market_id": "m1", "side": "yes", "error": "Unauthorized"},
+        {"success": False, "market_id": "m1", "side": "yes", "error": "Unauthorized"},
+    ]
+
+    result = client.trade("m1", "yes", amount=10.0)
+
+    assert client._request.call_count == 2  # exactly one retry, no infinite loop
+    assert result.success is False
+    assert "unauthorized" in (result.error or "").lower()
+
+
+def test_does_not_retry_on_non_auth_error():
+    """A liquidity / balance / signature error should NOT trigger the retry path."""
+    client = _make_external_client()
+    client._request.return_value = {
+        "success": False, "market_id": "m1", "side": "yes",
+        "error": "FAK order not filled at price 0.40 — no liquidity at this price.",
+    }
+
+    result = client.trade("m1", "yes", amount=10.0)
+
+    assert client._request.call_count == 1
+    client._ensure_clob_credentials.assert_not_called()
+    assert client._clob_creds_registered is True  # unchanged
+    assert result.success is False
+
+
+def test_does_not_retry_for_managed_wallet():
+    """Managed-wallet clients (no private_key, no ows_wallet) skip this retry —
+    the server handles their re-derive on its own end."""
+    client = _make_external_client()
+    client._private_key = None  # managed
+    client._ows_wallet = None
+    client._request.return_value = {
+        "success": False, "market_id": "m1", "side": "yes",
+        "error": "Unauthorized/Invalid api key",
+    }
+
+    result = client.trade("m1", "yes", amount=10.0)
+
+    assert client._request.call_count == 1
+    client._ensure_clob_credentials.assert_not_called()
+    assert result.success is False
+
+
+def test_does_not_retry_for_sim_venue():
+    """Sim trades can't hit CLOB-creds errors; if they somehow returned an
+    Unauthorized string, the retry path should still skip them."""
+    client = _make_external_client(venue="sim")
+    client._request.return_value = {
+        "success": False, "market_id": "m1", "side": "yes",
+        "error": "Unauthorized",
+    }
+
+    result = client.trade("m1", "yes", amount=10.0)
+
+    assert client._request.call_count == 1
+    client._ensure_clob_credentials.assert_not_called()
+
+
+def test_retry_swallows_exception_in_re_derive():
+    """If _ensure_clob_credentials throws during the retry attempt, the
+    original failure is surfaced — we don't propagate the recovery exception."""
+    client = _make_external_client()
+    client._request.return_value = {
+        "success": False, "market_id": "m1", "side": "yes",
+        "error": "Unauthorized",
+    }
+    client._ensure_clob_credentials.side_effect = RuntimeError("derive blocked")
+
+    result = client.trade("m1", "yes", amount=10.0)
+
+    assert client._request.call_count == 1  # retry never fired
+    assert result.success is False
+    assert "unauthorized" in (result.error or "").lower()


### PR DESCRIPTION
## Summary

Closes the long-standing parity gap that left 4 external-wallet users in a silent retry loop today (the SIM-1237 cohort post-Polymarket V2 cutover):

- **Managed wallets** auto-recover from stale CLOB creds at \`scripts/local_dev_server.py:19940\` — server holds the private key, so it can re-derive in the same trade call.
- **External wallets** had no equivalent — server can't re-derive without the private key, so cached-but-rejected creds caused 72-failure-zero-success loops with no path to recovery.

## What changes

\`client.trade()\` now detects \`Unauthorized\` / \`Invalid api key\` in the response (only on Polymarket external/OWS wallets), resets the SDK's internal \`_clob_creds_registered\` cache, calls \`_ensure_clob_credentials()\` (which derives locally with the user's private key + registers fresh creds with Simmer), and retries the trade once. Single retry — if that also fails, the original error surfaces.

The companion server PR (\`SupaFund/simmer#<TBD>\`) NULLs cached encrypted creds on the same condition so the SDK's existence check returns false on the retry attempt and forces a fresh derive.

## Behavior matrix

| Scenario | Action |
|---|---|
| External Polymarket trade returns \`Unauthorized\` | Reset cache, re-derive locally, retry once |
| External Polymarket trade returns other error (liquidity, balance, signature) | No retry, return original error |
| Managed Polymarket wallet returns \`Unauthorized\` | No retry from SDK — server already handles this path |
| Sim or Kalshi venue | No retry (path is Polymarket-only) |
| Both attempts fail \`Unauthorized\` | Single retry, surface failure (no infinite loop) |
| \`_ensure_clob_credentials\` itself raises | Swallow, surface original failure |

## Test plan

- [x] \`pytest tests/\` — 141 passing (6 new in \`test_cred_recovery_retry.py\`)
- [x] Pre-existing OWS env-setup failure on \`test_client_constructors.py\` unrelated, exists on \`origin/main\`
- [ ] After merge + PyPI publish + Polymarket rate-limit lift: spot-check one of the 4 stuck wallets recovers automatically without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)