### PR TITLE
fix(signing): round price to tick grid before CLOB submission (SIM-1666)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.0"
+version = "0.17.1"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -16,6 +16,7 @@ outside of memory. It is only used for signing operations.
 """
 
 import os
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, field
 
@@ -26,6 +27,27 @@ from simmer_sdk.polymarket_contracts import (
 
 # Polymarket token/USDC decimals (1 share = 1e6 raw units, 1 USDC/pUSD = 1e6 raw units)
 POLYMARKET_DECIMAL_FACTOR = 1e6
+
+
+def round_price_to_tick(price: float, tick_size: float) -> float:
+    """Round *price* to the nearest multiple of *tick_size*.
+
+    Polymarket's CLOB rejects orders whose price is not on the market's tick
+    grid (e.g. 0.9690009744… when tick=0.001 → must be 0.969 or 0.970).
+    This helper quantises to the nearest tick using ROUND_HALF_UP so that
+    the rounded price always passes the CLOB's tick-grid check.
+
+    A price that is already exactly on-grid passes through unchanged.
+
+    Args:
+        price: Raw price in (0, 1).
+        tick_size: Market tick size (e.g. 0.01, 0.001, 0.0001).
+
+    Returns:
+        Price rounded to the nearest tick, as a Python float.
+    """
+    tick_dec = Decimal(str(tick_size))
+    return float(Decimal(str(price)).quantize(tick_dec, rounding=ROUND_HALF_UP))
 
 # Minimum order size (Polymarket requires >= 5 shares)
 MIN_ORDER_SIZE_SHARES = 5
@@ -161,6 +183,10 @@ def build_and_sign_order(
         ImportError: If required signing deps aren't installed
         ValueError: If order parameters are invalid
     """
