### PR TITLE
fix(0.17.2): canonical get_order_amounts for GTC/GTD on POLY_1271 (SIM-1666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] — 2026-05-09
+
+### Fixed
+
+- **GTC/GTD off-tick rejection on deposit-wallet signing path (SIM-1666 follow-up).** `_build_and_sign_order_v2_dw` GTC/GTD branch now delegates to `py_clob_client_v2.OrderBuilder.get_order_amounts` — the canonical precision helper Polymarket V2's CLOB validates against. Previously, polynode's `compute_amounts` did `round(size * 1e6)` without first flooring `size` to `RoundConfig.size`, producing 6-decimal `maker`/`taker` integers whose derived effective price (`maker / taker`) drifted off the tick grid and triggered `Price (X) breaks minimum tick size rule: Y` upstream. 0.17.1's `round_price_to_tick()` quantised the input price but couldn't fix the maker/taker ratio Polymarket recomputes. Affected wallets that had already upgraded to 0.17.1 (rjreyes / mt_1200, 327 hits over 2026-05-07–09 even on the latest SDK).
+
+  The canonical helper does `raw_taker = round_down(size, size_dec=2)` → `raw_maker = raw_taker × raw_price` → `round_down(raw_maker, amount_dec)` if needed. With size pre-floored, the resulting integers are tick-aligned by construction, so both Polymarket's CLOB and Simmer's pre-submit precision gate (`local_dev_server.py:19443`) accept them without further work. Replaces the SIM-1620 post-hoc share-side floor (no longer needed; the canonical path produces clean amounts naturally).
+
+  The fix only touches the GTC/GTD branch of the POLY_1271 (deposit-wallet) path. FAK/FOK BUY (Decimal cents-aligned), FAK/FOK SELL (Decimal pre-floor + compute_amounts), and the non-DW V2 path (already canonical) are unchanged.
+
+  Worked example (price=0.97, size=5.6701030927835, tick=0.001):
+  - polynode (broken): `maker=5499999` (6dp ❌), `taker=5670103` (6dp ❌), effective price 0.9699998… off-tick
+  - canonical (fixed): `maker=5499900` (4dp ✓), `taker=5670000` (clean ✓), effective price 0.97 exact ✓
+
+  Reported by rjreyes / mt_1200 2026-05-09. SIM-1666.
+
+## [0.17.1] — 2026-05-08
+
+### Fixed
+
+- **Price not on tick grid (SIM-1666).** Added `round_price_to_tick(price, tick_size)` helper using `Decimal.quantize(ROUND_HALF_UP)`, applied at the entry of `build_and_sign_order()` and `build_and_sign_order_ows()` so all V1/V2/DW/OWS paths quantise the raw input price before reaching the CLOB. Fixes ~25+ buy rejections per cycle on rjreyes/weather-trader999 with errors like `Price (0.9690009744) breaks minimum tick size rule: 0.001`. Insufficient on its own for the deposit-wallet GTC path — see 0.17.2 for the maker/taker ratio drift fix.
+
 ## [0.17.0] — 2026-05-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.1"
+version = "0.17.2"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -943,28 +943,41 @@ def _build_and_sign_order_v2_dw(
             tick_size=tick_str,
         )
     else:
