### PR TITLE
fix(0.15.1): NO sells use live orderbook price (SIM-1560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] — 2026-05-06
+
+### Fixed
+
+- **NO-side sells silently failing on V2 neg-risk markets** when `client.trade(side='no', action='sell')` is called without an explicit `price`. The SDK previously derived the limit price from the V1 binary identity `1 - external_price_yes`, which is correct for V1 binary markets and non-neg-risk V2 binaries (CTF redemption keeps the two outcome tokens tightly arbitraged) but **wrong on V2 neg-risk markets** — there YES and NO are independent CLOB tokens with independent orderbooks, so the V1-derived price often sits far above the actual NO best bid. Result: GTC orders never matched and stoplosses sat pending until the market resolved. Reported by mt_1200 (weather-trader999) on 2026-05-02 ($5.54 NO position lost in Atlanta-64-65°F when stoploss tried to exit at price=0.999 ten+ times) and again on 2026-05-06 (multiple stuck stoploss exits).
+
+  The SDK now queries the live orderbook via the new `/api/sdk/markets/{id}/executable-price` server endpoint and uses the returned best bid (SELL) or best ask (BUY) — with a one-tick buffer applied — for any Polymarket trade where `price` was not explicitly provided. The V1 fallback remains for the case where the executable-price endpoint is unreachable (older server, network hiccup) but is no longer the primary path.
+
+  **Workaround on older versions**: pass an explicit `price=<actual_no_bid>` to `client.trade()` until you can upgrade.
+
+  SIM-1560.
+
 ## [0.15.0] — 2026-05-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3098,14 +3098,37 @@ class SimmerClient:
         if not token_id:
             raise ValueError(f"Market {market_id} does not have Polymarket token IDs")
 
-        # Get price - use custom price if provided, otherwise fetch from market data
+        # Get price — use caller-provided price first, otherwise query the live
+        # orderbook for the side+action being traded. SIM-1560: the prior fallback
+        # used the V1 binary identity `1 - external_price_yes` for NO-side trades,
+        # which is wrong on V2 neg-risk markets where YES and NO are independent
+        # CLOB tokens with independent orderbooks. /api/sdk/markets/{id}/executable-price
+        # wraps the server's orderbook helper and returns the actual best bid (SELL)
+        # or best ask (BUY) for the side's CLOB token, with a one-tick buffer applied
+        # so the order crosses the spread.
         if price is None:
-            # Fetch current market price for the side
-            if side.lower() == "yes":
-                price = market_data.get("external_price_yes") or 0.5
-            else:
-                external_yes = market_data.get("external_price_yes") or 0.5
-                price = 1.0 - external_yes
+            try:
+                exec_resp = self._request(
+                    "GET",
+                    f"/api/sdk/markets/{market_id}/executable-price",
+                    params={"side": side.lower(), "action": action.lower(), "apply_buffer": "true"},
+                )
+                if isinstance(exec_resp, dict) and exec_resp.get("success") and exec_resp.get("price") is not None:
+                    price = float(exec_resp["price"])
+            except Exception:
+                price = None  # Fall through to legacy fallback
+
+            if price is None:
+                # Legacy fallback: V1 binary identity. Correct for non-neg-risk
+                # binary markets where the CTF redemption keeps `NO = 1 - YES`
+                # tightly arbitraged. Wrong for neg-risk markets — the executable
+                # endpoint above is the canonical path; this fires only when the
+                # endpoint is unreachable (older server, network hiccup).
+                if side.lower() == "yes":
+                    price = market_data.get("external_price_yes") or 0.5
+                else:
+                    external_yes = market_data.get("external_price_yes") or 0.5
+                    price = 1.0 - external_yes
 
             # Clamp price to valid range to avoid division issues
             if price <= 0 or price >= 1:


### PR DESCRIPTION
## Summary

Companion to [simmer PR #548](https://github.com/SupaFund/simmer/pull/548). When `client.trade(side='no', action='sell', price=None)` is called for a Polymarket trade, the SDK previously derived the limit price from `1 - external_price_yes` (V1 binary identity). Wrong on V2 neg-risk markets — YES and NO are independent CLOB tokens with independent orderbooks, so the V1-derived price sits far above the actual NO best bid → orders never match → stoplosses sit pending until resolution.

Now: SDK calls `GET /api/sdk/markets/{id}/executable-price?side=...&action=...` (the new server endpoint shipped in #548) and uses the returned best bid (SELL) / best ask (BUY) with a one-tick buffer. V1 fallback remains for the case where the endpoint is unreachable (older server, network hiccup) but is no longer the primary path.

Reported by mt_1200 (weather-trader999) on 2026-05-02 ($5.54 NO position lost in Atlanta-64-65°F) and again on 2026-05-06 (multiple stuck stoploss exits). SIM-1329 covers the silent-fill retry-loop class that this partially explains.

**Workaround on older versions**: pass an explicit `price=<actual_no_bid>` to `client.trade()` until you can upgrade.

- Bumps version 0.14.2 → 0.14.3
- Updates CHANGELOG with the bug, the fix, and the workaround

Refs SIM-1560.

## Test plan

- [x] `simmer_sdk/client.py` parses cleanly
- [ ] Land + deploy server PR #548 first
- [ ] Then merge this, publish 0.14.3 to PyPI
- [ ] mt_1200 to test stuck stoploss path on a neg-risk V2 market post-publish
- [ ] Verify V1 fallback path still works (e.g., point SDK at an older server that lacks the endpoint and confirm graceful degradation, not an exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)