### PR TITLE
feat(sdk): add client.wrap_on_dw() — headless USDC.e wrap (0.17.7) (SIM-1730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.7] — 2026-05-12
+
+### Added
+
+- **`client.wrap_on_dw()` — headless USDC.e wrap for external-wallet DW users (SIM-1730).** External-wallet operators with stranded USDC.e on their Polymarket Deposit Wallet can now wrap to pUSD directly from the SDK without a browser session. Mirrors the `activate_polymarket_dw()` shape exactly (EIP-712 prepare → sign → submit). Supports both `WALLET_PRIVATE_KEY` (local signing) and OWS wallet. Idempotent: returns `wrapped=False, amount_units=0` immediately when the deposit wallet has no stranded balance.
+
+  Return shape: `{"wrapped": bool, "amount_units": int, "calls_count": int, "success": bool}`.
+
+  Surfaced by Track 5 of the external-wallet signer-picker workstream.
+
 ## [0.17.4] — 2026-05-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.6"
+version = "0.17.7"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -4301,6 +4301,115 @@ class SimmerClient:
         print(f"[DW-Activate] Done — {len(calls)} approval(s) set.")
         return {"already_set": False, "calls_count": len(calls), "success": True}
 
+    def wrap_on_dw(self) -> Dict[str, Any]:
+        """Wrap stranded USDC.e on the Deposit Wallet to pUSD headlessly.
+
+        Calls /wrap-on-dw/external/prepare to get the EIP-712 batch, signs
+        it locally with WALLET_PRIVATE_KEY (key never leaves the process),
+        then submits via /wrap-on-dw/external/submit. No browser required.
+
+        Idempotent: if there is no stranded USDC.e on the deposit wallet
+        (amount_units == 0), returns immediately with wrapped=False.
+
+        Requires:
+        - WALLET_PRIVATE_KEY env var (or private_key constructor arg),
+          OR OWS_WALLET env var (or ows_wallet constructor arg)
+        - Account upgraded to a Deposit Wallet (wallet_uses_deposit_wallet=True)
+        - eth-account: pip install eth-account
+
+        Returns:
+            Dict with keys:
+            - wrapped (bool): True if a wrap transaction was submitted
+            - amount_units (int): USDC.e units wrapped (0 if nothing to wrap)
+            - calls_count (int): number of batch calls submitted (0 if no-op)
+            - success (bool): True on completion
+
+        Raises:
+            ValueError: if no private key is configured
+            ImportError: if eth-account is not installed
+
+        Example:
+            client = SimmerClient(api_key="sk_live_...")  # WALLET_PRIVATE_KEY in env
+            result = client.wrap_on_dw()
+            if result["wrapped"]:
+                print(f"Wrapped {result['amount_units']} USDC.e units to pUSD")
+            else:
+                print("Nothing to wrap — deposit wallet already clean")
+        """
+        if not self._private_key and not self._ows_wallet:
+            raise ValueError(
+                "wrap_on_dw() requires a signing key. "
+                "Set WALLET_PRIVATE_KEY env var, pass private_key to the constructor, "
+                "or configure an OWS wallet (OWS_WALLET env var or ows_wallet arg)."
+            )
+
+        if self._private_key:
+            try:
+                from eth_account import Account  # noqa: F401 — early dep check
+            except ImportError:
+                raise ImportError(
+                    "eth-account is required for wrap_on_dw(). "
+                    "Install with: pip install eth-account"
+                )
+
+        # Step 1 — prepare: server checks on-chain USDC.e balance and returns
+        # the EIP-712 batch. Returns amount_units=0 when nothing to wrap.
+        print("[WrapOnDW] Preparing wrap batch…")
+        prepare = self._request(
+            "POST",
+            "/api/user/wallet/wrap-on-dw/external/prepare",
+        )
+
+        amount_units = prepare.get("amount_units", 0)
+        if not amount_units:
+            print("[WrapOnDW] No stranded USDC.e found — nothing to wrap.")
+            return {"wrapped": False, "amount_units": 0, "calls_count": 0, "success": True}
+
+        typed_data = prepare.get("typed_data")
+        nonce = prepare.get("nonce")
+        deadline = prepare.get("deadline")
+        calls = prepare.get("calls", [])
+
+        if not typed_data or not nonce or deadline is None or not calls:
+            raise RuntimeError(
+                f"Unexpected prepare response — missing required fields. "
+                f"Got keys: {list(prepare.keys())}"
+            )
+
+        # Step 2 — sign locally. Same pattern as activate_polymarket_dw:
+        # pass the full typed_data dict via full_message so primaryType is
+        # honoured. Key never leaves this process.
+        print(f"[WrapOnDW] Signing batch for {amount_units / 1_000_000:.2f} USDC.e…")
+        if self._private_key:
+            from eth_account import Account
+            signed = Account.sign_typed_data(self._private_key, full_message=typed_data)
+            signature = signed.signature.hex()
+            if not signature.startswith("0x"):
+                signature = "0x" + signature
+        else:
+            from simmer_sdk.ows_utils import ows_sign_typed_data
+            import json as _json
+            sig = ows_sign_typed_data(self._ows_wallet, _json.dumps(typed_data))
+            signature = sig if sig.startswith("0x") else "0x" + sig
+
+        # Step 3 — submit: server validates the batch shape, relays via
+        # Polymarket's builder with our HMAC, polls until STATE_MINED.
+        print("[WrapOnDW] Submitting to relayer…")
+        self._request(
+            "POST",
+            "/api/user/wallet/wrap-on-dw/external/submit",
+            json={
+                "signature": signature,
+                "calls": calls,
+                "nonce": nonce,
+                "deadline": deadline,
+                "amount_units": amount_units,
+            },
+        )
+
+        print(f"[WrapOnDW] Done — {len(calls)} call(s), {amount_units / 1_000_000:.2f} USDC.e wrapped.")
+        return {"wrapped": True, "amount_units": amount_units, "calls_count": len(calls), "success": True}
+
     def register_agent_wallet(self, ows_wallet_name: str) -> dict:
         """Register an OWS wallet for this agent. Elite-only (beta).
 

--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -125,11 +125,16 @@ client.set_approvals()  # signs approval txs locally — fully headless, key nev
 
 # If your account uses a Polymarket Deposit Wallet (Elite / upgraded accounts):
 client.activate_polymarket_dw()  # one-time — signs EIP-712 batch locally, no browser needed
+
+# If you have stranded USDC.e on your Deposit Wallet, wrap it to pUSD:
+result = client.wrap_on_dw()  # idempotent — no-op when nothing stranded
 ```
 
 Both calls work without a browser session. `link_wallet()` signs a challenge with your local key. `set_approvals()` builds, signs, and broadcasts each approval transaction via Simmer's RPC proxy — your `WALLET_PRIVATE_KEY` never leaves the agent process.
 
 > **Using a Deposit Wallet?** If your account has been upgraded to a Polymarket Deposit Wallet (DW), run `client.activate_polymarket_dw()` after `set_approvals()` — it signs the EIP-712 activation batch headlessly with your local key. Alternatively, use the dashboard browser flow at [simmer.markets/dashboard](https://simmer.markets/dashboard) → Wallets → Activate Trading.
+
+> **Stranded USDC.e on your DW?** Run `client.wrap_on_dw()` to convert it to pUSD headlessly. Idempotent — safe to call on every startup; returns immediately if nothing is stranded. Returns `{"wrapped": bool, "amount_units": int, "calls_count": int, "success": bool}`. Requires the same key as `activate_polymarket_dw()` (WALLET_PRIVATE_KEY or OWS wallet). Added in SDK 0.17.7.
 
 ### Migrating to OWS when ready
 

--- a/tests/test_wrap_on_dw.py
+++ b/tests/test_wrap_on_dw.py
@@ -1,0 +1,169 @@
+"""Tests for client.wrap_on_dw() (0.17.7).
+
+Pure unit tests — no network, no real signing.
+Covers:
+  - no-op short-circuit when amount_units == 0
+  - missing private key raises ValueError before any network call
+  - prepare failure propagation
+  - full happy-path: prepare → sign → submit (private-key path)
+  - full happy-path: OWS path
+  - submit failure propagation
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+API_BASE = "https://api.simmer.example.com/api"
+FAKE_KEY = "sk_live_testkey"
+FAKE_PRIVATE_KEY = "0x" + "ab" * 32
+
+FAKE_TYPED_DATA = {
+    "domain": {"name": "DepositWallet", "version": "1", "chainId": 137},
+    "types": {
+        "DepositWalletBatch": [
+            {"name": "calls", "type": "DepositWalletCall[]"},
+            {"name": "nonce", "type": "uint256"},
+            {"name": "deadline", "type": "uint256"},
+        ],
+        "DepositWalletCall": [
+            {"name": "target", "type": "address"},
+            {"name": "value", "type": "uint256"},
+            {"name": "data", "type": "bytes"},
+        ],
+    },
+    "primaryType": "DepositWalletBatch",
+    "message": {"calls": [], "nonce": "1", "deadline": 9999999999},
+}
+
+FAKE_CALLS = [{"target": "0xOnramp", "value": "0", "data": "0x12345678"}]
+
+PREPARE_RESPONSE = {
+    "wrapped": False,
+    "calls": FAKE_CALLS,
+    "typed_data": FAKE_TYPED_DATA,
+    "nonce": "77",
+    "deadline": "9999999999",
+    "amount_units": 5_000_000,  # $5.00
+    "amount_usd": 5.0,
+    "needs_approve": False,
+    "deposit_wallet_address": "0xDW",
+    "eoa_address": "0xEOA",
+}
+
+PREPARE_NO_OP = {
+    "wrapped": False,
+    "amount_units": 0,
+    "deposit_wallet_address": "0xDW",
+    "message": "No USDC.e on deposit wallet to wrap.",
+}
+
+
+def _make_client(private_key=FAKE_PRIVATE_KEY, ows_wallet=None):
+    client = SimmerClient.__new__(SimmerClient)
+    client._api_key = FAKE_KEY
+    client._api_base = API_BASE
+    client._private_key = private_key
+    client._ows_wallet = ows_wallet
+    client._wallet_address = "0xEOA"
+    client._session = MagicMock()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_raises_without_private_key():
+    client = _make_client(private_key=None, ows_wallet=None)
+    with pytest.raises(ValueError, match="signing key"):
+        client.wrap_on_dw()
+
+
+def test_no_op_when_amount_units_zero():
+    client = _make_client()
+    with patch.object(client, "_request", return_value=PREPARE_NO_OP) as mock_req:
+        result = client.wrap_on_dw()
+
+    assert result == {"wrapped": False, "amount_units": 0, "calls_count": 0, "success": True}
+    mock_req.assert_called_once_with("POST", "/api/user/wallet/wrap-on-dw/external/prepare")
+
+
+def test_prepare_failure_propagates():
+    client = _make_client()
+    with patch.object(client, "_request", side_effect=RuntimeError("HTTP 503")):
+        with pytest.raises(RuntimeError, match="503"):
+            client.wrap_on_dw()
+
+
+def test_happy_path_private_key():
+    client = _make_client()
+
+    fake_sig = MagicMock()
+    fake_sig.signature.hex.return_value = "0xdeadbeef"
+
+    request_calls = []
+    submit_kwargs = {}
+
+    def fake_request(method, path, **kwargs):
+        request_calls.append((method, path))
+        if path.endswith("prepare"):
+            return PREPARE_RESPONSE
+        submit_kwargs.update(kwargs)
+        return {"wrapped": True, "tx_hash": "0xabc"}
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("eth_account.Account.sign_typed_data", return_value=fake_sig):
+            result = client.wrap_on_dw()
+
+    assert result == {"wrapped": True, "amount_units": 5_000_000, "calls_count": 1, "success": True}
+    assert request_calls[0] == ("POST", "/api/user/wallet/wrap-on-dw/external/prepare")
+    assert request_calls[1][1].endswith("submit")
+
+    # Submit body must echo calls, nonce, deadline, amount_units, signature
+    body = submit_kwargs.get("json", {})
+    assert body["amount_units"] == 5_000_000
+    assert body["calls"] == FAKE_CALLS
+    assert body["nonce"] == "77"
+    assert body["signature"].startswith("0x")
+
+
+def test_happy_path_ows():
+    client = _make_client(private_key=None, ows_wallet="my-agent-wallet")
+
+    request_calls = []
+
+    def fake_request(method, path, **kwargs):
+        request_calls.append((method, path))
+        if path.endswith("prepare"):
+            return PREPARE_RESPONSE
+        return {"wrapped": True, "tx_hash": "0xabc"}
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("simmer_sdk.ows_utils.ows_sign_typed_data", return_value="0xcafebabe"):
+            result = client.wrap_on_dw()
+
+    assert result["wrapped"] is True
+    assert result["success"] is True
+    assert request_calls[1][1].endswith("submit")
+
+
+def test_submit_failure_propagates():
+    client = _make_client()
+    fake_sig = MagicMock()
+    fake_sig.signature.hex.return_value = "0xdeadbeef"
+
+    def fake_request(method, path, **kwargs):
+        if path.endswith("prepare"):
+            return PREPARE_RESPONSE
+        raise RuntimeError("relayer rejected")
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("eth_account.Account.sign_typed_data", return_value=fake_sig):
+            with pytest.raises(RuntimeError, match="relayer rejected"):
+                client.wrap_on_dw()


