### PR TITLE
feat(sdk): dual-wallet position listing + per-trade sell routing (0.17.0, SIM-1646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] — 2026-05-08
+
+### Added
+
+- **Dual-wallet position listing for deposit-wallet users (SIM-1646).** For users with `wallet_uses_deposit_wallet=True` who have pre-migration positions on their owner EOA, `client.get_positions()` now returns ALL positions — from both the EOA and the deposit wallet — each tagged with a `holder_address` field indicating which on-chain address holds the CTF tokens.
+
+  Previously these users only saw positions held by the deposit wallet, making any pre-migration position invisible to their agent. Confirmed root case: rjreyes had 53 open positions on his EOA that his agent could not see or manage stop-losses on, leading to 190/199 failed trade attempts.
+
+- **Per-trade sell routing by holder (SIM-1646).** `client.trade(action='sell', ...)` and stop-loss execution paths now select the signing method on a per-trade basis based on `holder_address`:
+
+  - **holder == EOA** (pre-migration position): signs as sig-type-0 (V2 EOA-direct). The existing pre-DW signing path.
+  - **holder == DW** (post-migration position): signs as sig-type-3 (POLY_1271 batch via deposit wallet). The existing post-migration path.
+  - **Non-DW users**: zero behavior change — always sig-type-0 as before.
+
+  The routing decision is per-trade, not per-session, so users with a mix of EOA and DW positions are handled correctly within the same agent run.
+
+- **`holder_address` field on `Position` dataclass.** New optional `str` field. `None` for sim-venue positions and server versions predating SIM-1646. Existing skill flows that don't read `holder_address` are unaffected.
+
+  SIM-1646.
+
 ## [0.16.1] — 2026-05-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.16.1"
+version = "0.17.0"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -71,6 +71,12 @@ class Position:
     avg_cost: Optional[float] = None  # Average cost per share
     current_price: Optional[float] = None  # Current market price
     sources: Optional[List[str]] = None  # Trade sources (e.g., ["sdk:weather"])
+    # SIM-1646: on-chain address holding the CTF tokens (Polymarket only).
+    # For dual-wallet users with pre-migration positions: may be the owner EOA
+    # rather than the deposit_wallet. trade() uses this to route sells via
+    # sig-type-0 (EOA) or sig-type-3 (POLY_1271 / DW). None for sim venue
+    # or when connected to a server that predates SIM-1646.
+    holder_address: Optional[str] = None
 
 
 @dataclass
@@ -246,6 +252,11 @@ class SimmerClient:
         self._solana_wallet_address: Optional[str] = None  # Solana wallet address
         self._held_markets_cache: Optional[dict] = None  # {market_id: [source_tags]}
         self._held_markets_ts: float = 0  # Cache timestamp
+        # SIM-1646: holder-address cache for dual-wallet sell routing.
+        # Maps "market_id:side" -> holder_address. Populated by get_positions() and
+        # refreshed by _get_holder_address() on-demand for DW users doing sells.
+        self._position_holder_cache: dict = {}
+        self._position_holder_ts: float = 0
         self._clob_client = None  # Cached ClobClient for local CLOB operations
         self._market_data_cache: dict = {}  # market_id -> market data for signing
         self._ows_wallet: Optional[str] = None  # OWS wallet name
@@ -1291,10 +1302,17 @@ class SimmerClient:
             self._ensure_wallet_linked()
             # Warn about missing approvals (once per session)
             self._warn_approvals_once()
+            # SIM-1646: for DW users doing sells, look up the on-chain holder so
+            # _build_signed_order picks the correct sig type (EOA vs DW). Buys
+            # always land on the DW post-migration so no lookup needed for those.
+            _sell_holder = None
+            if is_sell and effective_venue == "polymarket":
+                _sell_holder = self._get_holder_address(market_id, side)
             # Sign order locally
             signed_order = self._build_signed_order(
                 market_id, side, amount if not is_sell else 0,
-                shares if is_sell else 0, action, order_type, price
+                shares if is_sell else 0, action, order_type, price,
+                holder_address=_sell_holder,
             )
             if signed_order:
                 payload["signed_order"] = signed_order