+    # Round price to the market's tick grid before signing. The CLOB rejects
+    # orders whose price is not an exact multiple of tick_size (SIM-1666).
+    price = round_price_to_tick(price, tick_size)
+
     if is_v2_enabled():
         return _build_and_sign_order_v2(
             private_key=private_key,
@@ -570,6 +596,9 @@ def build_and_sign_order_ows(
         raise ValueError(f"Invalid size {size}. Must be positive")
     if signature_type not in (0, 1, 2):
         raise ValueError(f"Invalid signature_type {signature_type}. Must be 0, 1, or 2")
+
+    # Round price to the market's tick grid (SIM-1666)
+    price = round_price_to_tick(price, tick_size)
 
     # Get wallet address from OWS
     wallet_address = get_ows_wallet_address(ows_wallet)

--- a/tests/test_tick_price_rounding.py
+++ b/tests/test_tick_price_rounding.py
@@ -1,0 +1,112 @@
+"""Tests for price tick-grid rounding (SIM-1666).
+
+Validates that round_price_to_tick() correctly quantises raw computed prices
+to the market's tick_size before the CLOB sees them.
+"""
+
+from decimal import Decimal
+import pytest
+
+from simmer_sdk.signing import round_price_to_tick
+
+
+# ---------------------------------------------------------------------------
+# Basic rounding — each supported tick size
+# ---------------------------------------------------------------------------
+
+def test_tick_001_rounds_to_nearest():
+    # 0.9690009... → nearest 0.001 is 0.969
+    result = round_price_to_tick(0.9690009744043256, 0.001)
+    assert result == pytest.approx(0.969, abs=1e-9)
+
+
+def test_tick_001_rounds_up():
+    # 0.9695 → rounds up to 0.970 (ROUND_HALF_UP)
+    result = round_price_to_tick(0.9695, 0.001)
+    assert result == pytest.approx(0.970, abs=1e-9)
+
+
+def test_tick_001_rounds_to_nearest_high_side():
+    # 0.9700160467... → nearest 0.001 is 0.970
+    result = round_price_to_tick(0.9700160467338586, 0.001)
+    assert result == pytest.approx(0.970, abs=1e-9)
+
+
+def test_tick_001_rounds_price_on_grid_unchanged():
+    # Already on tick — must pass through exactly
+    result = round_price_to_tick(0.969, 0.001)
+    assert result == pytest.approx(0.969, abs=1e-9)
+
+
+def test_tick_001_rounds_error_examples_from_ticket():
+    # Exact error examples from rjreyes/weather-trader999 log 2026-05-07
+    assert round_price_to_tick(0.9690009744043256, 0.001) == pytest.approx(0.969, abs=1e-9)
+    assert round_price_to_tick(0.8960009211897021, 0.001) == pytest.approx(0.896, abs=1e-9)
+
+
+def test_tick_001_error_examples_01_tick():
+    # tick=0.01 examples from same log
+    assert round_price_to_tick(0.9700160467338586, 0.01) == pytest.approx(0.97, abs=1e-9)
+    assert round_price_to_tick(0.9200079217903246, 0.01) == pytest.approx(0.92, abs=1e-9)
+    assert round_price_to_tick(0.8600061171983232, 0.01) == pytest.approx(0.86, abs=1e-9)
+    assert round_price_to_tick(0.7700039487381987, 0.01) == pytest.approx(0.77, abs=1e-9)
+
+
+def test_tick_0001_passes_through_full_precision():
+    # tick=0.0001 → 4dp; a 4dp price is on grid
+    result = round_price_to_tick(0.4809, 0.0001)
+    assert result == pytest.approx(0.4809, abs=1e-9)
+
+
+def test_tick_0001_rounds_5dp_to_4dp():
+    result = round_price_to_tick(0.48091, 0.0001)
+    assert result == pytest.approx(0.4809, abs=1e-9)
+
+
+def test_tick_01_rounds_to_nearest():
+    result = round_price_to_tick(0.456789, 0.1)
+    assert result == pytest.approx(0.5, abs=1e-9)
+
+
+def test_tick_01_rounds_down():
+    result = round_price_to_tick(0.44, 0.1)
+    assert result == pytest.approx(0.4, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: on-grid prices must be stable (idempotent)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tick,price", [
+    (0.01, 0.50),
+    (0.01, 0.97),
+    (0.001, 0.969),
+    (0.001, 0.970),
+    (0.0001, 0.4809),
+    (0.1, 0.3),
+])
+def test_on_grid_price_unchanged(tick, price):
+    result = round_price_to_tick(price, tick)
+    assert Decimal(str(result)) % Decimal(str(tick)) == 0, (
+        f"round_price_to_tick({price}, {tick}) = {result} is not on tick grid"
+    )
+    assert result == pytest.approx(price, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Result is always on the tick grid
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tick,price", [
+    (0.01, 0.9700160467338586),
+    (0.01, 0.9200079217903246),
+    (0.001, 0.9690009744043256),
+    (0.001, 0.8960009211897021),
+    (0.0001, 0.48091234),
+])
+def test_result_is_on_grid(tick, price):
+    result = round_price_to_tick(price, tick)
+    remainder = Decimal(str(result)) % Decimal(str(tick))
+    assert remainder == 0, (
+        f"round_price_to_tick({price}, {tick}) = {result} remainder {remainder} ≠ 0"
+    )


### PR DESCRIPTION
Fixes "Price (0.969000…) breaks minimum tick size rule: 0.001" rejections hitting rjreyes/weather-trader999 on every buy 2026-05-07 21:45–22:13 UTC (~25 failures).

## Root cause

The SDK passes raw computed prices (e.g. `0.9690009744043256`) directly to the order builder without rounding to the market's tick grid. Polymarket's CLOB validates that `price % tick_size == 0` and rejects any price that doesn't land exactly on a tick.

## Changes

- `simmer_sdk/signing.py`: Add `round_price_to_tick(price, tick_size)` helper (Decimal ROUND_HALF_UP). Call it at the entry of `build_and_sign_order()` and `build_and_sign_order_ows()` so all order paths (V1, V2, deposit-wallet, OWS) get on-grid prices before signing.
- `pyproject.toml`: 0.17.0 → 0.17.1
- `tests/test_tick_price_rounding.py`: 21 tests covering all 4 tick sizes, exact error examples from the log, on-grid idempotency, and grid-membership assertions.

## Tests

```
21 passed in 0.32s
```
All exact error values from the ticket (`0.9690009744043256`, `0.9700160467338586`, etc.) now round cleanly to their nearest tick.

## Notes

- PyPI publish gated on Adrian auth (mirrors SIM-1620 / 0.16.1 pattern).
- `LATEST_SDK_VERSION_FALLBACK` in the backend can be bumped to 0.17.1 separately after publish.

Closes SIM-1666