### PR DESCRIPTION
Headless companion to SDK 0.17.6's `activate_polymarket_dw()`. External-wallet users with stranded USDC.e on their Deposit Wallet can now wrap to pUSD from agents without ever touching a browser.

## Changes

- `simmer_sdk/client.py`: add `wrap_on_dw()` method (~105 lines) mirroring `activate_polymarket_dw()` shape — EIP-712 prepare/sign/submit, private-key + OWS paths, idempotent no-op when `amount_units == 0`
- `tests/test_wrap_on_dw.py`: 6 unit tests — no-op, missing key, prepare failure, happy-path private key, happy-path OWS, submit failure
- `pyproject.toml`: bump 0.17.6 → 0.17.7
- `CHANGELOG.md`: add [0.17.7] entry
- `skills/simmer-wallet-setup/SKILL.md`: document `wrap_on_dw()` in setup snippet + callout box

## Tests

- `python3 -m pytest tests/test_wrap_on_dw.py -v` → 6/6 PASSED

## Acceptance criteria

- [x] `client.wrap_on_dw()` callable with `WALLET_PRIVATE_KEY` (no browser)
- [x] `client.wrap_on_dw()` callable with `OWS_WALLET` (no browser)
- [x] Idempotent: returns clean no-op when `amount_units == 0`
- [x] Return shape: `{"wrapped", "amount_units", "calls_count", "success"}`
- [x] Tests pass; covers PK path + OWS path + no-op + missing key error
- [x] CHANGELOG entry + version bump + skill.md updated

Closes SIM-1730