### PR TITLE
feat(0.16.0): pass confirm_replace_managed=False on auto-relink (SIM-1580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] — 2026-05-06
+
+### Changed
+
+- **Auto-relink no longer silently replaces a managed wallet.** When `_ensure_wallet_linked` (the implicit per-trade auto-link path) detects a mismatch between the local key's address and the server's wallet, it now passes `confirm_replace_managed=false` to `/api/sdk/wallet/link`. The paired server-side guard (SIM-1580) rejects the request with a clear 4xx if the displacement would replace an existing managed wallet — instead of silently moving the managed wallet to legacy and oscillating the account state.
+
+  Surfaced by wongc305@: account migrated from external to a managed deposit wallet via CTO one-off, but his bot env still had `WALLET_PRIVATE_KEY` set. Each trade triggered auto-relink → server flipped back to external with the old (Polymarket-blocklisted) address. ~85 trades over 5 days, 83 failed at Polymarket. Same failure mode would reproduce for every `/v2-setup-wizard` external→managed migration without bot reconfiguration.
+
+  After this version, that misconfig produces a loud, actionable error in the bot's trade response: `"This account already has a managed wallet... remove WALLET_PRIVATE_KEY (and OWS_WALLET if set) from its environment and restart"`. No more silent oscillation.
+
+  Explicit `client.link_wallet()` calls default to `confirm_replace_managed=True` (the user signalled intent to take self-custody), so legitimate managed→external switches still work without changes. Pass `confirm_replace_managed=False` explicitly if you want the safe default.
+
+  SIM-1580 / paired with simmer/PR #559.
+
 ## [0.15.1] — 2026-05-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.15.1"
+version = "0.16.0"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -791,9 +791,20 @@ class SimmerClient:
         # Wallet not linked - attempt to link automatically. link_wallet()
         # calls _ensure_clob_credentials() internally on success, so don't
         # call it again here.
+        #
+        # SIM-1580: pass confirm_replace_managed=False on this implicit
+        # auto-link path so a stale WALLET_PRIVATE_KEY (or OWS_WALLET) left
+        # in a bot env after a managed-mode migration cannot silently
+        # displace the managed wallet. The server-side guard (PR adding the
+        # `confirm_replace_managed` field on /wallet/link) returns a clear
+        # 4xx with WALLET_PRIVATE_KEY remediation guidance — surfaces the
+        # misconfig loud instead of silently oscillating production state.
+        # Explicit user calls to client.link_wallet() default to True (see
+        # method signature) since the user signalled intent to take
+        # self-custody.
         print(f"Auto-linking wallet {self._wallet_address[:10]}... to Simmer account...")
         try:
-            result = self.link_wallet(signature_type=0)
+            result = self.link_wallet(signature_type=0, confirm_replace_managed=False)
             if result.get("success"):
                 self._wallet_linked = True
                 print("Wallet linked successfully")
@@ -3383,7 +3394,11 @@ class SimmerClient:
                 self._held_markets_cache.pop(market_id, None)
         return result
 
