### PR TITLE
feat(0.17.8): add [ows] optional extra — fixes install-name confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.8] — 2026-05-12
+
+### Added
+
+- **`[ows]` optional extra — one-command OWS install (SIM-1735).** New `pip install 'simmer-sdk[ows]'` pulls in `open-wallet-standard` (the Python bindings for the Open Wallet Standard) alongside the SDK. Eliminates the package-name vs import-name confusion (pip package is `open-wallet-standard`; import is `ows`) that bit our first OWS canary on 2026-05-12. Existing users on `pip install open-wallet-standard` directly still work — the extra is additive, not a breaking change.
+
+### Changed
+
+- Install hints in `ows_utils.py`, `client.py`, and `simmer-wallet-setup/SKILL.md` now recommend `pip install 'simmer-sdk[ows]'` as the primary install path, with `pip install open-wallet-standard` shown as the direct alternative.
+
 ## [0.17.7] — 2026-05-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.7"
+version = "0.17.8"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [
@@ -40,6 +40,22 @@ dependencies = [
     # working release; the helper API is stable.
     "polynode>=0.10.3",
 ]
+
+[project.optional-dependencies]
+# Open Wallet Standard — local-first encrypted wallet vault with policy
+# engine. Required for OWS-mode signing (per-agent isolation, recommended
+# for new agents). Not a hard dep because most SDK users today use
+# private-key mode (`WALLET_PRIVATE_KEY` env var) which is the default;
+# OWS is opt-in.
+#
+# Install with: pip install 'simmer-sdk[ows]'
+#
+# Note: the import name `ows` differs from the pip package name
+# `open-wallet-standard`. Surfaced 2026-05-12 via johng@iexecutellc —
+# users searching PyPI for `ows` find nothing. The `[ows]` extra
+# eliminates the asymmetry: one install command, no package-name lookup
+# required.
+ows = ["open-wallet-standard>=1.3.0"]
 
 [project.urls]
 Homepage = "https://simmer.markets"

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -205,7 +205,7 @@ class SimmerClient:
                 - Ensure your bot runs in a secure environment
             ows_wallet: Optional OWS wallet name for Polymarket trading.
                 When provided, orders are signed via OWS — your private key
-                never leaves the OWS vault. Install with: pip install open-wallet-standard
+                never leaves the OWS vault. Install with: pip install 'simmer-sdk[ows]'
                 Create a wallet: ows wallet create --name my-agent
 
                 If not provided, the SDK will auto-detect from the OWS_WALLET
@@ -281,7 +281,8 @@ class SimmerClient:
             except ImportError:
                 logger.warning(
                     "OWS wallet '%s' specified but open-wallet-standard not installed. "
-                    "Install with: pip install open-wallet-standard",
+                    "Install with: pip install 'simmer-sdk[ows]' "
+                    "(or directly: pip install open-wallet-standard)",
                     effective_ows
                 )
                 self._ows_wallet = None

--- a/simmer_sdk/ows_utils.py
+++ b/simmer_sdk/ows_utils.py
@@ -44,7 +44,8 @@ def get_ows_wallet_address(wallet_name: str) -> str:
     except ImportError:
         raise ImportError(
             "open-wallet-standard is required for OWS wallet mode. "
-            "Install with: pip install open-wallet-standard"
+            "Install with: pip install 'simmer-sdk[ows]' "
+            "(or directly: pip install open-wallet-standard)"
         )
 
     try:

--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -39,9 +39,11 @@ OWS = [Open Wallet Standard](https://openwallet.sh). Local-first encrypted vault
 ### One-time setup
 
 ```bash
-# Install OWS CLI
+# Install OWS CLI (creates ~/.ows vault, runs `ows wallet create`)
 curl -fsSL https://docs.openwallet.sh/install.sh | bash
-pip install open-wallet-standard
+
+# Install the SDK with OWS Python bindings (one command — note the [ows] extra)
+pip install 'simmer-sdk[ows]'
 
 # Create a wallet for this agent
 ows wallet create --name "my-agent-wallet"


### PR DESCRIPTION
## Summary

`johng@iexecutellc.com` (canary OWS user, 2026-05-12) reported `register_agent_wallet()` failed because *"the `ows` Python package isn't on PyPI"*. Root cause: pip package name (`open-wallet-standard`) ≠ import name (`ows`). Even though our error messages already said *"pip install open-wallet-standard"*, agent harnesses can intercept the bare `ImportError("No module named 'ows'")` before our hint surfaces — and users naturally try `pip install ows` first, finding nothing.

Structural fix: add an `[ows]` optional extra. Users now run **one command** — `pip install 'simmer-sdk[ows]'` — and never need to discover the underlying package name.

## Changes

- **`pyproject.toml`**: new `[project.optional-dependencies] ows = ["open-wallet-standard>=1.3.0"]`
- **`simmer_sdk/ows_utils.py`** + **`simmer_sdk/client.py`**: ImportError + docstring now recommend `pip install 'simmer-sdk[ows]'` (with `pip install open-wallet-standard` shown as the direct alternative)
- **`skills/simmer-wallet-setup/SKILL.md`**: lead with the `[ows]` extra, dropped the two-line install pattern
- **`CHANGELOG.md`**: 0.17.8 entry

## Why not a hard dep

`open-wallet-standard` is a 2.1MB native-Rust binding. Most SDK users today use private-key mode (`WALLET_PRIVATE_KEY`) which is the default; OWS is opt-in for per-agent isolation. Hard-depping would bloat install for the majority who don't need it. The optional-extra idiom is the standard Python answer here.

## Test plan

- [x] `pytest tests/test_agent_wallets_sdk.py tests/test_activate_polymarket_dw.py tests/test_wrap_on_dw.py` — 22/22 pass
- [x] `python -m build` clean
- [x] `pip install --dry-run dist/simmer_sdk-0.17.8-py3-none-any.whl[ows]` resolves `open-wallet-standard-1.3.2`
- [ ] CI green
- [ ] PyPI publish post-merge

Closes SIM-1735
Refs _external-wallet-signer-picker workstream Track 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)