### PR TITLE
fix(sdk): set_approvals() detects deposit-wallet users and routes to dashboard (SIM-1613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.9] — 2026-05-13
+
+### Fixed
+
+- **`set_approvals()` now detects deposit-wallet users and routes to the dashboard.** Previously the function silently set EOA approvals for POLY_1271 deposit-wallet users — approvals that had no effect because collateral lives in the deposit wallet, not the EOA. The function now short-circuits with a structured response (`deposit_wallet_user: True`, `set: 0`, `skipped: 0`, `failed: 0`) and a message directing users to the dashboard's "Activate Trading" EIP-712 flow. No transactions are submitted, no eth-account import attempted. Backward-compatible: existing callers that only check `set/skipped/failed` keys continue to work unchanged; callers wanting to branch on the DW case can check `result.get("deposit_wallet_user")`. SIM-1613.
+
 ## [0.17.8] — 2026-05-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.8"
+version = "0.17.9"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3900,6 +3900,10 @@ class SimmerClient:
             - skipped: Number of approvals already in place
             - failed: Number of approvals that failed
             - details: List of per-approval results
+            - deposit_wallet_user: True if the account uses the deposit-wallet
+              pathway (approvals must be set via the dashboard instead).
+              When present and True, set/skipped/failed are all 0 and no
+              transactions are submitted.
 
         Raises:
             ValueError: If no wallet is configured
@@ -3921,6 +3925,24 @@ class SimmerClient:
                 "No signing key available. Set WALLET_PRIVATE_KEY env var, pass private_key to constructor, "
                 "or configure an OWS wallet (OWS_WALLET env var or ows_wallet constructor arg)."
             )
+
+        # SIM-1613: deposit-wallet users must set approvals via the dashboard's
+        # "Activate Trading" EIP-712 flow — EOA approvals have no effect because
+        # collateral lives in the deposit wallet, not the EOA.
+        if self._uses_deposit_wallet:
+            return {
+                "set": 0,
+                "skipped": 0,
+                "failed": 0,
+                "deposit_wallet_user": True,
+                "message": (
+                    "This account is on the Polymarket deposit-wallet pathway. "
+                    "Approvals must be set via the dashboard's 'Activate Trading' "
+                    "flow (one EIP-712 signature, no per-tx prompts). "
+                    "See https://docs.simmer.markets/wallets#deposit-wallet-approvals"
+                ),
+                "details": [],
+            }
 
         try:
             import eth_account  # noqa: F401 — early dep check; signing happens in _sign_eip1559_tx_for_broadcast