-    def link_wallet(self, signature_type: int = 0) -> Dict[str, Any]:
+    def link_wallet(
+        self,
+        signature_type: int = 0,
+        confirm_replace_managed: bool = True,
+    ) -> Dict[str, Any]:
         """
         Link an external wallet to your Simmer account.
 
@@ -3396,6 +3411,16 @@ class SimmerClient:
                 - 0: EOA (standard wallet, default)
                 - 1: Polymarket proxy wallet
                 - 2: Gnosis Safe
+            confirm_replace_managed: When `True` (default), opt into replacing
+                an existing managed wallet on this account with the external
+                wallet you're linking. Defaulting `True` here matches the user
+                intent of an explicit `client.link_wallet()` call ("I want
+                self-custody"). The implicit auto-relink path inside the SDK
+                (`_ensure_wallet_linked`) overrides this to `False` so a stale
+                `WALLET_PRIVATE_KEY` left in a bot env after a managed-mode
+                migration cannot silently displace the managed wallet — the
+                relink fails loud with an actionable 4xx instead. Server-side
+                guard: SIM-1580.
 
         Returns:
             Dict with success status and wallet info. When `success` is True,
@@ -3469,7 +3494,8 @@ class SimmerClient:
                 "address": self._wallet_address,
                 "signature": signature,
                 "nonce": nonce,
-                "signature_type": signature_type
+                "signature_type": signature_type,
+                "confirm_replace_managed": confirm_replace_managed,
             }
         )
 

--- a/tests/test_link_wallet_confirm_replace_managed.py
+++ b/tests/test_link_wallet_confirm_replace_managed.py
@@ -1,0 +1,136 @@
+"""Tests for the SIM-1580 confirm_replace_managed flag in client.link_wallet.
+
+The flag pairs with a server-side guard on `/api/sdk/wallet/link` that
+prevents silent overwrite of a managed wallet by simmer-sdk's
+`_ensure_wallet_linked` auto-relink path. The intent split is:
+
+  - Explicit `client.link_wallet()` → user-driven self-custody → flag True
+  - Implicit `_ensure_wallet_linked` → auto-relink on local-key mismatch
+    → flag False (so a stale WALLET_PRIVATE_KEY in a bot env after a
+    managed-mode migration cannot silently displace the managed wallet
+    — the relink fails loud with a 4xx instead).
+
+These tests pin the contract so a future refactor can't quietly invert
+either side and re-open the wongc305@ failure mode.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+from simmer_sdk.client import SimmerClient
+
+
+CLIENT_PATH = Path(__file__).parent.parent / "simmer_sdk" / "client.py"
+
+
+def _client_source() -> str:
+    return CLIENT_PATH.read_text()
+
+
+# =============================================================================
+# Method signature
+# =============================================================================
+
+
+def test_link_wallet_accepts_confirm_replace_managed():
+    """Public method signature must accept the flag — without this, no
+    caller can opt into replacement and the server-side guard becomes a
+    permanent block on legitimate managed→external switches."""
+    sig = inspect.signature(SimmerClient.link_wallet)
+    assert "confirm_replace_managed" in sig.parameters, (
+        "SimmerClient.link_wallet must accept confirm_replace_managed — "
+        "removing it breaks the legitimate managed→external switch flow."
+    )
+
+
+def test_link_wallet_default_is_true():
+    """Default MUST be True for explicit user calls. An explicit
+    `client.link_wallet()` is a self-custody intent statement; defaulting
+    False here would surprise users who switched to self-custody before
+    SIM-1580 and break their existing flows on upgrade. The auto-relink
+    path overrides to False (asserted below) — that's where the safe
+    default lives, not on the public method."""
+    sig = inspect.signature(SimmerClient.link_wallet)
+    default = sig.parameters["confirm_replace_managed"].default
+    assert default is True, (
+        f"link_wallet() default for confirm_replace_managed must be True "
+        f"(explicit user call = self-custody intent). Got {default!r}. "
+        f"Defaulting False would break existing user flows on upgrade."
+    )
+
+
+# =============================================================================
+# Wire format — flag must reach the server
+# =============================================================================
+
+
+def test_link_wallet_sends_flag_in_request_body():
+    """The flag must be in the POST body — adding it to the signature but
+    not the body would mean the server defaults the flag to False (its
+    server-side default) and the explicit user call ALSO hits the guard."""
+    src = _client_source()
+    # Find the link_wallet method body and look at the json= payload.
+    method_body = re.search(
+        r"def link_wallet\([\s\S]*?(?=\n    def |\nclass )",
+        src,
+    )
+    assert method_body, "Could not isolate link_wallet method body"
+    body = method_body.group(0)
+
+    # The /wallet/link POST must include confirm_replace_managed in json.
+    payload = re.search(
+        r'"/api/sdk/wallet/link",\s*\n\s*json\s*=\s*\{([\s\S]*?)\}',
+        body,
+    )
+    assert payload, "Could not locate the /wallet/link POST json payload"
+    payload_text = payload.group(1)
+
+    assert "confirm_replace_managed" in payload_text, (
+        "POST /api/sdk/wallet/link body must include confirm_replace_managed "
+        "— otherwise the flag is dropped client-side and the server reverts "
+        "to its safe default (False), blocking even legitimate user calls."
+    )
+    # Pinned to the parameter, not a hardcoded literal — so the explicit
+    # default + auto-relink override both flow through correctly.
+    assert re.search(
+        r'"confirm_replace_managed"\s*:\s*confirm_replace_managed',
+        payload_text,
+    ), (
+        "POST body must pass the parameter through (not a hardcoded True/False) "
+        "so the auto-relink override actually reaches the server."
+    )
+
+
+# =============================================================================
+# Auto-relink path overrides to False
+# =============================================================================
+
+
+def test_ensure_wallet_linked_passes_false():
+    """The implicit auto-relink path must override to False. This is the
+    LOAD-BEARING invariant of SIM-1580 — without this override, a stale
+    WALLET_PRIVATE_KEY in a bot env after a managed-mode migration would
+    still silently displace the managed wallet."""
+    src = _client_source()
+    # Isolate _ensure_wallet_linked.
+    method = re.search(
+        r"def _ensure_wallet_linked\([\s\S]*?(?=\n    def |\nclass )",
+        src,
+    )
+    assert method, "Could not isolate _ensure_wallet_linked"
+    body = method.group(0)
+
+    # Inside the auto-link path it must call self.link_wallet with
+    # confirm_replace_managed=False — explicit, no relying on default.
+    call = re.search(
+        r"self\.link_wallet\(\s*signature_type\s*=\s*0\s*,\s*"
+        r"confirm_replace_managed\s*=\s*False\s*\)",
+        body,
+    )
+    assert call, (
+        "_ensure_wallet_linked must call self.link_wallet(signature_type=0, "
+        "confirm_replace_managed=False) — explicit override is what protects "
+        "managed accounts from silent overwrite. Removing this re-opens the "
+        "SIM-1580 footgun."
+    )


### PR DESCRIPTION
Pairs with simmer/PR #559 server-side guard. Auto-relink (_ensure_wallet_linked, per-trade) now passes confirm_replace_managed=False so a stale WALLET_PRIVATE_KEY in a bot env after a managed-mode migration cannot silently displace the managed wallet — server returns a clear 4xx with WALLET_PRIVATE_KEY remediation guidance. Explicit client.link_wallet() defaults to True (user's explicit call = self-custody intent), preserving existing flows.

Bumps to 0.16.0. CHANGELOG entry includes wongc305@ context.

Tests:
- Method signature accepts the flag
- Default True for explicit user calls
- Flag reaches the POST body
- _ensure_wallet_linked explicitly passes False

4/4 new tests pass. 4 pre-existing OWS-fixture failures unrelated (confirmed via stash + retest on main).

Server PR: https://github.com/SupaFund/simmer/pull/559

Note on shipping order: server PR can land first (its default is False, so old SDKs hitting the auto-relink path correctly fail loud). This SDK update lets explicit client.link_wallet() calls pass the flag automatically without users having to upgrade individually.