### PR TITLE
fix(0.17.3): Decimal-pure GTC arithmetic for POLY_1271 (codex P2 follow-up to 0.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] — 2026-05-09
+
+### Fixed
+
+- **GTC/GTD float underflow on clean 2dp sizes (codex P2 follow-up to 0.17.2).** `py_clob_client_v2.get_order_amounts` uses float-based `round_down(size, size_dec)` internally, which does `floor(size * 10**size_dec) / 10**size_dec`. A clean 2-decimal size like `2.30` is stored in IEEE-754 as `2.299999999999999822…`, so `floor(2.30 * 100) = floor(229.999…) = 229` — the user's 2.30-share order silently signs as 2.29. Same class of bug as the FAK/FOK SELL branch already fixed via Decimal-via-str.
+
+  Replaces the `get_order_amounts` call in `_build_and_sign_order_v2_dw` GTC/GTD branch with a Decimal-pure mirror of its algorithm. `Decimal(str(size)).quantize(size_q, ROUND_DOWN)` preserves user intent (`str(2.30) == '2.3'` → quantized to 2dp = `2.30`, not `2.29`). The Decimal product `size × price` always has at most `price_dec + size_dec` decimals (= `amount_dec` for all standard ticks), so the overflow path of the canonical algorithm is unreachable and skipped.
+
+  Caught by codex review on the sibling simmer monorepo PR (`simmer/simmer_v3/polymarket_v2_signing.py:_build_and_sign_order_v2_dw`, PR #647) — same canonical-helper swap, same underflow, same fix.
+
+  SIM-1666.
+
 ## [0.17.2] — 2026-05-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.2"
+version = "0.17.3"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -943,25 +943,33 @@ def _build_and_sign_order_v2_dw(
             tick_size=tick_str,
         )
     else:
-        # GTC / GTD limit — delegate to py_clob_client_v2's canonical
-        # get_order_amounts. This is the exact precision logic Polymarket
-        # V2's CLOB validates against: floor size to RoundConfig.size,
-        # round price to RoundConfig.price, compute maker = size × price,
-        # round_down maker to RoundConfig.amount if it overflows.
+        # GTC / GTD limit — Decimal-pure mirror of py_clob_client_v2's
+        # canonical get_order_amounts. We can't call get_order_amounts
+        # directly because its internal round_down(size, size_dec) does
+        # `floor(size * 10**size_dec) / 10**size_dec` in float, and a
+        # clean 2dp size like `2.30` is stored in IEEE-754 as
+        # 2.299999999999999822…, so `floor(229.999…) = 229` and the user's
+        # 2.30-share order signs as 2.29. Codex caught this in the
+        # sibling simmer PR #647 review (same fix applied there).
+        # The nearby market-SELL branch already uses Decimal-via-str.
         #
-        # Why not polynode.compute_amounts: it does round(size * 1e6) with
-        # NO size flooring, producing 6dp maker/taker that violate
-        # RoundConfig.amount on tick=0.001. Symptoms:
-        #   - takerAmount X exceeds max precision (caught by our pre-submit
-        #     gate) → SIM-1620, mt_1200 2026-05-07
-        #   - "Price (X) breaks minimum tick size rule" (caught by
-        #     Polymarket's CLOB on the derived maker/taker ratio) →
-        #     rjreyes/mt_1200 327 hits 2026-05-07–09 even on 0.17.1
-        # Both root-cause to the same missing round_down(size, size_dec).
-        # The canonical helper does it; matching what Polymarket itself
-        # uses is preferable to maintaining a parallel post-hoc floor.
+        # Algorithm (mirrors py_clob_client_v2.OrderBuilder.get_order_amounts):
+        #   raw_price = round_normal(price, price_dec)   # nearest tick
+        #   raw_size  = round_down(size, size_dec)       # floor (preserves intent in Decimal)
+        #   BUY:  raw_taker = raw_size; raw_maker = raw_size × raw_price
+        #   SELL: raw_maker = raw_size; raw_taker = raw_size × raw_price
+        #   if dp(amount_side) > amount_dec: round_down to amount_dec
+        # With Decimal arithmetic on size/price quantized to size_dec/price_dec,
+        # the product has at most price_dec + size_dec decimals (= amount_dec
+        # for all standard ticks), so the overflow path is unreachable here.
+        #
+        # Why not polynode.compute_amounts: skips the size pre-floor entirely
+        # (does round(size * 1e6)), producing 6dp maker/taker whose derived
+        # effective price drifts off the tick grid → 327 CLOB rejections on
+        # rjreyes/mt_1200 across 2026-05-07–09 even on 0.17.1. Was the
+        # original SIM-1666 / 0.17.2 fix.
+        from decimal import Decimal, ROUND_DOWN, ROUND_HALF_EVEN  # noqa: WPS433
         from py_clob_client_v2.order_builder.builder import (  # noqa: WPS433
-            OrderBuilder as _V2OrderBuilder,
             ROUNDING_CONFIG as _V2_ROUNDING_CONFIG,
         )
         if tick_str not in _V2_ROUNDING_CONFIG:
@@ -969,15 +977,28 @@ def _build_and_sign_order_v2_dw(
                 f"Unsupported tick_size for GTC/GTD: {tick_str!r}. "
                 f"Expected one of {list(_V2_ROUNDING_CONFIG)}."
             )
-        # Bypass __init__ (avoids needing a Signer for this pure helper).
-        # Same pattern as the V1 path at line ~240.
-        _dummy = _V2OrderBuilder.__new__(_V2OrderBuilder)
-        _, maker_amount, taker_amount = _dummy.get_order_amounts(
-            side_upper,
-            float(size),
-            float(price),
-            _V2_ROUNDING_CONFIG[tick_str],
-        )
+        _rc = _V2_ROUNDING_CONFIG[tick_str]
+        _price_q = Decimal(10) ** -_rc.price
+        _size_q = Decimal(10) ** -_rc.size
+        _amt_q = Decimal(10) ** -_rc.amount
+
+        # Decimal-via-str preserves user intent (str(2.30) == '2.3',
+        # quantized to 2dp = '2.30', NOT the 2.299999… IEEE artifact).
+        _p_dec = Decimal(str(price)).quantize(_price_q, rounding=ROUND_HALF_EVEN)
+        _s_dec = Decimal(str(size)).quantize(_size_q, rounding=ROUND_DOWN)
+
+        if side_upper == "BUY":
+            _taker_dec = _s_dec
+            _maker_dec = (_s_dec * _p_dec).quantize(_amt_q, rounding=ROUND_DOWN)
+        else:
+            _maker_dec = _s_dec
+            _taker_dec = (_s_dec * _p_dec).quantize(_amt_q, rounding=ROUND_DOWN)
+
+        # Convert to 6-decimal raw integer (USDC/share token decimals).
+        # to_integral_value with ROUND_DOWN matches int() semantics for
+        # the non-negative values we deal with here.
+        maker_amount = int((_maker_dec * 1_000_000).to_integral_value(rounding=ROUND_DOWN))
+        taker_amount = int((_taker_dec * 1_000_000).to_integral_value(rounding=ROUND_DOWN))
 
     # Enforce MIN_ORDER_SIZE_SHARES locally to fail fast (matches the V1
     # path's behavior). Without this, sub-minimum orders signed cleanly

--- a/tests/test_poly_1271_signing.py
+++ b/tests/test_poly_1271_signing.py
@@ -752,3 +752,55 @@ def test_dw_gtc_effective_price_on_tick_grid(side, tick_size, price, size):
         f"Polymarket CLOB will reject with 'breaks minimum tick size rule'. "
         f"SIM-1666 regression."
     )