-        # GTC / GTD limit — compute_amounts does round(size * 1e6) which
-        # can produce arbitrary 6dp share amounts. For tick=0.001 the CLOB
-        # and Simmer's pre-submit validation require shares to be divisible
-        # by 10 (max 5dp = 10^(6-5)). Floor shares to tick precision after
-        # compute_amounts to match what py_clob_client_v2.build_order does
-        # internally via round_down(size, round_config.size=2).
-        maker_amount, taker_amount = compute_amounts(
-            price=float(price), size=float(size), side=side_upper, tick_size=tick_str
+        # GTC / GTD limit — delegate to py_clob_client_v2's canonical
+        # get_order_amounts. This is the exact precision logic Polymarket
+        # V2's CLOB validates against: floor size to RoundConfig.size,
+        # round price to RoundConfig.price, compute maker = size × price,
+        # round_down maker to RoundConfig.amount if it overflows.
+        #
+        # Why not polynode.compute_amounts: it does round(size * 1e6) with
+        # NO size flooring, producing 6dp maker/taker that violate
+        # RoundConfig.amount on tick=0.001. Symptoms:
+        #   - takerAmount X exceeds max precision (caught by our pre-submit
+        #     gate) → SIM-1620, mt_1200 2026-05-07
+        #   - "Price (X) breaks minimum tick size rule" (caught by
+        #     Polymarket's CLOB on the derived maker/taker ratio) →
+        #     rjreyes/mt_1200 327 hits 2026-05-07–09 even on 0.17.1
+        # Both root-cause to the same missing round_down(size, size_dec).
+        # The canonical helper does it; matching what Polymarket itself
+        # uses is preferable to maintaining a parallel post-hoc floor.
+        from py_clob_client_v2.order_builder.builder import (  # noqa: WPS433
+            OrderBuilder as _V2OrderBuilder,
+            ROUNDING_CONFIG as _V2_ROUNDING_CONFIG,
         )
-        # _MARKET_AMOUNT_DECIMALS defined above in the FAK/FOK BUY block.
-        # Re-lookup here to keep the else block self-contained.
-        _amt_dec_gtc = {
-            "0.1": 3, "0.01": 4, "0.001": 5, "0.0001": 6,
-        }.get(tick_str)
-        if _amt_dec_gtc is not None:
-            _share_divisor = 10 ** (6 - _amt_dec_gtc)
-            if side_upper == "BUY":
-                # taker = shares received; floor to tick precision
-                taker_amount = (taker_amount // _share_divisor) * _share_divisor
-            else:
-                # maker = shares sold; floor to tick precision
-                maker_amount = (maker_amount // _share_divisor) * _share_divisor
+        if tick_str not in _V2_ROUNDING_CONFIG:
+            raise ValueError(
+                f"Unsupported tick_size for GTC/GTD: {tick_str!r}. "
+                f"Expected one of {list(_V2_ROUNDING_CONFIG)}."
+            )
+        # Bypass __init__ (avoids needing a Signer for this pure helper).
+        # Same pattern as the V1 path at line ~240.
+        _dummy = _V2OrderBuilder.__new__(_V2OrderBuilder)
+        _, maker_amount, taker_amount = _dummy.get_order_amounts(
+            side_upper,
+            float(size),
+            float(price),
+            _V2_ROUNDING_CONFIG[tick_str],
+        )
 
     # Enforce MIN_ORDER_SIZE_SHARES locally to fail fast (matches the V1
     # path's behavior). Without this, sub-minimum orders signed cleanly

--- a/tests/test_poly_1271_signing.py
+++ b/tests/test_poly_1271_signing.py
@@ -591,3 +591,164 @@ def test_dw_gtc_buy_taker_precision_all_tick_sizes(tick_size, price, amount, exp
         f"divisible by {expected_divisor} for tick_size={tick_size}. "
         f"SIM-1620 regression."
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Regression: GTC/GTD MAKER precision + derived effective price (SIM-1666
+# 0.17.2 follow-up). 0.17.1 round_price_to_tick fixed the input price but
+# couldn't fix the maker/taker ratio Polymarket recomputes server-side.
+# rjreyes/mt_1200 hit 327 tick-rule rejections on 0.17.1 because polynode
+# compute_amounts skips round_down(size, 2), letting both maker AND taker
+# drift to 6dp. The 0.17.2 swap to py_clob_client_v2.get_order_amounts
+# fixes both legs by construction.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("tick_size,price,amount,expected_divisor", [
+    (0.1,    0.3,    2.47, 1000),
+    (0.01,   0.33,   2.47, 100),
+    (0.001,  0.557,  3.09, 10),
+    (0.0001, 0.5555, 3.09, 1),
+])
+def test_dw_gtc_buy_maker_precision_all_tick_sizes(tick_size, price, amount, expected_divisor):
+    """GTC BUY makerAmount must be divisible by 10^(6-amount_dec) for every
+    tick. polynode compute_amounts produced 6dp maker on tick=0.001 because
+    raw_size was un-floored; the canonical get_order_amounts pre-floors size
+    so maker = size_floored × price stays within RoundConfig.amount.
+
+    Sister to taker test above. Both legs must be tick-aligned for the
+    derived effective price (maker/taker) to land on the tick grid;
+    Polymarket's CLOB validates the ratio, not the input price.
+
+    SIM-1666 (0.17.2 follow-up).
+    """
+    _ensure_v2_enabled()
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+    size = amount / price
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side="BUY",
+        price=price,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=tick_size,
+        order_type="GTC",
+    )
+    maker_raw = int(signed.makerAmount)
+    assert maker_raw % expected_divisor == 0, (
+        f"GTC BUY makerAmount {maker_raw} ({maker_raw/1e6} USDC) not "
+        f"divisible by {expected_divisor} for tick_size={tick_size}. "
+        f"SIM-1666 regression — polynode 6dp drift returning."
+    )
+
+
+@pytest.mark.parametrize("tick_size,price,size,expected_divisor", [
+    (0.1,    0.3,    8.249,  1000),
+    (0.01,   0.33,   7.4848, 100),
+    (0.001,  0.557,  5.5476, 10),
+    (0.0001, 0.5555, 5.5631, 1),
+])
+def test_dw_gtc_sell_taker_precision_all_tick_sizes(tick_size, price, size, expected_divisor):
+    """GTC SELL takerAmount (USDC received) must be divisible by
+    10^(6-amount_dec) for every tick. Same root cause as the BUY-maker
+    case above; tested independently because the SELL branch swaps the
+    maker/taker semantics inside get_order_amounts.
+
+    SIM-1666 (0.17.2 follow-up).
+    """
+    _ensure_v2_enabled()
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side="SELL",
+        price=price,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=tick_size,
+        order_type="GTC",
+    )
+    taker_raw = int(signed.takerAmount)
+    assert taker_raw % expected_divisor == 0, (
+        f"GTC SELL takerAmount {taker_raw} ({taker_raw/1e6} USDC) not "
+        f"divisible by {expected_divisor} for tick_size={tick_size}. "
+        f"SIM-1666 regression."
+    )
+
+
+@pytest.mark.parametrize("side,tick_size,price,size", [
+    # mt_1200 / rjreyes 2026-05-09: $5.5 BUY at 0.97 (tick=0.001) → size=5.6701030927835
+    # polynode produced effective price 0.96999982… off-tick → CLOB rejected
+    ("BUY",  0.001, 0.97,   5.6701030927835),
+    # rjreyes 2026-05-09 02:50: 0.962 case → effective price 0.962000962… off-tick
+    ("BUY",  0.001, 0.962,  5.7172557172557),
+    # tick=0.01 case: float-drift land
+    ("BUY",  0.01,  0.97,   5.5573453608247),
+    # SELL parity
+    ("SELL", 0.001, 0.97,   5.6701030927835),
+    ("SELL", 0.01,  0.33,   7.4848484848484),
+])
+def test_dw_gtc_effective_price_on_tick_grid(side, tick_size, price, size):
+    """Derived effective price (makerAmount / takerAmount) must equal a
+    tick-grid value. Polymarket's CLOB recomputes this server-side and
+    rejects with `Price (X) breaks minimum tick size rule: Y` when it
+    doesn't land on a multiple of tick_size — exactly what mt_1200/rjreyes
+    hit 327 times on 0.17.1.
+
+    The canonical get_order_amounts pre-floors size to RoundConfig.size,
+    so price = (size_floored × price) / size_floored = price exactly
+    (modulo the tick-grid rounding of price itself).
+
+    SIM-1666 (0.17.2 follow-up).
+    """
+    _ensure_v2_enabled()
+    from decimal import Decimal
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side=side,
+        price=price,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=tick_size,
+        order_type="GTC",
+    )
+    maker = int(signed.makerAmount)
+    taker = int(signed.takerAmount)
+
+    # Effective price: BUY → maker(USDC)/taker(shares); SELL → taker(USDC)/maker(shares)
+    if side == "BUY":
+        eff_price = Decimal(maker) / Decimal(taker)
+    else:
+        eff_price = Decimal(taker) / Decimal(maker)
+
+    tick_dec = Decimal(str(tick_size))
+    # eff_price should be an exact multiple of tick. Use modulo on the
+    # quantized representation to avoid Decimal-vs-float comparison noise.
+    remainder = eff_price.quantize(Decimal("0.0000001")) % tick_dec
+    assert remainder == 0 or remainder == tick_dec, (
+        f"{side} GTC effective price {eff_price} (maker={maker}, taker={taker}) "
+        f"is not on tick grid (tick_size={tick_size}). "
+        f"Polymarket CLOB will reject with 'breaks minimum tick size rule'. "
+        f"SIM-1666 regression."
+    )


