### PR TITLE
docs(client): document automatic tick rounding in trade() + README (SIM-1678)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ print(f"Balance: ${summary['balance']:.2f}, P&L: ${summary['total_pnl']:.2f}")
 
 > **Per-agent wallets (Elite tier):** `activate_polymarket_dw()` is user-primary only. For per-agent wallets (Elite tier dedicated wallets), use `update_agent_wallet_creds(ows_wallet_name)` instead. The per-agent path requires OWS-Python (`pip install simmer-sdk[ows] open-wallet-standard`).
 
+**Tip — don't pre-round prices.** simmer-sdk ≥ 0.17.1 automatically rounds the price to each Polymarket market's tick grid. Pass your raw computed price to `client.trade(..., price=p)` and the SDK handles the rest. Pre-rounding with a hardcoded tick (e.g. `round(price, 3)`) will silently produce wrong values for markets at different tick sizes.
+
 **Error handling:** All SDK 4xx responses include a `fix` field with actionable instructions when the error matches a known pattern. You can also call `POST /api/sdk/troubleshoot` with `{"error_text": "..."}` to look up any error.
 
 Full API reference with parameters, examples, and error codes: **[simmer.markets/docs.md](https://simmer.markets/docs.md)**

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1473,6 +1473,15 @@ class SimmerClient:
         Returns:
             TradeResult with execution details
 
+        Note:
+            **Tick rounding (Polymarket):** As of simmer-sdk 0.17.1, prices are
+            automatically rounded to the market's tick grid before signing. Pass
+            raw computed prices; do NOT pre-round in your client code.
+            Pre-rounding with a hardcoded tick (e.g. ``round(price, 3)``) produces
+            incorrect results for markets with different tick sizes (Polymarket
+            markets have tick_size in {0.0001, 0.001, 0.01, 0.1}; the SDK fetches
+            each market's tick from ``/api/sdk/markets/{id}`` and applies it).
+
         Example:
             # Use client default venue
             result = client.trade(market_id, "yes", 10.0)


### PR DESCRIPTION
Adds documentation for the automatic price-to-tick rounding behaviour introduced in simmer-sdk 0.17.1 (SIM-1666), so users don't replicate the MT1200/rjreyes pattern of pre-rounding with a hardcoded tick.

## Changes
- `simmer_sdk/client.py`: Added `Note:` paragraph to `trade()` docstring warning against pre-rounding and explaining the SDK's dynamic tick fetch
- `README.md`: Added tip under Key Methods table with the same guidance

## Tests
- Pure docs — no logic changes, no version bump needed
- `py_compile simmer_sdk/client.py` passes

Closes SIM-1678