+
+
+@pytest.mark.parametrize("side,tick_size,price,size,expected_share_units", [
+    # Codex P2 (sibling PR simmer#647) ported back to the SDK: clean 2dp size
+    # with IEEE-754 underflow. `5.30` is stored as 5.299999999999999822…, so
+    # py_clob_client_v2's float `round_down(5.30, 2) = floor(529.999…)/100 = 5.29`,
+    # silently shaving the user's 5.30-share order. Decimal-via-str preserves
+    # intent (str(5.30) == '5.3' → quantized 2dp = 5.30 → preserved).
+    # Sizes are >= MIN_ORDER_SIZE_SHARES (5) so the local guard doesn't fire.
+    # `expected_share_units` is the share-side raw (taker for BUY, maker for SELL).
+    ("BUY",  0.01,  0.50, 5.30, 5_300_000),
+    ("SELL", 0.01,  0.50, 5.30, 5_300_000),
+    ("BUY",  0.01,  0.40, 7.10, 7_100_000),
+    ("SELL", 0.01,  0.40, 7.10, 7_100_000),
+    ("BUY",  0.001, 0.500, 5.30, 5_300_000),
+    ("SELL", 0.001, 0.500, 5.30, 5_300_000),
+])
+def test_dw_gtc_clean_2dp_size_preserved(side, tick_size, price, size, expected_share_units):
+    """Clean 2dp sizes with IEEE-754 underflow (e.g. 2.30 stored as
+    2.2999999999…) must NOT be shaved by the GTC path. The canonical
+    py_clob_client_v2.get_order_amounts uses float-based round_down which
+    does floor(229.999…) = 229 → 2.30 signs as 2.29. Decimal-via-str
+    pre-floor preserves the user's intent.
+
+    Codex P2 finding from sibling simmer PR #647. SIM-1666 regression.
+    """
+    _ensure_v2_enabled()
+    from simmer_sdk.signing import build_and_sign_order
+
+    priv, eoa = _make_eoa()
+    dw = _derive_dw(eoa)
+
+    signed = build_and_sign_order(
+        private_key=priv,
+        wallet_address=eoa,
+        token_id="71321045679252212594626385532706912750332728571942532289631379312455583992563",
+        side=side,
+        price=price,
+        size=size,
+        signature_type=3,
+        deposit_wallet_address=dw,
+        tick_size=tick_size,
+        order_type="GTC",
+    )
+    share_side_raw = int(signed.takerAmount if side == "BUY" else signed.makerAmount)
+    assert share_side_raw == expected_share_units, (
+        f"{side} GTC size={size} on tick={tick_size}: expected share-side "
+        f"raw={expected_share_units} ({expected_share_units/1e6} sh, preserved), "
+        f"got {share_side_raw} ({share_side_raw/1e6} sh, shaved). "
+        f"IEEE-754 underflow regression — float round_down(size, 2) is "
+        f"silently flooring 2.30 → 2.29 when it shouldn't."
+    )


