### PR TITLE
fix(redeem): raise gas cap 500k → 1.5M for adapter calls (0.14.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] — 2026-05-04
+
+### Fixed
+
+- **`Gas limit too high (XXX), max 500000`** on external-wallet auto-redeem
+  for the new pUSD collateral adapters added in 0.13.3. The 500k cap was
+  set when redemption hit `CTF.redeemPositions` directly (~150-300k). The
+  new `CtfCollateralAdapter` / `NegRiskCtfCollateralAdapter` do extra
+  on-chain work (USDC.e wrap → CTF burn → pUSD mint) that legitimately
+  consumes 500-1000k gas. weather-trader999 reported a wave of failures
+  with `eth_estimateGas`-derived budgets of 502k–956k getting clipped.
+  Cap raised to 1.5M, which gives ~50% headroom for the heaviest adapter
+  calls while still guarding against pathological estimates (1.5M @
+  ~30 gwei ≈ 0.045 POL ≈ $0.01 worst case).
+
+  External-wallet users on `0.13.3` / `0.14.0` / `0.14.1` need
+  `pip install --upgrade simmer-sdk` to pick this up. Note: a parallel
+  server-side fix landed in simmer PR #491 — `/api/sdk/wallet/broadcast-tx`
+  had the same legacy whitelist gap and rejected adapter txs; the
+  dashboard ships that automatically.
+
 ## [0.14.1] — 2026-05-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.14.1"
+version = "0.14.2"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2643,9 +2643,19 @@ class SimmerClient:
         else:
             tx_gas = int(unsigned_tx.get("gas", 300_000))
 
-        # Cap gas limit to prevent POL drain
-        if tx_gas > 500_000:
-            return {"success": False, "error": f"Gas limit too high ({tx_gas}), max 500000"}
+        # Cap gas limit to prevent POL drain.
+        #
+        # 2026-05-04: raised from 500k to 1.5M. The new pUSD collateral
+        # adapters (added to whitelist in 0.13.3) do extra on-chain work —
+        # USDC.e wrap → CTF burn → pUSD mint — that legitimately consumes
+        # 500-1000k gas. weather-trader999 reported a wave of "Gas limit
+        # too high" failures with eth_estimateGas-derived budgets of
+        # 502k–956k for adapter redemptions; all were honest estimates
+        # the old cap was clipping. 1.5M gives ~50% headroom for the
+        # heaviest adapter calls while still guarding against pathological
+        # estimates (1.5M @ ~30 gwei ≈ 0.045 POL ≈ $0.01 worst case).
+        if tx_gas > 1_500_000:
+            return {"success": False, "error": f"Gas limit too high ({tx_gas}), max 1500000"}
 
         nonce = int(_rpc_call("eth_getTransactionCount", [self._wallet_address, "pending"]) or "0x0", 16)
 


### PR DESCRIPTION
## Summary
Continuation of 0.13.3 (whitelist fix). The 500k gas cap dated from when redemption called \`CTF.redeemPositions\` directly (~150-300k). The new pUSD collateral adapters routed through in 0.13.3 do extra on-chain work (USDC.e wrap → CTF burn → pUSD mint) that legitimately consumes 500-1000k gas.

User report: wave of \`Gas limit too high (XXX), max 500000\` failures. Estimates from the log: 502k, 540k, 578k, 617k, 878k, 956k — all honest \`eth_estimateGas\`-derived numbers being clipped.

## Fix
Cap raised to 1.5M:
- Covers the heaviest observed adapter call (956k) + ~50% headroom
- 1.5M @ ~30 gwei ≈ 0.045 POL ≈ $0.01 worst-case POL drain — still a meaningful guardrail, just calibrated to actual adapter cost

## Test plan
- [ ] PyPI publish 0.14.1
- [ ] User upgrades → next auto-redeem cycle clears stuck adapter redemptions
- [ ] Companion server-side whitelist fix lands separately (handled by dashboard auto-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)