### PR TITLE
fix(sdk-tests): update test_agent_wallets_sdk.py to match 0.17.5 behavior

### DIFF
--- a/tests/test_agent_wallets_sdk.py
+++ b/tests/test_agent_wallets_sdk.py
@@ -41,10 +41,11 @@ class TestRegisterAgentWallet:
         result = client.register_agent_wallet("agent-test")
 
         mock_addr.assert_called_once_with("agent-test")
+        # PR #73 (0.17.5): agent_id is now derived server-side from the API
+        # key; the SDK only sends ows_wallet_name + wallet_address.
         client._request.assert_called_once_with(
             "POST", "/api/sdk/agent-wallet/register",
             json={
-                "agent_id": "test-agent-uuid",
                 "ows_wallet_name": "agent-test",
                 "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
             }
@@ -87,20 +88,13 @@ class TestGetAgentWallets:
 
 class TestGetAgentWalletPnl:
 
-    def test_uses_default_agent_id(self):
+    def test_raises_when_agent_id_missing(self):
+        """PR #73 (0.17.5): agent_id is now a required arg — no default-to-
+        self._agent_id fallback. Multi-agent clients must specify which agent
+        they want P&L for explicitly."""
         client = _make_client(agent_id="my-agent")
-        client._request.return_value = {
-            "agent_id": "my-agent",
-            "realized_pnl": 10.0,
-            "unrealized_pnl": -2.0,
-            "total_cost": 50.0,
-            "positions": [],
-        }
-
-        pnl = client.get_agent_wallet_pnl()
-
-        client._request.assert_called_once_with("GET", "/api/sdk/agent-wallet/my-agent/pnl")
-        assert pnl["realized_pnl"] == 10.0
+        with pytest.raises(ValueError, match="agent_id is required"):
+            client.get_agent_wallet_pnl()
 
     def test_accepts_custom_agent_id(self):
         client = _make_client(agent_id="default-agent")
@@ -122,7 +116,7 @@ class TestGetAgentWalletPnl:
             "positions": [],
         }
 
-        pnl = client.get_agent_wallet_pnl()
+        pnl = client.get_agent_wallet_pnl("my-agent")
 
         assert pnl["unrealized_pnl"] == 0.0
         assert isinstance(pnl["unrealized_pnl"], float)
@@ -137,7 +131,7 @@ class TestGetAgentWalletPnl:
             "positions": [],
         }
 
-        pnl = client.get_agent_wallet_pnl()
+        pnl = client.get_agent_wallet_pnl("my-agent")
 
         assert pnl["unrealized_pnl"] == 0.0
 


### PR DESCRIPTION
## Summary

Pure test cleanup — no production code changes. Unblocks `simmer-sdk` CI without admin-merge.

PR #73 (0.17.5) intentionally changed two behaviors that the unit tests didn't follow:

1. `register_agent_wallet()` no longer sends `agent_id` in the POST payload (server derives from API key). Test asserted the old 3-field payload.
2. `get_agent_wallet_pnl(agent_id=None)` now raises `ValueError` instead of falling back to `self._agent_id`. 3 tests called it with no arg.

This PR updates the 4 assertions to match. The behavior changes themselves are intentional per PR #73's design.

## Note on John's report

`johng@iexecutellc.com` (2026-05-12) reported `register_agent_wallet()` failed with *"ows Python package which isn't on PyPI"*. Investigation confirms **this is not related to these test failures**. His error is from `get_ows_wallet_address` → `import ows` → the install-instructions ImportError. The pip package is `open-wallet-standard`; the import name is `ows`. Pure user confusion, no behavior bug.

## Test plan

- [x] `pytest tests/test_agent_wallets_sdk.py` — 11/11 pass locally
- [x] `pytest tests/` — only pre-existing `test_client_constructors.py` failures remain (env-specific, pass in CI)
- [ ] CI green on 3.10 + 3.12

Closes SIM-1734
Refs _external-wallet-signer-picker workstream (test cleanup observed during SIM-1730 admin-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)