### PR DESCRIPTION
## Summary

Codex P2 follow-up to PR #70 (0.17.2). Caught on the sibling simmer monorepo PR — same bug exists in this SDK.

`py_clob_client_v2.get_order_amounts` uses float-based `round_down(size, size_dec)` internally:
```python
floor(size * 10**size_dec) / 10**size_dec
```

A clean 2dp size like `5.30` is stored in IEEE-754 as `5.299999999999999822…`, so `floor(5.30 * 100) = floor(529.999…) = 529` and the user's 5.30-share order silently signs as 5.29. Same class of bug as the FAK/FOK SELL branch already fixed via Decimal-via-str.

## Fix

Replaces the `get_order_amounts` call in `_build_and_sign_order_v2_dw` GTC/GTD branch with a Decimal-pure mirror of its algorithm:

```python
_p_dec = Decimal(str(price)).quantize(_price_q, rounding=ROUND_HALF_EVEN)
_s_dec = Decimal(str(size)).quantize(_size_q, rounding=ROUND_DOWN)  # preserves '2.30' → 2.30
if BUY:  taker_dec = _s_dec; maker_dec = (_s_dec * _p_dec).quantize(_amt_q, ROUND_DOWN)
else:    maker_dec = _s_dec; taker_dec = (_s_dec * _p_dec).quantize(_amt_q, ROUND_DOWN)
maker_amount = int((maker_dec * 1_000_000).to_integral_value(ROUND_DOWN))
taker_amount = int((taker_dec * 1_000_000).to_integral_value(ROUND_DOWN))
```

`Decimal(str(size))` is the key — `str(5.30) == '5.3'`, then `quantize` to 2dp gives exactly `5.30`. The Decimal product `size × price` always has at most `price_dec + size_dec` decimals (= `amount_dec` for all standard ticks), so the canonical algorithm's overflow path is unreachable here.

## Verification

| Case | 0.17.2 (broken) | 0.17.3 (fixed) |
|---|---|---|
| BUY 5.30 @ 0.50 tick=0.01 | takerAmount=5,290,000 (5.29 sh ❌) | takerAmount=5,300,000 (5.30 sh ✓) |
| BUY \$5.5 @ 0.97 tick=0.001 (mt_1200) | maker=5,499,900, eff=0.97 ✓ | maker=5,499,900, eff=0.97 ✓ |

Original SIM-1666 fix preserved; new IEEE underflow class also covered.

## Sibling PR

[`simmer/simmer_v3/polymarket_v2_signing.py`](https://github.com/SupaFund/simmer/pull/647) — same canonical helper swap, same underflow, same fix. Already merged at `37a4bc25`.

## Test plan

- [x] `pytest tests/test_poly_1271_signing.py -x` — 38/38 pass (6 new IEEE-underflow cases)
- [x] Empirical verification on codex P2 case (5.30 → 5.30 sh, preserved)
- [x] Empirical verification on mt_1200 case (5.5/0.97 → 5.67 sh, eff=0.97)
- [ ] `/codex review`
- [ ] Merge after Adrian sign-off
- [ ] PyPI publish — supersedes 0.17.2 (which is on origin/main but not yet on PyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)