@@ -1681,7 +1699,7 @@ class SimmerClient:
         positions = []
         for p in data.get("positions", []):
             pos_venue = p.get("venue", "sim")
-            positions.append(Position(
+            pos = Position(
                 market_id=p["market_id"],
                 question=p.get("question", ""),
                 shares_yes=p.get("shares_yes", 0),
@@ -1695,10 +1713,68 @@ class SimmerClient:
                 avg_cost=p.get("avg_cost"),
                 current_price=p.get("current_price"),
                 sources=p.get("sources"),
-            ))
+                holder_address=p.get("holder_address"),  # SIM-1646: on-chain token holder
+            )
+            positions.append(pos)
+            # SIM-1646: update holder cache for trade() sell routing
+            if pos.holder_address and pos_venue == "polymarket":
+                if (pos.shares_yes or 0) > 0:
+                    self._position_holder_cache[f"{pos.market_id}:yes"] = pos.holder_address
+                if (pos.shares_no or 0) > 0:
+                    self._position_holder_cache[f"{pos.market_id}:no"] = pos.holder_address
+        # Stamp the cache so _get_holder_address() sees it as fresh
+        import time as _t
+        self._position_holder_ts = _t.time()
         return positions
 
     _HELD_MARKETS_TTL = 30  # seconds
+    _HOLDER_CACHE_TTL = 30  # seconds — same as held-markets TTL
+
+    def _get_holder_address(self, market_id: str, side: str) -> Optional[str]:
+        """SIM-1646: Return the on-chain address holding CTF tokens for a position.
+
+        For DW users with pre-migration EOA positions this will be the EOA, not
+        the deposit wallet. Returns None for non-DW users (no routing override).
+
+        Checks `_position_holder_cache` (populated by get_positions()). On cache
+        miss or staleness, re-fetches positions to rebuild the cache. This lookup
+        is triggered only on sell paths to avoid unnecessary GET /positions calls
+        during buy-only loops.
+        """
+        uses_dw = bool(getattr(self, "_uses_deposit_wallet", False))
+        dw_address = getattr(self, "_deposit_wallet_address", None)
+        if not uses_dw or not dw_address:
+            return None  # Non-DW user — no holder override needed
+
+        import time as _t
+        now = _t.time()
+        cache_key = f"{market_id}:{side}"
+
+        # Return from cache if fresh (cache is always a dict; ts=0 means never populated)
+        if self._position_holder_ts > 0 and (now - self._position_holder_ts) < self._HOLDER_CACHE_TTL:
+            return self._position_holder_cache.get(cache_key)
+
+        # Cache miss / stale — refresh via get_positions()
+        self._position_holder_cache = {}
+        self._position_holder_ts = now
+        try:
+            data = self._request("GET", "/api/sdk/positions")
+            for p in data.get("positions", []):
+                if p.get("venue") != "polymarket":
+                    continue
+                h = p.get("holder_address")
+                if not h:
+                    continue
+                mid = p.get("market_id")
+                if (p.get("shares_yes") or 0) > 0:
+                    self._position_holder_cache[f"{mid}:yes"] = h
+                if (p.get("shares_no") or 0) > 0:
+                    self._position_holder_cache[f"{mid}:no"] = h
+        except Exception as _e:
+            logger.debug("holder lookup failed (%s) — using DW default", _e)
+            return None  # Fail open: caller falls back to DW sig-type-3
+
+        return self._position_holder_cache.get(cache_key)
 
     def _get_held_markets(self) -> dict:
         """Get market_id -> [source_tags] for all held positions. Cached 30s."""
@@ -3060,6 +3136,7 @@ class SimmerClient:
         action: str = "buy",
         order_type: str = "FAK",
         price: Optional[float] = None,
