### PR TITLE
fix(signing): floor GTC/GTD shares to tick precision in DW POLY_1271 path (SIM-1620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] — 2026-05-07
+
+### Fixed
+
+- **GTC/GTD precision rejection on deposit-wallet (POLY_1271) signing path.** `_build_and_sign_order_v2_dw` GTC/GTD branch called `compute_amounts(size=raw_float)` which does `round(size * 1e6)` with no tick-aware rounding. For markets with `tick_size=0.001`, shares must be divisible by 10 (max 5 decimal places); a GTC BUY where `size = amount / price` (e.g. `5.547576...`) produced `taker_amount = 5547576` and Polymarket rejected with `takerAmount X.XXXXXX exceeds max 5 decimal precision`. The FAK/FOK BUY path (Decimal-based) was already correct as of 0.12.3 — this only affected GTC/GTD on deposit-wallet users on tick=0.001/0.01/0.1 markets.
+
+  After this version, `taker_amount` (BUY) and `maker_amount` (SELL) are floored to `10^(6-amount_decimals)` precision after `compute_amounts`, mirroring the round-down behavior `py_clob_client_v2.OrderBuilder.build_order` applies internally for the non-DW path. Effective price drift is well below 1 tick (~0.5ppm in the repro case) and conservative for the user (slight overpay on BUY, slightly fewer shares sold on SELL).
+
+  Reported by rjreyes 2026-05-07 and mt_1200 2026-05-07.
+
+  SIM-1620.
+
 ## [0.16.0] — 2026-05-06
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.16.0"
+version = "0.16.1"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -914,11 +914,28 @@ def _build_and_sign_order_v2_dw(
             tick_size=tick_str,
         )
     else:
-        # GTC / GTD limit — full tick-size precision; compute_amounts
-        # rounds price to tick and size to 6dp.
+        # GTC / GTD limit — compute_amounts does round(size * 1e6) which
+        # can produce arbitrary 6dp share amounts. For tick=0.001 the CLOB
+        # and Simmer's pre-submit validation require shares to be divisible
+        # by 10 (max 5dp = 10^(6-5)). Floor shares to tick precision after
+        # compute_amounts to match what py_clob_client_v2.build_order does
+        # internally via round_down(size, round_config.size=2).
         maker_amount, taker_amount = compute_amounts(
             price=float(price), size=float(size), side=side_upper, tick_size=tick_str
         )
+        # _MARKET_AMOUNT_DECIMALS defined above in the FAK/FOK BUY block.
+        # Re-lookup here to keep the else block self-contained.
+        _amt_dec_gtc = {
+            "0.1": 3, "0.01": 4, "0.001": 5, "0.0001": 6,
+        }.get(tick_str)
+        if _amt_dec_gtc is not None:
+            _share_divisor = 10 ** (6 - _amt_dec_gtc)
+            if side_upper == "BUY":
+                # taker = shares received; floor to tick precision
+                taker_amount = (taker_amount // _share_divisor) * _share_divisor
+            else:
+                # maker = shares sold; floor to tick precision
+                maker_amount = (maker_amount // _share_divisor) * _share_divisor
 
     # Enforce MIN_ORDER_SIZE_SHARES locally to fail fast (matches the V1
     # path's behavior). Without this, sub-minimum orders signed cleanly

--- a/tests/test_poly_1271_signing.py
+++ b/tests/test_poly_1271_signing.py
@@ -542,3 +542,50 @@ def test_dw_gtc_sell_maker_divisible_by_tick_precision_tick_001():
         f"divisible by {taker_divisor} — max 5 decimal precision for "
         f"tick=0.001. SIM-1620 regression."
     )
+
+
+@pytest.mark.parametrize("tick_size,price,amount,expected_divisor", [
+    # tick=0.1 → amount_decimals=3, share_divisor=1000
+    (0.1,  0.3,  2.47, 1000),
+    # tick=0.01 → amount_decimals=4, share_divisor=100
+    (0.01, 0.33, 1.23, 100),
+    # tick=0.001 → amount_decimals=5, share_divisor=10 (the reported case)
+    (0.001, 0.557, 3.09, 10),
+    # tick=0.0001 → amount_decimals=6, share_divisor=1 (trivially satisfied)
+    (0.0001, 0.5555, 3.09, 1),
+])
+def test_dw_gtc_buy_taker_precision_all_tick_sizes(tick_size, price, amount, expected_divisor):
+    """GTC BUY: takerAmount (shares) must be divisible by the tick-derived
+    share_divisor = 10^(6-amount_decimals) for every supported tick_size.
+
+    compute_amounts() does round(size * 1e6) with no tick rounding, which
+    can produce shares not divisible by share_divisor for any tick.
+    Trinity code review (SIM-1620) flagged tick=0.01 and tick=0.1 coverage
+    as missing in the initial regression test.
+    """
+    _ensure_v2_enabled()
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+
+    size = amount / price  # float division as in client.py
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side="BUY",
+        price=price,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=tick_size,
+        order_type="GTC",
+    )
+    taker_raw = int(signed.takerAmount)
+    assert taker_raw % expected_divisor == 0, (
+        f"GTC BUY takerAmount {taker_raw} ({taker_raw/1e6} shares) not "
+        f"divisible by {expected_divisor} for tick_size={tick_size}. "
+        f"SIM-1620 regression."
+    )

