### PR TITLE
feat(0.17.6): headless DW activation via client.activate_polymarket_dw()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.5"
+version = "0.17.6"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -4200,6 +4200,107 @@ class SimmerClient:
         print()
         return {"set": set_count, "skipped": skipped, "failed": failed, "details": details}
 
+    def activate_polymarket_dw(self) -> Dict[str, Any]:
+        """Activate Polymarket Deposit Wallet trading headlessly.
+
+        Calls /dw-approvals/prepare to get the EIP-712 batch, signs it
+        locally with WALLET_PRIVATE_KEY (key never leaves the process),
+        then submits via /dw-approvals/submit. No browser required.
+
+        Requires:
+        - WALLET_PRIVATE_KEY env var (or private_key constructor arg)
+        - Account upgraded to a Deposit Wallet (wallet_uses_deposit_wallet=True)
+        - eth-account: pip install eth-account
+
+        Returns:
+            Dict with keys:
+            - already_set (bool): True if all approvals were already in place
+            - calls_count (int): number of approval calls submitted (0 if already_set)
+            - success (bool): True on completion
+
+        Raises:
+            ValueError: if no private key is configured
+            ImportError: if eth-account is not installed
+
+        Example:
+            client = SimmerClient(api_key="sk_live_...")  # WALLET_PRIVATE_KEY in env
+            result = client.activate_polymarket_dw()
+            print(f"Done — already_set={result['already_set']}, calls={result['calls_count']}")
+        """
+        if not self._private_key and not self._ows_wallet:
+            raise ValueError(
+                "activate_polymarket_dw() requires a signing key. "
+                "Set WALLET_PRIVATE_KEY env var, pass private_key to the constructor, "
+                "or configure an OWS wallet (OWS_WALLET env var or ows_wallet arg)."
+            )
+
+        if self._private_key:
+            try:
+                from eth_account import Account  # noqa: F401 — early dep check
+            except ImportError:
+                raise ImportError(
+                    "eth-account is required for activate_polymarket_dw(). "
+                    "Install with: pip install eth-account"
+                )
+
+        # Step 1 — prepare: server scans on-chain allowances and returns the
+        # EIP-712 typed data batch. Idempotent — returns already_set=True if
+        # nothing to do.
+        print("[DW-Activate] Preparing approval batch…")
+        prepare = self._request(
+            "POST",
+            "/api/user/wallet/external/dw-approvals/prepare",
+        )
+
+        if prepare.get("already_set"):
+            print("[DW-Activate] All approvals already set — nothing to do.")
+            return {"already_set": True, "calls_count": 0, "success": True}
+
+        typed_data = prepare.get("typed_data")
+        nonce = prepare.get("nonce")
+        deadline = prepare.get("deadline")
+        calls = prepare.get("calls", [])
+
+        if not typed_data or not nonce or deadline is None or not calls:
+            raise RuntimeError(
+                f"Unexpected prepare response — missing required fields. "
+                f"Got keys: {list(prepare.keys())}"
+            )
+
+        # Step 2 — sign locally. Mirrors dw_redeem.sign_dw_redeem_typed_data:
+        # pass the full typed_data dict via full_message so primaryType is
+        # honoured. Key never leaves this process.
+        print("[DW-Activate] Signing batch locally…")
+        if self._private_key:
+            from eth_account import Account
+            signed = Account.sign_typed_data(self._private_key, full_message=typed_data)
+            signature = signed.signature.hex()
+            if not signature.startswith("0x"):
+                signature = "0x" + signature
+        else:
+            from simmer_sdk.ows_utils import ows_sign_typed_data
+            import json as _json
+            sig = ows_sign_typed_data(self._ows_wallet, _json.dumps(typed_data))
+            signature = sig if sig.startswith("0x") else "0x" + sig
+
+        # Step 3 — submit: server re-builds the DepositWalletBatchRequest,
+        # posts to Polymarket's relayer with its builder HMAC, polls until
+        # STATE_MINED, then flips polymarket_allowances_set=TRUE.
+        print("[DW-Activate] Submitting to relayer…")
+        self._request(
+            "POST",
+            "/api/user/wallet/external/dw-approvals/submit",
+            json={
+                "signature": signature,
+                "nonce": nonce,
+                "deadline": deadline,
+                "calls": calls,
+            },
+        )
+
+        print(f"[DW-Activate] Done — {len(calls)} approval(s) set.")
+        return {"already_set": False, "calls_count": len(calls), "success": True}
+
     def register_agent_wallet(self, ows_wallet_name: str) -> dict:
         """Register an OWS wallet for this agent. Elite-only (beta).
 

--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -120,6 +120,9 @@ client = SimmerClient(api_key="sk_live_...")
 # private_key is auto-detected from WALLET_PRIVATE_KEY env var
 client.link_wallet()    # signs a challenge message locally — fully headless
 client.set_approvals()  # signs approval txs locally — fully headless, key never leaves agent
+
+# If your account uses a Polymarket Deposit Wallet (Elite / upgraded accounts):
+client.activate_polymarket_dw()  # one-time — signs EIP-712 batch locally, no browser needed
 ```
 
 Both calls work without a browser session. `link_wallet()` signs a challenge with your local key. `set_approvals()` builds, signs, and broadcasts each approval transaction via Simmer's RPC proxy — your `WALLET_PRIVATE_KEY` never leaves the agent process.

--- a/tests/test_activate_polymarket_dw.py
+++ b/tests/test_activate_polymarket_dw.py
@@ -1,0 +1,141 @@
+"""Tests for client.activate_polymarket_dw() (0.17.6).
+
+Pure unit tests — no network, no real signing.
+Covers:
+  - already_set short-circuit
+  - prepare failure propagation
+  - missing private key raises ValueError before any network call
+  - full happy-path: prepare → sign → submit
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+API_BASE = "https://api.simmer.example.com/api"
+FAKE_KEY = "sk_live_testkey"
+FAKE_PRIVATE_KEY = "0x" + "ab" * 32
+
+FAKE_TYPED_DATA = {
+    "domain": {"name": "DepositWallet", "version": "1", "chainId": 137},
+    "types": {
+        "DepositWalletBatch": [
+            {"name": "calls", "type": "DepositWalletCall[]"},
+            {"name": "nonce", "type": "uint256"},
+            {"name": "deadline", "type": "uint256"},
+        ],
+        "DepositWalletCall": [
+            {"name": "target", "type": "address"},
+            {"name": "value", "type": "uint256"},
+            {"name": "data", "type": "bytes"},
+        ],
+    },
+    "primaryType": "DepositWalletBatch",
+    "message": {"calls": [], "nonce": "1", "deadline": 9999999999},
+}
+
+FAKE_CALLS = [{"target": "0xabc", "value": "0", "data": "0x095ea7b3"}]
+
+PREPARE_RESPONSE = {
+    "already_set": False,
+    "calls": FAKE_CALLS,
+    "calls_summary": [{"target": "0xabc", "data_prefix": "0x095ea7b"}],
+    "typed_data": FAKE_TYPED_DATA,
+    "nonce": "42",
+    "deadline": 9999999999,
+    "deposit_wallet_address": "0xDW",
+}
+
+PREPARE_ALREADY_SET = {
+    "already_set": True,
+    "calls": [],
+    "typed_data": None,
+    "nonce": None,
+    "deadline": None,
+}
+
+
+def _make_client(private_key=FAKE_PRIVATE_KEY):
+    client = SimmerClient.__new__(SimmerClient)
+    client._api_key = FAKE_KEY
+    client._api_base = API_BASE
+    client._private_key = private_key
+    client._ows_wallet = None
+    client._wallet_address = "0xEOA"
+    client._session = MagicMock()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_raises_without_private_key():
+    client = _make_client(private_key=None)
+    client._ows_wallet = None
+    with pytest.raises(ValueError, match="signing key"):
+        client.activate_polymarket_dw()
+
+
+def test_already_set_short_circuits():
+    client = _make_client()
+    with patch.object(client, "_request", return_value=PREPARE_ALREADY_SET) as mock_req:
+        result = client.activate_polymarket_dw()
+
+    assert result == {"already_set": True, "calls_count": 0, "success": True}
+    mock_req.assert_called_once_with("POST", "/api/user/wallet/external/dw-approvals/prepare")
+
+
+def test_prepare_failure_propagates():
+    client = _make_client()
+    with patch.object(client, "_request", side_effect=RuntimeError("HTTP 503")):
+        with pytest.raises(RuntimeError, match="503"):
+            client.activate_polymarket_dw()
+
+
+def test_happy_path_prepare_sign_submit():
+    client = _make_client()
+
+    fake_sig = MagicMock()
+    fake_sig.signature.hex.return_value = "0xdeadbeef"
+
+    request_calls = []
+
+    def fake_request(method, path, **kwargs):
+        request_calls.append((method, path))
+        if path.endswith("prepare"):
+            return PREPARE_RESPONSE
+        return {"success": True}
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("eth_account.Account.sign_typed_data", return_value=fake_sig):
+            result = client.activate_polymarket_dw()
+
+    assert result == {"already_set": False, "calls_count": 1, "success": True}
+    assert request_calls[0] == ("POST", "/api/user/wallet/external/dw-approvals/prepare")
+    assert request_calls[1][1].endswith("submit")
+
+    # Confirm submit body included the signature
+    _, submit_path = request_calls[1]
+    assert "submit" in submit_path
+
+
+def test_submit_failure_propagates():
+    client = _make_client()
+    fake_sig = MagicMock()
+    fake_sig.signature.hex.return_value = "0xdeadbeef"
+
+    def fake_request(method, path, **kwargs):
+        if path.endswith("prepare"):
+            return PREPARE_RESPONSE
+        raise RuntimeError("relayer rejected")
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("eth_account.Account.sign_typed_data", return_value=fake_sig):
+            with pytest.raises(RuntimeError, match="relayer rejected"):
+                client.activate_polymarket_dw()


### PR DESCRIPTION
## Summary
- Adds `client.activate_polymarket_dw()` to `SimmerClient` — external wallet users with a Deposit Wallet can now complete the one-time Polymarket approval batch headlessly, no browser required
- Signs the EIP-712 batch locally with `WALLET_PRIVATE_KEY` (key never leaves the process), submits via `/dw-approvals/submit`
- No backend changes needed — both endpoints already accepted SDK API key auth via `_resolve_user_id_from_request`
- Updates `simmer-wallet-setup` skill to document the new method
- Bumps to 0.17.6

## How it works
1. `POST /dw-approvals/prepare` → server returns EIP-712 typed data batch
2. Sign with `eth-account.Account.sign_typed_data()` locally
3. `POST /dw-approvals/submit` → server relays to Polymarket, polls until mined, flips `polymarket_allowances_set=TRUE`

## Test plan
- [ ] 5 unit tests pass (already_set short-circuit, prepare failure, missing key, happy path, submit failure)
- [ ] Verify against a real DW account: `client.activate_polymarket_dw()` prints progress and returns `{"already_set": False, "calls_count": N, "success": True}`
- [ ] Re-run returns `{"already_set": True, ...}` (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)