+        holder_address: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Build and sign a Polymarket order locally.
@@ -3071,6 +3148,10 @@ class SimmerClient:
             side: 'yes' or 'no'
             amount: USDC amount (for buys)
             shares: Number of shares (for sells)
+            holder_address: SIM-1646. On-chain address holding the CTF tokens.
+                For DW users: if provided and equals the EOA (pre-migration position),
+                sign as sig-type-0 (EOA-direct). If it's the DW, sign as sig-type-3.
+                If None, falls back to the session-level DW detection.
             action: 'buy' or 'sell'
             order_type: Order type ('FAK', 'GTC', etc.)
             price: Optional limit price (0.001-0.999). If None, uses current market price.
@@ -3164,15 +3245,30 @@ class SimmerClient:
         # caller asked for, not a derived size*price that may shave a cent.
         amount_usdc = float(amount) if (not is_sell and amount > 0) else None
 
-        # SIM-1521: pick sig type based on whether the user has been
-        # upgraded to a Polymarket deposit wallet. _ensure_wallet_linked()
-        # caches `self._uses_deposit_wallet` and `self._deposit_wallet_address`
-        # from /api/sdk/settings; defaults are False / None for users on
-        # older server versions or pre-upgrade external wallets, in which
-        # case we stay on sig type 0 (EOA) as before.
+        # SIM-1521 / SIM-1646: pick sig type based on which address holds the tokens.
+        # _ensure_wallet_linked() caches `self._uses_deposit_wallet` and
+        # `self._deposit_wallet_address` from /api/sdk/settings; defaults are
+        # False / None for users on older server versions or pre-upgrade external
+        # wallets, in which case we stay on sig type 0 (EOA) as before.
+        #
+        # SIM-1646 dual-wallet routing: for DW users with pre-migration EOA
+        # positions, `holder_address` is the EOA → use sig-type-0.
+        # For DW positions (holder == DW), use sig-type-3 (POLY_1271).
         uses_dw = bool(getattr(self, "_uses_deposit_wallet", False))
         dw_address = getattr(self, "_deposit_wallet_address", None) if uses_dw else None
-        order_signature_type = 3 if uses_dw and dw_address else 0
+        if uses_dw and dw_address and holder_address:
+            _holder_lower = holder_address.lower()
+            _dw_lower = dw_address.lower()
+            _eoa_lower = (self._wallet_address or "").lower()
+            if _holder_lower == _eoa_lower and _holder_lower != _dw_lower:
+                # Pre-migration position on the EOA → sign as EOA (sig-type-0)
+                order_signature_type = 0
+                dw_address = None  # Don't pass DW address to the builder
+            else:
+                # DW-held position → standard POLY_1271 path (sig-type-3)
+                order_signature_type = 3
+        else:
+            order_signature_type = 3 if uses_dw and dw_address else 0
 
         if self._ows_wallet:
             # OWS path is V1-only and predates deposit-wallet support; if a

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1754,22 +1754,12 @@ class SimmerClient:
         if self._position_holder_ts > 0 and (now - self._position_holder_ts) < self._HOLDER_CACHE_TTL:
             return self._position_holder_cache.get(cache_key)
 
-        # Cache miss / stale — refresh via get_positions()
-        self._position_holder_cache = {}
-        self._position_holder_ts = now
+        # Cache miss / stale — refresh by fetching live positions.
+        # get_positions() populates _position_holder_cache and stamps
+        # _position_holder_ts as a side-effect, so we just discard the
+        # return value and read from the now-fresh cache.
         try:
-            data = self._request("GET", "/api/sdk/positions")
-            for p in data.get("positions", []):
-                if p.get("venue") != "polymarket":
-                    continue
-                h = p.get("holder_address")
-                if not h:
-                    continue
-                mid = p.get("market_id")
-                if (p.get("shares_yes") or 0) > 0:
-                    self._position_holder_cache[f"{mid}:yes"] = h
-                if (p.get("shares_no") or 0) > 0:
-                    self._position_holder_cache[f"{mid}:no"] = h
+            self.get_positions(venue="polymarket")
         except Exception as _e:
             logger.debug("holder lookup failed (%s) — using DW default", _e)
             return None  # Fail open: caller falls back to DW sig-type-3

