### PR TITLE
feat(sdk): emit DeprecationWarning for V1-incompatible SDK versions (SIM-1788)

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -407,6 +407,15 @@ class SimmerClient:
             except Exception as e:
                 logger.warning("Risk alert check failed: %s", e)
 
+        # Server-side SDK version compatibility check (fail-quiet).
+        # Emits DeprecationWarning if the server says this SDK version is
+        # deprecated or blocked.  One call per client instance, no re-check.
+        try:
+            from .version_check import check_server_version_compatibility
+            check_server_version_compatibility(self.base_url, _sdk_version, self._session)
+        except Exception as e:
+            logger.debug("SDK version check setup error — ignoring: %s", e)
+
     def __repr__(self):
         return f"SimmerClient(venue={self.venue!r}, base_url={self.base_url!r})"
 

--- a/simmer_sdk/version_check.py
+++ b/simmer_sdk/version_check.py
@@ -29,7 +29,7 @@ def check_server_version_compatibility(
 ) -> None:
     """Hit the server's version-check endpoint and emit a warning if needed.
 
-    Emits ``DeprecationWarning`` (stacklevel=4 so the warning points at the
+    Emits ``DeprecationWarning`` (stacklevel=3 so the warning points at the
     caller's ``SimmerClient(...)`` line) when status is ``deprecated`` or
     ``blocked``.
 
@@ -55,5 +55,5 @@ def check_server_version_compatibility(
     message = data.get("message", "")
 
     if status in ("deprecated", "blocked"):
-        warnings.warn(message, DeprecationWarning, stacklevel=4)
+        warnings.warn(message, DeprecationWarning, stacklevel=3)
         logger.debug("SDK version check result: %s — %s", status, message)

--- a/simmer_sdk/version_check.py
+++ b/simmer_sdk/version_check.py
@@ -1,0 +1,59 @@
+"""
+SDK version-check helper.
+
+Called once from SimmerClient.__init__ to ask the server whether this SDK
+version is ok / deprecated / blocked and emit a DeprecationWarning when the
+server says so.
+
+Design constraints:
+- Fail-quiet on any network error (SDK must not hard-fail at startup because
+  our server is briefly unreachable).
+- Cache result for the lifetime of the client (no re-check per API call).
+- No extra RTT on every cold start — the check is fire-and-forget from the
+  caller's perspective (called synchronously but swallows all exceptions).
+"""
+from __future__ import annotations
+
+import logging
+import warnings
+
+logger = logging.getLogger(__name__)
+
+VERSION_CHECK_PATH = "/api/sdk/version-check"
+
+
+def check_server_version_compatibility(
+    base_url: str,
+    sdk_version: str,
+    session,  # requests.Session — already configured with auth headers
+) -> None:
+    """Hit the server's version-check endpoint and emit a warning if needed.
+
+    Emits ``DeprecationWarning`` (stacklevel=4 so the warning points at the
+    caller's ``SimmerClient(...)`` line) when status is ``deprecated`` or
+    ``blocked``.
+
+    Never raises — all exceptions are caught and logged at DEBUG level so the
+    SDK never hardens into a startup failure.
+
+    Args:
+        base_url:    Client base URL (no trailing slash), e.g.
+                     "https://api.simmer.markets".
+        sdk_version: The SDK's own ``__version__`` string.
+        session:     Configured ``requests.Session`` to reuse for the call.
+    """
+    url = f"{base_url.rstrip('/')}{VERSION_CHECK_PATH}"
+    try:
+        resp = session.get(url, params={"sdk_version": sdk_version}, timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.debug("SDK version check failed (network/parse error) — ignoring: %s", exc)
+        return
+
+    status = data.get("status", "ok")
+    message = data.get("message", "")
+
+    if status in ("deprecated", "blocked"):
+        warnings.warn(message, DeprecationWarning, stacklevel=4)
+        logger.debug("SDK version check result: %s — %s", status, message)

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for simmer_sdk/version_check.py.
+
+All network calls are mocked — pure unit tests, no server needed.
+"""
+import warnings
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(status_code: int, json_body: dict):
+    """Return a mock requests.Session whose .get() returns the given response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = json_body
+    mock_resp.raise_for_status.return_value = None  # no-op for 200
+
+    session = MagicMock()
+    session.get.return_value = mock_resp
+    return session
+
+
+def _make_error_session(exc):
+    """Return a mock session whose .get() raises the given exception."""
+    session = MagicMock()
+    session.get.side_effect = exc
+    return session
+
+
+# ---------------------------------------------------------------------------
+# check_server_version_compatibility
+# ---------------------------------------------------------------------------
+
+class TestCheckServerVersionCompatibility:
+    from simmer_sdk.version_check import check_server_version_compatibility
+
+    def test_ok_status_no_warning(self):
+        session = _make_session(200, {"status": "ok", "message": "all good"})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            check_server_version_compatibility("https://api.simmer.markets", "0.17.0", session)
+        assert len(w) == 0
+
+    def test_deprecated_emits_deprecation_warning(self):
+        msg = "simmer-sdk 0.13.0 is outdated. Upgrade recommended."
+        session = _make_session(200, {"status": "deprecated", "message": msg})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            check_server_version_compatibility("https://api.simmer.markets", "0.13.0", session)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "0.13.0" in str(w[0].message)
+
+    def test_blocked_emits_deprecation_warning(self):
+        msg = "simmer-sdk 0.9.2 is too old. Upgrade immediately."
+        session = _make_session(200, {"status": "blocked", "message": msg})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            check_server_version_compatibility("https://api.simmer.markets", "0.9.2", session)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "0.9.2" in str(w[0].message)
+
+    def test_network_error_is_fail_quiet(self):
+        """ConnectionError must not propagate — SDK startup must not break."""
+        import requests
+        session = _make_error_session(requests.exceptions.ConnectionError("unreachable"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            # Should not raise
+            check_server_version_compatibility("https://api.simmer.markets", "0.9.2", session)
+        # No warning emitted either — network error is silently swallowed
+        assert len(w) == 0
+
+    def test_timeout_is_fail_quiet(self):
+        import requests
+        session = _make_error_session(requests.exceptions.Timeout("timed out"))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            check_server_version_compatibility("https://api.simmer.markets", "0.17.0", session)
+        assert len(w) == 0
+
+    def test_bad_json_is_fail_quiet(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.side_effect = ValueError("invalid json")
+        session = MagicMock()
+        session.get.return_value = mock_resp
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            check_server_version_compatibility("https://api.simmer.markets", "0.9.0", session)
+        assert len(w) == 0
+
+    def test_http_error_is_fail_quiet(self):
+        import requests
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
+        session = MagicMock()
+        session.get.return_value = mock_resp
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from simmer_sdk.version_check import check_server_version_compatibility
+            check_server_version_compatibility("https://api.simmer.markets", "0.9.0", session)
+        assert len(w) == 0
+
+    def test_correct_url_constructed(self):
+        session = _make_session(200, {"status": "ok", "message": ""})
+        from simmer_sdk.version_check import check_server_version_compatibility
+        check_server_version_compatibility("https://api.simmer.markets/", "0.17.0", session)
+        call_args = session.get.call_args
+        url = call_args[0][0]
+        # trailing slash stripped, path appended
+        assert url == "https://api.simmer.markets/api/sdk/version-check"
+
+    def test_sdk_version_passed_as_query_param(self):
+        session = _make_session(200, {"status": "ok", "message": ""})
+        from simmer_sdk.version_check import check_server_version_compatibility
+        check_server_version_compatibility("https://api.simmer.markets", "0.9.1", session)
+        call_kwargs = session.get.call_args[1]
+        assert call_kwargs.get("params", {}).get("sdk_version") == "0.9.1"


### PR DESCRIPTION
SDK half of SIM-1788 — adds the version-check call to `SimmerClient.__init__` so zombie bots on old SDK versions get a clear stderr warning on their next polling cycle.

## Changes
- `simmer_sdk/version_check.py`: new helper — calls `GET /api/sdk/version-check` once per client instance, emits `DeprecationWarning` on `deprecated` or `blocked` status. Fail-quiet on all network/parse errors (timeout=5s, exception caught at DEBUG level).
- `simmer_sdk/client.py`: call `check_server_version_compatibility()` at the end of `__init__`, after the session is built and risk-alert check runs. Wrapped in try/except so import error can't hard-fail client init.
- `tests/test_version_check.py`: 9 unit tests — ok/deprecated/blocked status, ConnectionError, Timeout, bad JSON, HTTP 500, URL construction, query param passing.

## Tests
```
9 passed in 0.39s
```

Refs SIM-1788