--- a/tests/test_set_approvals_dw.py
+++ b/tests/test_set_approvals_dw.py
@@ -1,0 +1,104 @@
+"""
+Tests for set_approvals() deposit-wallet short-circuit (SIM-1613).
+
+When _uses_deposit_wallet is True, set_approvals() must return immediately with
+a structured response that:
+  - preserves the set/skipped/failed/details keys (backward-compat)
+  - adds deposit_wallet_user=True so callers can branch
+  - includes a human-readable message pointing to the dashboard
+  - never submits any transaction or calls eth-account
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _make_dw_client():
+    """Return a minimally-configured SimmerClient in deposit-wallet mode."""
+    from simmer_sdk.client import SimmerClient
+
+    client = SimmerClient.__new__(SimmerClient)
+    # Minimal attributes set_approvals() reads before the DW guard
+    client._wallet_address = "0xb0d4000000000000000000000000000000005550"
+    client._private_key = "0x" + "aa" * 32
+    client._ows_wallet = None
+    client._uses_deposit_wallet = True
+    client._deposit_wallet_address = "0xDEAD000000000000000000000000000000000001"
+    return client
+
+
+def _make_eoa_client():
+    """Return a minimally-configured SimmerClient NOT in deposit-wallet mode."""
+    from simmer_sdk.client import SimmerClient
+
+    client = SimmerClient.__new__(SimmerClient)
+    client._wallet_address = "0xAAAA000000000000000000000000000000000001"
+    client._private_key = "0x" + "bb" * 32
+    client._ows_wallet = None
+    client._uses_deposit_wallet = False
+    client._deposit_wallet_address = None
+    return client
+
+
+class TestSetApprovalsDWShortCircuit:
+    def test_returns_structured_response(self):
+        """DW client gets a structured dict back, not an exception."""
+        client = _make_dw_client()
+        result = client.set_approvals()
+        assert isinstance(result, dict)
+
+    def test_backward_compat_keys_present(self):
+        """set/skipped/failed/details keys must always be present."""
+        result = _make_dw_client().set_approvals()
+        for key in ("set", "skipped", "failed", "details"):
+            assert key in result, f"missing key: {key}"
+
+    def test_counts_are_zero(self):
+        """No approvals should be registered as set/skipped/failed."""
+        result = _make_dw_client().set_approvals()
+        assert result["set"] == 0
+        assert result["skipped"] == 0
+        assert result["failed"] == 0
+        assert result["details"] == []
+
+    def test_deposit_wallet_user_flag(self):
+        """deposit_wallet_user=True signals the DW path to sophisticated callers."""
+        result = _make_dw_client().set_approvals()
+        assert result.get("deposit_wallet_user") is True
+
+    def test_message_present(self):
+        """Human-readable message must be non-empty."""
+        result = _make_dw_client().set_approvals()
+        assert "message" in result
+        assert len(result["message"]) > 0
+
+    def test_message_references_dashboard(self):
+        """Message must point toward the dashboard activate-trading flow."""
+        result = _make_dw_client().set_approvals()
+        msg = result["message"].lower()
+        assert "dashboard" in msg or "activate trading" in msg.lower()
+
+    def test_no_eth_account_import_attempted(self):
+        """eth-account must not be imported — no transactions are signed."""
+        client = _make_dw_client()
+        with patch.dict("sys.modules", {"eth_account": None}):
+            # Would raise ImportError if the import block were reached
+            result = client.set_approvals()
+        assert result["deposit_wallet_user"] is True
+
+    def test_no_http_calls_made(self):
+        """No network calls should be made for the DW short-circuit path."""
+        client = _make_dw_client()
+        client._request = MagicMock(side_effect=AssertionError("_request must not be called for DW users"))
+        result = client.set_approvals()
+        assert result["deposit_wallet_user"] is True
+        client._request.assert_not_called()
+
+    def test_eoa_client_not_short_circuited(self):
+        """Non-DW clients must NOT hit the early-return path."""
+        client = _make_eoa_client()
+        # The function will proceed past the DW guard and eventually fail
+        # because the test client has no _request method — that's fine, it
+        # proves the guard was not triggered.
+        with pytest.raises(Exception):
+            client.set_approvals()


### PR DESCRIPTION
For POLY_1271 deposit-wallet users, `set_approvals()` was silently returning `set: 8/8 success` while setting approvals on the EOA — which holds nothing. Collateral lives in the deposit wallet, so those approvals were a no-op. Users ran the SDK setup flow, saw success, and then hit silent CLOB failures.

## Changes

- `simmer_sdk/client.py`: Add DW detection guard at the top of `set_approvals()` — short-circuits with a structured response pointing to the dashboard's Activate Trading flow
- `tests/test_set_approvals_dw.py`: 9 tests covering the short-circuit path (return shape, flag, no eth-account import, no HTTP calls, EOA client not affected)
- `CHANGELOG.md` / `pyproject.toml`: Bump to 0.16.2

## Return shape

```python
{
    "set": 0,
    "skipped": 0,
    "failed": 0,
    "deposit_wallet_user": True,
    "message": "This account is on the Polymarket deposit-wallet pathway...",
    "details": [],
}
```

Backward-compatible: `set/skipped/failed/details` keys still present. New `deposit_wallet_user: True` flag for callers that want to branch.

## Tests

- 9/9 pass (`python3 -m pytest tests/test_set_approvals_dw.py -v`)
- No eth-account import attempted on DW path
- No HTTP calls made on DW path

Closes SIM-1613