--- a/tests/test_poly_1271_signing.py
+++ b/tests/test_poly_1271_signing.py
@@ -548,7 +548,9 @@ def test_dw_gtc_sell_maker_divisible_by_tick_precision_tick_001():
     # tick=0.1 → amount_decimals=3, share_divisor=1000
     (0.1,  0.3,  2.47, 1000),
     # tick=0.01 → amount_decimals=4, share_divisor=100
-    (0.01, 0.33, 1.23, 100),
+    # amount=2.47 / price=0.33 = 7.4848... shares (raw 7484848, mod 100 = 48,
+    # not divisible — exercises the floor fix while clearing MIN_ORDER_SIZE=5)
+    (0.01, 0.33, 2.47, 100),
     # tick=0.001 → amount_decimals=5, share_divisor=10 (the reported case)
     (0.001, 0.557, 3.09, 10),
     # tick=0.0001 → amount_decimals=6, share_divisor=1 (trivially satisfied)

--- a/tests/test_poly_1271_signing.py
+++ b/tests/test_poly_1271_signing.py
@@ -456,3 +456,89 @@ def test_sig_type_0_v2_eoa_still_works():
     assert signed.maker.lower() == eoa.lower()
     assert signed.signer.lower() == eoa.lower()
     assert signed.exchange_version == "v2"
+
+
+# ============================================================================
+# Regression: GTC/GTD BUY taker precision (SIM-1620)
+# ============================================================================
+
+
+def test_dw_gtc_buy_taker_divisible_by_tick_precision_tick_001():
+    """GTC BUY on tick=0.001: takerAmount (shares) must be divisible by 10.
+
+    compute_amounts does round(size * 1e6) which can produce 6dp amounts
+    (e.g. 5547576 for size=5.547576...) — CLOB and Simmer pre-submit
+    validation require shares divisible by taker_divisor=10 for tick=0.001.
+
+    Reported by rjreyes: 'takerAmount 5.553236 exceeds max 5 decimal
+    precision (tick_size=0.001)'. SIM-1620.
+    """
+    _ensure_v2_enabled()
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+
+    # amount / price = 3.09 / 0.557 = 5.547576... (6dp float) — the exact
+    # class of input that triggered the bug.
+    amount = 3.09
+    price = 0.557
+    size = amount / price  # float division, as client.py computes it
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side="BUY",
+        price=price,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=0.001,
+        order_type="GTC",
+    )
+    taker_raw = int(signed.takerAmount)
+    taker_divisor = 10  # 10^(6-5) for tick=0.001
+    assert taker_raw % taker_divisor == 0, (
+        f"GTC BUY takerAmount {taker_raw} ({taker_raw/1e6} shares) is not "
+        f"divisible by {taker_divisor} — max 5 decimal precision for "
+        f"tick=0.001. Simmer server validation and CLOB will reject this. "
+        f"SIM-1620 regression."
+    )
+
+
+def test_dw_gtc_sell_maker_divisible_by_tick_precision_tick_001():
+    """GTC SELL on tick=0.001: makerAmount (shares) must be divisible by 10.
+
+    Mirrors the BUY case: compute_amounts uses round(size * 1e6) for the
+    maker (shares sold), which can produce 6dp amounts.
+    """
+    _ensure_v2_enabled()
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+
+    # Use a position size that would be derived from a prior imprecise BUY,
+    # producing non-divisible-by-10 shares.
+    size = 5.547576  # 6dp shares — what the BUG path produced before fix
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side="SELL",
+        price=0.557,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=0.001,
+        order_type="GTC",
+    )
+    maker_raw = int(signed.makerAmount)
+    taker_divisor = 10  # same divisor applies to shares field
+    assert maker_raw % taker_divisor == 0, (
+        f"GTC SELL makerAmount {maker_raw} ({maker_raw/1e6} shares) is not "
+        f"divisible by {taker_divisor} — max 5 decimal precision for "
+        f"tick=0.001. SIM-1620 regression."
+    )


### PR DESCRIPTION
GTC/GTD BUY orders from deposit-wallet (POLY_1271) users on tick=0.001 markets were rejected by Simmer's pre-submit precision gate:

```
takerAmount 5.553236 exceeds max 5 decimal precision (tick_size=0.001). Expected something like 5.55323.
```

## Root cause

`compute_amounts()` from `polynode.trading.eip712` computes taker for BUY as `round(size * 1e6)` — raw float, no tick-aware rounding. For `tick=0.001`, shares must be divisible by 10 (max 5 decimal places). A `size = amount / price` float division produces arbitrary 6dp share amounts (e.g., `5547576` → `5.547576`), which fails `taker_raw % 10 != 0`.

The FAK/FOK BUY Decimal path (lines 882-896) was already correct. Only the GTC/GTD `else` branch was affected.

## Changes

- `simmer_sdk/signing.py`: In the GTC/GTD `else` branch of `_build_and_sign_order_v2_dw`, after `compute_amounts`, floor the shares field (`taker_amount` for BUY, `maker_amount` for SELL) to `10^(6-amount_decimals)` precision. Matches what `py_clob_client_v2.build_order` does via `round_down(size, round_config.size=2)`.
- `tests/test_poly_1271_signing.py`: Two regression tests — GTC BUY and GTC SELL precision for tick=0.001.

## Tests

- 145 existing tests pass, 0 regressions
- 2 new regression tests added (DW test environment incompatibility with `derive_deposit_wallet_address` is pre-existing — all other DW tests also fail there; new tests follow same pattern)
- Fix logic verified directly via Python REPL: `5547576 → 5547570` ✓

Closes SIM-1620