### PR DESCRIPTION
## Summary

- Replaces polynode `compute_amounts` with `py_clob_client_v2.OrderBuilder.get_order_amounts` in `_build_and_sign_order_v2_dw` GTC/GTD branch — the canonical precision helper Polymarket V2's CLOB validates against
- Drops the SIM-1620 post-hoc share-side floor (no longer needed; canonical path produces tick-aligned amounts by construction)
- 14 new parametrized regression tests covering BUY/SELL × 4 ticks × maker/taker/effective-price assertions, including mt_1200's and rjreyes's exact failing inputs

## Why

0.17.1 added `round_price_to_tick()` which fixes the **input** price. But Polymarket's CLOB recomputes price from the **derived** `maker / taker` ratio server-side and rejects if that ratio isn't on the tick grid. polynode's `compute_amounts` does `round(size * 1e6)` without first flooring `size` to `RoundConfig.size`, leaving 6dp maker/taker that produce off-tick effective prices.

Result: mt_1200 / rjreyes hit **327 `Price (X) breaks minimum tick size rule: Y` rejections over 2026-05-07–09** — including 66 today, after upgrading to 0.17.1.

Also affects the precision pre-submit gate (mt_1200's `makerAmount 5.499999 exceeds max precision` Telegram report) — same root cause, different gate.

## Worked example

mt_1200's 2026-05-09 failing input (`amount=$5.5, price=0.97, side=NO BUY, tick=0.001`):

| | Before (polynode) | After (canonical) |
|---|---|---|
| size handling | `round(5.6701 × 1e6) = 5670103` (no floor) | `round_down(5.6701, 2) = 5.67` → `5670000` |
| `makerAmount` | `5499999` (6dp ❌) | `5499900` (4dp ✓) |
| `takerAmount` | `5670103` (6dp ❌) | `5670000` (clean ✓) |
| Effective price (maker/taker) | `0.96999982…` ❌ off-tick | `0.97` exact ✓ |
| CLOB verdict | Rejected | Accepts |

## Scope

Only the GTC/GTD branch of the POLY_1271 (deposit-wallet) path. FAK/FOK BUY (Decimal cents-aligned), FAK/FOK SELL (Decimal pre-floor + compute_amounts), and the non-DW V2 path (already canonical via `OrderBuilder.build_order`) are unchanged.

A sibling fix is needed in `simmer/simmer_v3/polymarket_v2_signing.py` for the managed-DW server-side path (45 hits / 4 wallets in same 14d window) — separate PR.

## Test plan

- [x] `pytest tests/test_poly_1271_signing.py -x` — 32/32 pass (14 new SIM-1666 cases plus existing SIM-1620 coverage)
- [x] Empirical verification on mt_1200's exact reported case — produces tick-aligned amounts, effective price 0.97 exact
- [x] Empirical verification on rjreyes's 0.962 case — same
- [ ] `/simmer-code-quality` review
- [ ] PyPI publish on Adrian's auth (gate per CHANGELOG)
- [ ] TG mt_1200 once 0.17.2 is on PyPI: "upgrade to 0.17.2 — pip install -U simmer-sdk"
- [ ] Bump `LATEST_SDK_VERSION_FALLBACK` to 0.17.2 in simmer monorepo (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)