### PR TITLE
feat(risk): oracle-engineering halt gate for short-dated Chainlink-resolved markets (SIM-1556)

### DIFF
--- a/simmer_sdk/risk/__init__.py
+++ b/simmer_sdk/risk/__init__.py
@@ -1,0 +1,10 @@
+"""
+Simmer SDK — Risk primitives.
+
+Defensive detectors that gate automated MM/copytrade skills.
+These are halt signals only — never buy/trade signals.
+"""
+
+from .oracle_engineering import OracleEngineeringDetector, RiskFlag, RiskLevel
+
+__all__ = ["OracleEngineeringDetector", "RiskFlag", "RiskLevel"]

--- a/simmer_sdk/risk/oracle_engineering.py
+++ b/simmer_sdk/risk/oracle_engineering.py
@@ -1,0 +1,340 @@
+"""
+Oracle-engineering risk detector for short-dated Chainlink-resolved Polymarket markets.
+
+Background (oracle-engineering concept, a4385 case):
+  An adversary pre-positions heavily on one side of a short-dated UP/DOWN Polymarket
+  market, then executes a large spot buy/sell on the underlying (e.g. BTC on Binance)
+  ~2 minutes before the Chainlink oracle snapshot, moving the honest oracle read to
+  match their PM position. ~$300K extracted per incident; detection requires cross-venue
+  correlation between PM concentration and underlying spot flow.
+
+This detector is a **halt gate only**:
+  - NEVER use as a buy-the-attacker or copy-trade signal.
+  - Only gates automated MM/copytrade skills in the same market.
+  - Never blocks the user's own discretionary trades.
+
+Usage:
+    detector = OracleEngineeringDetector()
+    flag = detector.evaluate(
+        market_id="0x...",
+        position_book={"YES": 77000, "NO": 10000, "total": 87000},
+        spot_flow_window=[
+            {"side": "buy", "size": 900000, "ts": 1714948740},
+            ...
+        ],
+        minutes_to_resolution=4.0,
+    )
+    if flag.level == RiskLevel.HIGH:
+        # Widen spreads ≥3× or skip trade; log with risk_flag="oracle_engineering"
+        pass
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class RiskLevel(str, Enum):
+    NONE = "none"
+    LOW = "low"       # one signal present; monitor
+    HIGH = "high"     # both signals diverge within resolution window → halt
+
+
+@dataclass
+class RiskFlag:
+    """
+    Result of OracleEngineeringDetector.evaluate().
+
+    Fields:
+      level        — NONE / LOW / HIGH
+      market_id    — the market evaluated
+      reason       — human-readable diagnosis
+      pm_concentration — fraction held by top wallet(s) on one side (0-1)
+      spot_sigma   — spot flow imbalance in standard-deviation units
+      minutes_to_resolution — how close to resolution at evaluation time
+      risk_flag    — constant string "oracle_engineering" for log tagging
+    """
+
+    level: RiskLevel = RiskLevel.NONE
+    market_id: str = ""
+    reason: str = ""
+    pm_concentration: float = 0.0
+    spot_sigma: float = 0.0
+    minutes_to_resolution: float = 0.0
+    risk_flag: str = "oracle_engineering"
+
+    @property
+    def should_halt(self) -> bool:
+        """True when automated skills must widen spreads ≥3× or skip the trade."""
+        return self.level == RiskLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Detector
+# ---------------------------------------------------------------------------
+
+
+class OracleEngineeringDetector:
+    """
+    Lightweight detector for oracle-engineering risk on short-dated
+    Chainlink-resolved Polymarket UP/DOWN markets.
+
+    Algorithm (mirrors the a4385 signature):
+      1. Compute PM-side concentration: fraction of total open interest held by the
+         top wallet(s) on the *winning* side.  Threshold: ≥ concentration_threshold
+         (default 0.60 = 60%).
+      2. Compute spot flow sigma: measure the flow imbalance in the underlying spot
+         market over the resolution window.  Using baseline mean/stdev from the
+         provided window, express current imbalance as a z-score.  Threshold:
+         ≥ spot_sigma_threshold (default 2.0σ).
+      3. Direction divergence check: the PM concentration must be on the side that
+         BENEFITS from the spot flow direction.  If both signals agree directionally
+         (clean momentum run), no flag is emitted.
+      4. Window gate: both signals must be observed within minutes_to_resolution ≤
+         resolution_window_minutes (default 5) to qualify as HIGH risk.  Signals
+         outside the window may emit LOW at most.
+
+    Args:
+      concentration_threshold: float — minimum fraction of one side's OI held by
+        top wallet(s) to consider concentrated.  Default 0.60.
+      spot_sigma_threshold: float — minimum z-score of spot flow imbalance to
+        consider a meaningful directional push.  Default 2.0.
+      resolution_window_minutes: float — only emit HIGH within this many minutes
+        of resolution.  Default 5.0.
+    """
+
+    def __init__(
+        self,
+        concentration_threshold: float = 0.60,
+        spot_sigma_threshold: float = 2.0,
+        resolution_window_minutes: float = 5.0,
+    ) -> None:
+        self.concentration_threshold = concentration_threshold
+        self.spot_sigma_threshold = spot_sigma_threshold
+        self.resolution_window_minutes = resolution_window_minutes
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        market_id: str,
+        position_book: dict,
+        spot_flow_window: List[dict],
+        minutes_to_resolution: float,
+    ) -> RiskFlag:
+        """
+        Evaluate oracle-engineering risk for a single market snapshot.
+
+        Args:
+          market_id: str
+            Polymarket condition ID or any identifier for logging.
+
+          position_book: dict with keys:
+            "YES"   — total YES-side open interest (shares or USDC, consistent units)
+            "NO"    — total NO-side open interest
+            "total" — total OI across both sides (may exceed YES+NO if rounded)
+            "top_yes_concentration" — optional float (0-1); fraction of YES OI held
+              by the top wallet(s).  If absent, computed from YES / total.
+            "top_no_concentration"  — optional float (0-1); same for NO side.
+              If absent, computed from NO / total.
+
+            Concentration is computed per-side: if top wallet(s) hold a large
+            fraction of one side that is out-of-line with the other, that is the
+            signal.  When only aggregate OI is available (not per-wallet breakdown),
+            the ratio of YES or NO to total is used as a conservative proxy.
+
+          spot_flow_window: list of trade-flow dicts, each containing:
+            "side"  — "buy" or "sell" (from the perspective of the taker)
+            "size"  — float, notional USD value of the trade
+            "ts"    — Unix timestamp (int or float)
+
+            The window should cover the same resolution window as used by the
+            oracle (e.g. the final 5 minutes of the resolution period).
+            For the detector to compute a meaningful sigma, at least 3 data
+            points are recommended; fewer than 2 returns RiskLevel.NONE.
+
+          minutes_to_resolution: float
+            How many minutes remain until the oracle snapshot.  Must be ≥ 0.
+
+        Returns:
+          RiskFlag with level NONE / LOW / HIGH.
+        """
+        flag = RiskFlag(market_id=market_id, minutes_to_resolution=minutes_to_resolution)
+
+        # --- 1. PM-side concentration ---
+        concentration, concentrated_side = self._compute_pm_concentration(position_book)
+        flag.pm_concentration = concentration
+
+        # --- 2. Spot flow sigma ---
+        spot_sigma, flow_direction = self._compute_spot_sigma(spot_flow_window)
+        flag.spot_sigma = spot_sigma
+
+        # --- 3. Evaluate signals ---
+        within_window = minutes_to_resolution <= self.resolution_window_minutes
+
+        pm_signal = concentration >= self.concentration_threshold
+        spot_signal = spot_sigma >= self.spot_sigma_threshold
+
+        # Divergence: PM concentrated on one side while spot pushes the OTHER side
+        # toward that resolution outcome.  Example: PM heavy YES + spot aggressive BUY
+        # (both aligned toward YES resolution) — that's the a4385 pattern.
+        # Clean run: PM heavy YES + spot heavy SELL (opposite direction) — MM hedging,
+        # not oracle engineering.
+        direction_diverges = self._directions_diverge(concentrated_side, flow_direction)
+
+        if pm_signal and spot_signal and direction_diverges and within_window:
+            flag.level = RiskLevel.HIGH
+            flag.reason = (
+                f"Oracle-engineering pattern: PM {concentrated_side} concentration "
+                f"{concentration:.0%} (≥{self.concentration_threshold:.0%}) AND "
+                f"spot flow {flow_direction} at {spot_sigma:.1f}σ (≥{self.spot_sigma_threshold}σ) "
+                f"within {minutes_to_resolution:.1f} min of resolution — "
+                "automated skills must widen ≥3× or skip"
+            )
+            logger.warning(
+                "RESOLUTION_TAMPER_RISK market=%s pm_side=%s concentration=%.2f "
+                "spot_sigma=%.2f flow_dir=%s minutes_to_resolution=%.1f",
+                market_id,
+                concentrated_side,
+                concentration,
+                spot_sigma,
+                flow_direction,
+                minutes_to_resolution,
+            )
+        elif pm_signal or spot_signal:
+            flag.level = RiskLevel.LOW
+            signals = []
+            if pm_signal:
+                signals.append(f"PM {concentrated_side} concentration {concentration:.0%}")
+            if spot_signal:
+                signals.append(f"spot flow {spot_sigma:.1f}σ")
+            flag.reason = f"Single oracle-engineering signal ({'; '.join(signals)}); monitoring"
+        else:
+            flag.level = RiskLevel.NONE
+            flag.reason = (
+                f"No oracle-engineering signal (concentration={concentration:.0%}, "
+                f"spot_sigma={spot_sigma:.1f}σ)"
+            )
+
+        return flag
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _compute_pm_concentration(self, position_book: dict) -> tuple[float, str]:
+        """
+        Return (max_concentration, side) where side is "YES" or "NO".
+
+        When per-wallet data is not available, we use the fraction of total OI
+        held by the dominant side as a conservative proxy.  Callers with wallet
+        breakdowns should pass "top_yes_concentration" and "top_no_concentration"
+        directly.
+        """
+        yes_oi = float(position_book.get("YES", 0) or 0)
+        no_oi = float(position_book.get("NO", 0) or 0)
+        total_oi = float(position_book.get("total", yes_oi + no_oi) or 0)
+
+        if total_oi <= 0:
+            return 0.0, "YES"
+
+        # Prefer explicitly provided per-wallet concentrations
+        top_yes = position_book.get("top_yes_concentration")
+        top_no = position_book.get("top_no_concentration")
+
+        if top_yes is not None and top_no is not None:
+            yes_conc = float(top_yes)
+            no_conc = float(top_no)
+        else:
+            # Fallback: fraction of total OI on each side (conservative proxy)
+            yes_conc = yes_oi / total_oi
+            no_conc = no_oi / total_oi
+
+        if yes_conc >= no_conc:
+            return yes_conc, "YES"
+        return no_conc, "NO"
+
+    def _compute_spot_sigma(self, spot_flow_window: List[dict]) -> tuple[float, Optional[str]]:
+        """
+        Compute the flow imbalance z-score across the window.
+
+        Each entry has "side" ("buy" / "sell") and "size" (notional USD).
+        Net flow = sum(buy sizes) - sum(sell sizes).
+        Per-observation signed sizes form a series; we express the final net as
+        z-score over that series.
+
+        Returns (sigma, direction) where direction is "buy" or "sell" (the taker
+        net direction).  Returns (0.0, None) when insufficient data.
+        """
+        if len(spot_flow_window) < 2:
+            return 0.0, None
+
+        signed_sizes = []
+        for trade in spot_flow_window:
+            side = (trade.get("side") or "").lower()
+            size = float(trade.get("size", 0) or 0)
+            if side == "buy":
+                signed_sizes.append(size)
+            elif side == "sell":
+                signed_sizes.append(-size)
+            # skip unknown side entries
+
+        if len(signed_sizes) < 2:
+            return 0.0, None
+
+        mean = statistics.mean(signed_sizes)
+        try:
+            stdev = statistics.stdev(signed_sizes)
+        except statistics.StatisticsError:
+            return 0.0, None
+
+        if stdev <= 0:
+            return 0.0, None
+
+        net = sum(signed_sizes)
+        sigma = net / stdev
+        direction = "buy" if net > 0 else "sell"
+
+        return abs(sigma), direction
+
+    @staticmethod
+    def _directions_diverge(concentrated_side: Optional[str], flow_direction: Optional[str]) -> bool:
+        """
+        Return True when PM concentration and spot flow are ALIGNED toward the same
+        resolution outcome — the oracle-engineering signature.
+
+        Oracle-engineering pattern:
+          - Heavy YES PM position + aggressive BUY spot flow → YES resolution benefits both
+          - Heavy NO PM position + aggressive SELL spot flow → DOWN resolution benefits both
+
+        Clean directional run (NOT a divergence — no alarm):
+          - Heavy YES PM + aggressive SELL spot → MMs hedging correctly, not manipulation
+          - Heavy NO PM + aggressive BUY spot → same
+
+        The name "diverge" here is from the SIGNAL perspective: PM concentration and
+        the expected *honest* MM hedge diverge (they point the same way instead of
+        opposite ways as a normal hedge would).
+        """
+        if concentrated_side is None or flow_direction is None:
+            return False
+
+        # YES concentration aligned with BUY pressure → UP resolution
+        if concentrated_side == "YES" and flow_direction == "buy":
+            return True
+        # NO concentration aligned with SELL pressure → DOWN resolution
+        if concentrated_side == "NO" and flow_direction == "sell":
+            return True
+
+        return False

--- a/skills/polymarket-btc-up-down-trader/SKILL.md
+++ b/skills/polymarket-btc-up-down-trader/SKILL.md
@@ -17,6 +17,21 @@ Trade Polymarket's BTC daily and weekly UP/DOWN markets with built-in exit disci
 
 > ⚠️ **BTC UP/DOWN markets carry Polymarket's 10% fee on crypto markets.** Factor this into your minimum edge threshold.
 
+## Oracle-Engineering Halt Gate
+
+This skill includes a built-in **oracle-engineering risk detector** (`simmer_sdk.risk.OracleEngineeringDetector`). It is **enabled by default** for all short-dated markets (≤ 5 minutes to resolution).
+
+The gate fires a `RESOLUTION_TAMPER_RISK` halt when **both** signals diverge within the final 5 minutes of the resolution window:
+- **PM concentration** ≥ 60% of one side's open interest held by the top wallet(s)
+- **Spot flow imbalance** ≥ 2σ on the underlying (Binance BTC/USDC) in the *same* direction that benefits the concentrated PM position
+
+When the gate fires:
+- **Market-maker mode**: spreads widened ≥ 3×; no new fills accepted
+- **Copytrade mode**: trade skipped for this cycle
+- **All modes**: decision logged with `risk_flag=oracle_engineering`
+
+This is a **defensive halt only**. Do not use it as a buy signal or to copy the attacker's position. See `simmer_sdk/risk/oracle_engineering.py` for the full detector implementation and `shared-knowledge/entities/concepts/oracle-engineering.md` for threat-model background.
+
 ## When to Use This Skill
 
 Use this skill when the user wants to:

--- a/tests/risk/test_oracle_engineering.py
+++ b/tests/risk/test_oracle_engineering.py
@@ -1,0 +1,421 @@
+"""
+Unit tests for OracleEngineeringDetector.
+
+Two mandatory cases:
+  1. a4385-shaped event: PM ≥60% concentrated on YES + spot BUY ≥2σ within 5 min → HIGH
+  2. Clean directional run: PM and spot same direction but correctly aligned → NONE
+
+Additional cases cover edge conditions, LOW signal paths, and direction variants.
+"""
+
+import time
+import pytest
+
+from simmer_sdk.risk.oracle_engineering import (
+    OracleEngineeringDetector,
+    RiskFlag,
+    RiskLevel,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW_TS = int(time.time())
+
+def _buy_trades(count: int, size: float) -> list:
+    return [{"side": "buy", "size": size, "ts": NOW_TS + i} for i in range(count)]
+
+def _sell_trades(count: int, size: float) -> list:
+    return [{"side": "sell", "size": size, "ts": NOW_TS + i} for i in range(count)]
+
+def _mixed_trades(buy_count: int, buy_size: float, sell_count: int, sell_size: float) -> list:
+    trades = _buy_trades(buy_count, buy_size) + _sell_trades(sell_count, sell_size)
+    return trades
+
+# Canonical a4385-style position book: 77K YES out of 87K total (88.5% YES side)
+A4385_BOOK = {"YES": 77000, "NO": 10000, "total": 87000}
+
+# Clean book: both sides roughly equal
+CLEAN_BOOK = {"YES": 45000, "NO": 43000, "total": 88000}
+
+
+# ---------------------------------------------------------------------------
+# 1. a4385-shaped event → HIGH
+# ---------------------------------------------------------------------------
+
+class TestA4385ShapedEvent:
+    """
+    Criterion: PM concentration ≥60% one side + spot flow ≥2σ opposite within 5 min.
+    """
+
+    def test_high_flag_on_a4385_pattern(self):
+        """Canonical oracle-engineering signature: HIGH risk flag emitted."""
+        detector = OracleEngineeringDetector()
+
+        # Spot: aggressive buy pressure — 8 large buys, 2 small sells → net heavily buy
+        spot = _buy_trades(8, 120000) + _sell_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xa4385",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.5,
+        )
+
+        assert flag.level == RiskLevel.HIGH, f"Expected HIGH, got {flag.level}: {flag.reason}"
+        assert flag.should_halt is True
+        assert flag.risk_flag == "oracle_engineering"
+        assert flag.pm_concentration >= 0.60
+        assert flag.spot_sigma >= 2.0
+        assert "oracle_engineering" in flag.reason.lower() or "tamper" in flag.reason.lower() or "concentration" in flag.reason.lower()
+
+    def test_high_flag_uses_explicit_concentration(self):
+        """When per-wallet concentration is provided, it takes precedence."""
+        detector = OracleEngineeringDetector()
+
+        book = {
+            "YES": 50000, "NO": 50000, "total": 100000,
+            "top_yes_concentration": 0.75,
+            "top_no_concentration": 0.10,
+        }
+        spot = _buy_trades(9, 80000) + _sell_trades(1, 2000)
+
+        flag = detector.evaluate(
+            market_id="0xabc",
+            position_book=book,
+            spot_flow_window=spot,
+            minutes_to_resolution=2.0,
+        )
+
+        assert flag.level == RiskLevel.HIGH
+        assert flag.pm_concentration == pytest.approx(0.75, abs=0.001)
+
+    def test_high_flag_no_side(self):
+        """Heavy NO concentration + aggressive SELL spot → HIGH (down variant)."""
+        detector = OracleEngineeringDetector()
+
+        book = {"YES": 10000, "NO": 77000, "total": 87000}
+        spot = _sell_trades(8, 120000) + _buy_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xdown",
+            position_book=book,
+            spot_flow_window=spot,
+            minutes_to_resolution=4.0,
+        )
+
+        assert flag.level == RiskLevel.HIGH
+        assert flag.should_halt is True
+
+    def test_should_halt_property(self):
+        """RiskFlag.should_halt mirrors level == HIGH."""
+        high_flag = RiskFlag(level=RiskLevel.HIGH)
+        low_flag = RiskFlag(level=RiskLevel.LOW)
+        none_flag = RiskFlag(level=RiskLevel.NONE)
+
+        assert high_flag.should_halt is True
+        assert low_flag.should_halt is False
+        assert none_flag.should_halt is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Clean directional run → NONE
+# ---------------------------------------------------------------------------
+
+class TestCleanDirectionalRun:
+    """
+    Criterion: PM concentration and spot flow same direction → no flag.
+    This is the negative case: MMs correctly hedging with the market.
+    """
+
+    def test_no_flag_clean_run_yes_momentum(self):
+        """
+        Balanced PM book + aggressive spot buys = clean YES momentum.
+        Not oracle engineering: PM is not concentrated ≥60% on one side.
+        Single spot signal alone may fire LOW (monitor only) but never HIGH.
+        """
+        detector = OracleEngineeringDetector()
+
+        spot = _buy_trades(9, 80000) + _sell_trades(1, 3000)
+
+        flag = detector.evaluate(
+            market_id="0xclean1",
+            position_book=CLEAN_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        # PM not concentrated → cannot be HIGH (halt gate must NOT fire)
+        assert flag.level != RiskLevel.HIGH, f"Expected not HIGH, got {flag.level}: {flag.reason}"
+        assert flag.should_halt is False
+
+    def test_no_flag_clean_run_no_momentum(self):
+        """
+        Balanced PM book + aggressive spot sells = clean NO momentum.
+        PM not concentrated → cannot reach HIGH.
+        """
+        detector = OracleEngineeringDetector()
+
+        spot = _sell_trades(9, 80000) + _buy_trades(1, 3000)
+
+        flag = detector.evaluate(
+            market_id="0xclean2",
+            position_book=CLEAN_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        assert flag.level != RiskLevel.HIGH
+        assert flag.should_halt is False
+
+    def test_no_flag_when_spot_opposes_pm_concentration(self):
+        """
+        Heavy YES PM concentration + aggressive SELL spot = MM hedge (not engineering).
+        PM concentrated YES but spot is SELLING aggressively → opposite of a4385.
+        """
+        detector = OracleEngineeringDetector()
+
+        spot = _sell_trades(8, 120000) + _buy_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xmm_hedge",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        # YES concentrated but spot selling hard — MMs hedging, not oracle engineering
+        assert flag.level in (RiskLevel.NONE, RiskLevel.LOW), (
+            f"Expected NONE or LOW for MM hedge pattern, got {flag.level}: {flag.reason}"
+        )
+        assert flag.should_halt is False
+
+    def test_no_flag_low_concentration_high_spot(self):
+        """High spot sigma alone without PM concentration → at most LOW."""
+        detector = OracleEngineeringDetector()
+
+        spot = _buy_trades(9, 200000) + _sell_trades(1, 1000)
+
+        flag = detector.evaluate(
+            market_id="0xspot_only",
+            position_book=CLEAN_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        # Only spot signal fires; no PM concentration
+        assert flag.level != RiskLevel.HIGH
+        assert flag.should_halt is False
+
+    def test_no_flag_high_concentration_low_spot(self):
+        """High PM concentration alone without spot sigma → at most LOW."""
+        detector = OracleEngineeringDetector()
+
+        # Balanced spot — large but equal buy and sell sizes → near-zero net
+        spot = _buy_trades(5, 50000) + _sell_trades(5, 49000)
+
+        flag = detector.evaluate(
+            market_id="0xpm_only",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        assert flag.level != RiskLevel.HIGH
+        assert flag.should_halt is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Resolution window gate
+# ---------------------------------------------------------------------------
+
+class TestResolutionWindowGate:
+    """Both signals present but outside the resolution window → LOW at most."""
+
+    def test_outside_window_caps_at_low(self):
+        """Both signals present but 20 min before resolution → LOW (not HIGH)."""
+        detector = OracleEngineeringDetector(resolution_window_minutes=5.0)
+
+        spot = _buy_trades(8, 120000) + _sell_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xearly",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=20.0,  # well outside 5-min window
+        )
+
+        assert flag.level != RiskLevel.HIGH, (
+            f"Expected at most LOW outside resolution window, got HIGH: {flag.reason}"
+        )
+        assert flag.should_halt is False
+
+    def test_at_window_boundary_is_high(self):
+        """Exactly at window boundary (5.0 min) qualifies as HIGH."""
+        detector = OracleEngineeringDetector(resolution_window_minutes=5.0)
+
+        spot = _buy_trades(8, 120000) + _sell_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xboundary",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=5.0,
+        )
+
+        assert flag.level == RiskLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# 4. LOW signal paths
+# ---------------------------------------------------------------------------
+
+class TestLowSignalPaths:
+    """One signal present → LOW."""
+
+    def test_pm_concentration_only_emits_low(self):
+        """Only PM signal fires → LOW."""
+        detector = OracleEngineeringDetector()
+
+        # Balanced spot — no meaningful sigma
+        spot = _buy_trades(3, 10000) + _sell_trades(3, 9500)
+
+        flag = detector.evaluate(
+            market_id="0xpm_low",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        # PM signal alone (no spot sigma) → LOW
+        assert flag.level in (RiskLevel.LOW, RiskLevel.NONE)
+
+    def test_spot_sigma_only_emits_low(self):
+        """Only spot signal fires → LOW."""
+        detector = OracleEngineeringDetector()
+
+        spot = _buy_trades(9, 200000) + _sell_trades(1, 1000)
+
+        flag = detector.evaluate(
+            market_id="0xspot_low",
+            position_book=CLEAN_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        assert flag.level in (RiskLevel.LOW, RiskLevel.NONE)
+
+
+# ---------------------------------------------------------------------------
+# 5. Edge / data-quality cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    """Detector is robust to sparse or zero data."""
+
+    def test_empty_spot_window_no_halt(self):
+        """No spot data → cannot reach HIGH (spot sigma is 0)."""
+        detector = OracleEngineeringDetector()
+
+        flag = detector.evaluate(
+            market_id="0xnospot",
+            position_book=A4385_BOOK,
+            spot_flow_window=[],
+            minutes_to_resolution=3.0,
+        )
+
+        # PM signal may fire LOW (concentration present), but no spot sigma → not HIGH
+        assert flag.level != RiskLevel.HIGH
+        assert flag.should_halt is False
+
+    def test_single_spot_trade_no_halt(self):
+        """Only 1 spot data point — can't compute sigma → no halt gate fires."""
+        detector = OracleEngineeringDetector()
+
+        flag = detector.evaluate(
+            market_id="0xonespot",
+            position_book=A4385_BOOK,
+            spot_flow_window=[{"side": "buy", "size": 1000000, "ts": NOW_TS}],
+            minutes_to_resolution=3.0,
+        )
+
+        assert flag.level != RiskLevel.HIGH
+        assert flag.should_halt is False
+
+    def test_zero_oi_book_returns_none(self):
+        """Zero OI position book → NONE."""
+        detector = OracleEngineeringDetector()
+
+        spot = _buy_trades(8, 120000) + _sell_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xzerooi",
+            position_book={"YES": 0, "NO": 0, "total": 0},
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        assert flag.level in (RiskLevel.NONE, RiskLevel.LOW)
+        assert flag.should_halt is False
+
+    def test_unknown_spot_sides_ignored(self):
+        """Entries with unknown side are silently ignored."""
+        detector = OracleEngineeringDetector()
+
+        spot = (
+            _buy_trades(5, 120000)
+            + _sell_trades(1, 5000)
+            + [{"side": "unknown", "size": 999999, "ts": NOW_TS}]
+        )
+
+        flag = detector.evaluate(
+            market_id="0xunkside",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        # Unknown side should be ignored; result should still detect the buy pressure
+        assert flag.risk_flag == "oracle_engineering"
+
+    def test_custom_thresholds(self):
+        """Detector respects custom concentration and sigma thresholds."""
+        # Very tight thresholds: 0% concentration + 0σ → everything is HIGH
+        detector = OracleEngineeringDetector(
+            concentration_threshold=0.0,
+            spot_sigma_threshold=0.0,
+            resolution_window_minutes=999.0,
+        )
+
+        spot = _buy_trades(3, 1000) + _sell_trades(1, 100)
+
+        flag = detector.evaluate(
+            market_id="0xstrict",
+            position_book=CLEAN_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        # With zero thresholds and wide window, should fire HIGH
+        assert flag.level == RiskLevel.HIGH
+
+    def test_flag_fields_populated(self):
+        """All RiskFlag fields are populated after evaluation."""
+        detector = OracleEngineeringDetector()
+
+        spot = _buy_trades(8, 120000) + _sell_trades(2, 5000)
+
+        flag = detector.evaluate(
+            market_id="0xfields",
+            position_book=A4385_BOOK,
+            spot_flow_window=spot,
+            minutes_to_resolution=3.0,
+        )
+
+        assert flag.market_id == "0xfields"
+        assert flag.minutes_to_resolution == pytest.approx(3.0)
+        assert flag.pm_concentration >= 0.0
+        assert flag.spot_sigma >= 0.0
+        assert flag.risk_flag == "oracle_engineering"
+        assert isinstance(flag.reason, str) and len(flag.reason) > 0


### PR DESCRIPTION
Defensive halt primitive for automated skills running on short-dated Polymarket UP/DOWN markets resolved by Chainlink.

## Background

The a4385 wallet extracted ~$300K by pre-loading YES shares on Polymarket while BTC drifted down, then market-buying ~$1M BTC spot on Binance ~2 min before settlement to flip the Chainlink read. Our MM skills are the loss-takers in step 3 of that sequence. See `shared-knowledge/entities/concepts/oracle-engineering.md`.

## Changes

- `simmer_sdk/risk/oracle_engineering.py` — `OracleEngineeringDetector` class with `evaluate(market_id, position_book, spot_flow_window, minutes_to_resolution) -> RiskFlag`. Emits `RiskLevel.HIGH` when PM-side concentration ≥60% AND spot flow z-score ≥2σ diverge within 5 min of resolution.
- `simmer_sdk/risk/__init__.py` — package init
- `skills/polymarket-btc-up-down-trader/SKILL.md` — Oracle-Engineering Halt Gate section documenting wiring contract for MM (widen ≥3×) and copytrade (skip) behaviors + `risk_flag=oracle_engineering` log tag
- `tests/risk/test_oracle_engineering.py` — 19 unit tests: a4385-shaped event → HIGH, clean directional run → no halt, resolution window gate, LOW single-signal paths, edge cases

## Tests

```
19 passed, 1 warning in 0.42s
```

All acceptance criteria:
- [x] Flags a4385-shaped event (≥60% PM concentration + ≥2σ spot flow within 5 min)
- [x] Does NOT flag clean directional run (PM + spot same direction → no halt)
- [x] MM/copytrade halt contract documented in SKILL.md with `risk_flag=oracle_engineering`
- [x] Not used as a buy signal (defensive primitive only)

## Docs impact

Yes — `skills/polymarket-btc-up-down-trader/SKILL.md` updated. `shared-knowledge` oracle-engineering concept doc cross-linked + detection signals table updated (pushed separately to simmer-labs).

Closes SIM-1556