--- a/tests/test_dual_wallet_positions.py
+++ b/tests/test_dual_wallet_positions.py
@@ -1,0 +1,348 @@
+"""Tests for dual-wallet position listing and trade routing (SIM-1646).
+
+For users with `wallet_uses_deposit_wallet=True` who have pre-migration
+positions on their owner EOA:
+
+1. get_positions() returns ALL positions (EOA + DW), each tagged with
+   `holder_address` as returned by the server.
+2. _build_signed_order() routes by holder:
+   - holder == EOA → sig-type-0 (V2 EOA-direct)
+   - holder == DW  → sig-type-3 (POLY_1271 batch)
+
+The server (/api/sdk/positions) already merges both addresses and emits
+`holder_address` per position (SIM-1646 backend). These tests verify the
+SDK correctly surfaces the field and uses it for sell routing — without
+any live signing or network I/O.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient, Position
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+EOA = "0x98a0000000000000000000000000000000000dfb"
+DW  = "0x9300000000000000000000000000000000b42a00"
+
+MARKET_A = "market-aaa"  # pre-migration position on EOA
+MARKET_B = "market-bbb"  # post-migration position on DW
+
+
+def _server_response(include_holder: bool = True) -> dict:
+    """Fake /api/sdk/positions response with two Polymarket positions."""
+    def _ha(addr):
+        return addr if include_holder else None
+
+    return {
+        "positions": [
+            {
+                "market_id": MARKET_A,
+                "question": "Will team A win?",
+                "shares_yes": 10.0,
+                "shares_no": 0.0,
+                "current_value": 8.0,
+                "pnl": -2.0,
+                "status": "active",
+                "venue": "polymarket",
+                "holder_address": _ha(EOA),
+            },
+            {
+                "market_id": MARKET_B,
+                "question": "Will team B win?",
+                "shares_yes": 5.0,
+                "shares_no": 0.0,
+                "current_value": 4.5,
+                "pnl": -0.5,
+                "status": "active",
+                "venue": "polymarket",
+                "holder_address": _ha(DW),
+            },
+        ]
+    }
+
+
+def _make_client(uses_dw: bool = True) -> SimmerClient:
+    """Construct a minimal SimmerClient wired for unit tests (no network)."""
+    client = SimmerClient.__new__(SimmerClient)
+    client._agent_id = "test-agent"
+    client._ows_wallet = None
+    client._private_key = "0x" + "aa" * 32  # dummy private key (never used in routing tests)
+    client._wallet_address = EOA
+    client.base_url = "https://api.simmer.markets"
+    client.live = True
+    client.venue = "polymarket"
+    client._paper_portfolio = None  # forces live path in get_positions()
+    client._held_markets_cache = None
+    client._held_markets_ts = 0.0
+    client._position_holder_cache = {}
+    client._position_holder_ts = 0.0
+    client._market_data_cache = {}
+    client._request = MagicMock()
+    client._uses_deposit_wallet = uses_dw
+    client._deposit_wallet_address = DW if uses_dw else None
+    return client
+
+
+# ---------------------------------------------------------------------------
+# 1. get_positions() — dual-wallet surface tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_positions_dual_wallet_returns_all_positions():
+    """DW user: get_positions() returns positions from both EOA and DW."""
+    client = _make_client(uses_dw=True)
+    client._request.return_value = _server_response()
+
+    positions = client.get_positions()
+
+    assert len(positions) == 2, f"Expected 2 positions, got {len(positions)}"
+    market_ids = {p.market_id for p in positions}
+    assert MARKET_A in market_ids, "Pre-migration EOA position missing"
+    assert MARKET_B in market_ids, "Post-migration DW position missing"
+
+
+def test_list_positions_dual_wallet_tags_holder_address():
+    """Each position carries the address that holds the on-chain CTF tokens."""
+    client = _make_client(uses_dw=True)
+    client._request.return_value = _server_response()
+
+    positions = client.get_positions()
+    by_id = {p.market_id: p for p in positions}
+
+    assert by_id[MARKET_A].holder_address == EOA, (
+        f"EOA-held position must have holder_address={EOA}, "
+        f"got {by_id[MARKET_A].holder_address}"
+    )
+    assert by_id[MARKET_B].holder_address == DW, (
+        f"DW-held position must have holder_address={DW}, "
+        f"got {by_id[MARKET_B].holder_address}"
+    )
+
+
+def test_list_positions_dual_wallet_populates_holder_cache():
+    """get_positions() side-effect: _position_holder_cache is populated for sell routing."""
+    client = _make_client(uses_dw=True)
+    client._request.return_value = _server_response()
+
+    client.get_positions()
+
+    assert client._position_holder_cache.get(f"{MARKET_A}:yes") == EOA, (
+        "EOA-held YES position should be cached for sell routing"
+    )
+    assert client._position_holder_cache.get(f"{MARKET_B}:yes") == DW, (
+        "DW-held YES position should be cached for sell routing"
+    )
+
+
+def test_list_positions_dual_wallet_cache_timestamp_updated():
+    """get_positions() stamps _position_holder_ts so _get_holder_address() sees fresh data."""
+    client = _make_client(uses_dw=True)
+    client._request.return_value = _server_response()
+
+    before = time.time()
+    client.get_positions()
+    after = time.time()
+
+    assert before <= client._position_holder_ts <= after + 0.1, (
+        "_position_holder_ts must be set to current time by get_positions()"
+    )
+
+
+def test_list_positions_non_dw_user_unaffected():
+    """Non-DW users: holder_address may be None (server returns None/omits it).
+    The Position object is created fine with holder_address=None."""
+    client = _make_client(uses_dw=False)
+    response = _server_response(include_holder=False)  # server omits holder_address
+    client._request.return_value = response
+
+    positions = client.get_positions()
+
+    assert len(positions) == 2
+    for pos in positions:
+        assert pos.holder_address is None, (
+            f"Non-DW user: holder_address should be None, got {pos.holder_address}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. _get_holder_address() — cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_get_holder_address_returns_from_fresh_cache():
+    """_get_holder_address() returns from cache without a network call when fresh."""
+    client = _make_client(uses_dw=True)
+    client._position_holder_cache = {f"{MARKET_A}:yes": EOA}
+    client._position_holder_ts = time.time()  # fresh
+
+    result = client._get_holder_address(MARKET_A, "yes")
+    assert result == EOA
+    client._request.assert_not_called()
+
+
+def test_get_holder_address_fetches_on_cache_miss():
+    """Cache miss (ts=0): _get_holder_address() makes an API call and rebuilds."""
+    client = _make_client(uses_dw=True)
+    # Cache is empty and stale (ts=0)
+    client._position_holder_cache = {}
+    client._position_holder_ts = 0.0
+    client._request.return_value = _server_response()
+
+    result = client._get_holder_address(MARKET_A, "yes")
+
+    assert result == EOA
+    client._request.assert_called_once_with("GET", "/api/sdk/positions")
+
+
+def test_get_holder_address_returns_none_for_non_dw_user():
+    """Non-DW user: _get_holder_address() returns None immediately (no routing override)."""
+    client = _make_client(uses_dw=False)
+
+    result = client._get_holder_address(MARKET_A, "yes")
+
+    assert result is None
+    client._request.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. _build_signed_order() routing — sig type selection
+# ---------------------------------------------------------------------------
+
+
+def _fake_signed_order(sig_type: int) -> MagicMock:
+    """Fake SignedOrder returned from build_and_sign_order mock."""
+    order = MagicMock()
+    order.signatureType = sig_type
+    order.to_dict.return_value = {
+        "signatureType": sig_type,
+        "maker": EOA if sig_type == 0 else DW,
+        "signer": EOA if sig_type == 0 else DW,
+        "tokenId": "token123",
+        "makerAmount": "1000000",
+        "takerAmount": "2000000",
+        "side": "SELL",
+        "orderType": "FAK",
+        "timestamp": "999999",
+        "nonce": "0",
+        "feeRateBps": "0",
+        "signature": "0x" + "ab" * 32,
+        "exchange_version": "v2",
+    }
+    return order
+
+
+def _make_market_data(market_id: str) -> dict:
+    return {
+        "market_id": market_id,
+        "polymarket_token_id": "token123",
+        "polymarket_no_token_id": "token456",
+        "tick_size": 0.01,
+        "fee_rate_bps": 0,
+        "polymarket_neg_risk": False,
+        "external_price_yes": 0.6,
+    }
+
+
+def test_build_signed_order_eoa_holder_uses_sig_type_0():
+    """A sell where holder_address == EOA must sign as sig-type-0 (EOA-direct)."""
+    client = _make_client(uses_dw=True)
+    client._market_data_cache[MARKET_A] = _make_market_data(MARKET_A)
+
+    with patch("simmer_sdk.signing.build_and_sign_order") as mock_sign:
+        mock_sign.return_value = _fake_signed_order(sig_type=0)
+
+        client._build_signed_order(
+            MARKET_A, "yes",
+            amount=0, shares=10.0,
+            action="sell", order_type="FAK",
+            price=0.6,
+            holder_address=EOA,  # pre-migration position on EOA
+        )
+
+        assert mock_sign.called, "build_and_sign_order should have been called"
+        call_kwargs = mock_sign.call_args[1]
+        assert call_kwargs["signature_type"] == 0, (
+            f"EOA-held position must use sig-type-0. Got {call_kwargs['signature_type']}. "
+            "Possible regression: holder_address routing in _build_signed_order."
+        )
+        assert call_kwargs.get("deposit_wallet_address") is None, (
+            "sig-type-0 path must NOT pass deposit_wallet_address to builder"
+        )
+
+
+def test_build_signed_order_dw_holder_uses_sig_type_3():
+    """A sell where holder_address == DW must sign as sig-type-3 (POLY_1271)."""
+    client = _make_client(uses_dw=True)
+    client._market_data_cache[MARKET_B] = _make_market_data(MARKET_B)
+
+    with patch("simmer_sdk.signing.build_and_sign_order") as mock_sign:
+        mock_sign.return_value = _fake_signed_order(sig_type=3)
+
+        client._build_signed_order(
+            MARKET_B, "yes",
+            amount=0, shares=5.0,
+            action="sell", order_type="FAK",
+            price=0.7,
+            holder_address=DW,  # post-migration position on DW
+        )
+
+        assert mock_sign.called, "build_and_sign_order should have been called"
+        call_kwargs = mock_sign.call_args[1]
+        assert call_kwargs["signature_type"] == 3, (
+            f"DW-held position must use sig-type-3 (POLY_1271). Got {call_kwargs['signature_type']}."
+        )
+        assert call_kwargs.get("deposit_wallet_address") == DW, (
+            "sig-type-3 path must pass deposit_wallet_address to builder"
+        )
+
+
+def test_build_signed_order_no_holder_dw_user_defaults_to_sig_type_3():
+    """DW user, no holder_address provided → fallback to sig-type-3 (DW default)."""
+    client = _make_client(uses_dw=True)
+    client._market_data_cache[MARKET_B] = _make_market_data(MARKET_B)
+
+    with patch("simmer_sdk.signing.build_and_sign_order") as mock_sign:
+        mock_sign.return_value = _fake_signed_order(sig_type=3)
+
+        client._build_signed_order(
+            MARKET_B, "yes",
+            amount=0, shares=5.0,
+            action="sell", order_type="FAK",
+            price=0.7,
+            holder_address=None,  # no override — use session-level DW
+        )
+
+        assert mock_sign.called
+        call_kwargs = mock_sign.call_args[1]
+        assert call_kwargs["signature_type"] == 3, (
+            "DW user with no holder override must default to sig-type-3"
+        )
+
+
+def test_build_signed_order_non_dw_user_uses_sig_type_0():
+    """Non-DW user: sig-type-0 regardless of holder_address (should be None anyway)."""
+    client = _make_client(uses_dw=False)
+    client._market_data_cache[MARKET_A] = _make_market_data(MARKET_A)
+
+    with patch("simmer_sdk.signing.build_and_sign_order") as mock_sign:
+        mock_sign.return_value = _fake_signed_order(sig_type=0)
+
+        client._build_signed_order(
+            MARKET_A, "yes",
+            amount=0, shares=10.0,
+            action="sell", order_type="FAK",
+            price=0.6,
+            holder_address=None,
+        )
+
+        assert mock_sign.called
+        call_kwargs = mock_sign.call_args[1]
+        assert call_kwargs["signature_type"] == 0, (
+            "Non-DW user must always use sig-type-0"
+        )

--- a/tests/test_dual_wallet_positions.py
+++ b/tests/test_dual_wallet_positions.py
@@ -187,7 +187,7 @@ def test_get_holder_address_returns_from_fresh_cache():
 
 
 def test_get_holder_address_fetches_on_cache_miss():
-    """Cache miss (ts=0): _get_holder_address() makes an API call and rebuilds."""
+    """Cache miss (ts=0): _get_holder_address() fetches positions and rebuilds cache."""
     client = _make_client(uses_dw=True)
     # Cache is empty and stale (ts=0)
     client._position_holder_cache = {}
@@ -197,7 +197,10 @@ def test_get_holder_address_fetches_on_cache_miss():
     result = client._get_holder_address(MARKET_A, "yes")
 
     assert result == EOA
-    client._request.assert_called_once_with("GET", "/api/sdk/positions")
+    # get_positions(venue="polymarket") calls _request with venue param
+    assert client._request.called, "_request must be called to refresh holder cache"
+    call_args = client._request.call_args
+    assert call_args[0] == ("GET", "/api/sdk/positions")
 
 
 def test_get_holder_address_returns_none_for_non_dw_user():


### PR DESCRIPTION
## Summary

For DW users (like rjreyes) with pre-migration positions still on their owner EOA, the SDK was blind to those positions and incorrectly tried to route sells through the deposit-wallet path — causing 190/199 failed trades.

- `get_positions()` now returns ALL positions (EOA + DW), each tagged with `holder_address` from the server's dual-address merge (backend shipped in SIM-1645/SIM-1646 backend).
- `trade(action='sell', ...)` routes signing per-trade by holder: EOA-held → sig-type-0, DW-held → sig-type-3. No session-lock — handles mixed portfolios correctly.
- New optional `holder_address` field on `Position` dataclass. Non-DW users: zero behavior change.

## Changes

- `simmer_sdk/client.py`: `Position.holder_address` field; `get_positions()` holder cache population; `_get_holder_address()` helper; `_build_signed_order()` sig-type routing by holder; cache init fix (`None` → `{}`)
- `tests/test_dual_wallet_positions.py`: 12 new tests covering list merge, holder tagging, cache freshness, sig-type routing for EOA/DW/non-DW cases
- `pyproject.toml`: 0.16.1 → 0.17.0
- `CHANGELOG.md`: 0.17.0 entry

## Tests

- 12 new tests, all passing: `python3 -m pytest tests/test_dual_wallet_positions.py -v`
- Full suite: 152 passed, 5 pre-existing failures (polynode not installed in dev env, unrelated to this PR)
- No regressions

## Notes

- PyPI publish requires Adrian's explicit auth (same pattern as SIM-1620 / 0.16.1). PR ships; Adrian merges + manually publishes.
- Docs impact: `holder_address` is a new optional field on `Position`. Skills that don't read it are unaffected. `skill.md` / Mintlify docs update not needed for this field.

Closes SIM-1646