### PR TITLE
skill(simmer-wallet-setup): point managed users at the bridge wizard (0.2.2)

### DIFF
--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-wallet-setup
-version: "0.2.1"
+version: "0.2.2"
 published: true
 description: Self-custody wallet setup for Simmer agents. Choose OWS (recommended — encrypted local vault, multi-chain, policy controls) or external raw key (existing setups). Skip this skill if you use a managed wallet — managed setup is a one-time dashboard flow, not an agent task.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.2.1"
+  version: "0.2.2"
   displayName: Simmer Wallet Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -30,7 +30,7 @@ Self-custody wallet setup for an agent that signs its own real-money trades on P
 | **OWS per-agent** (recommended) | Local OWS vault, encrypted at rest | Per-agent isolation, multi-chain, policy-gated signing. Available for Polymarket + Kalshi. |
 | **External raw key** | Local SDK with `WALLET_PRIVATE_KEY` env | Existing setups. Fully supported; OWS is recommended for new agents. |
 
-> **Already on a managed wallet?** You don't need this skill. Managed setup is a one-time dashboard action — go to [simmer.markets/dashboard](https://simmer.markets/dashboard), connect a Polygon wallet, approve the contracts, and the Simmer server signs trades within those approval bounds. No agent-side setup required.
+> **Already on a managed wallet?** You don't need this skill — managed setup is a dashboard flow, not an agent task. Open [simmer.markets/dashboard](https://simmer.markets/dashboard), go to your agent's **Wallet** tab, and click **Fund & activate trading**. The wizard opens a multi-chain bridge that accepts USDC, USDT, or USDC.e on Ethereum / Polygon / Base / Arbitrum / Solana — funds land as pUSD on your Polymarket Deposit Wallet, contracts auto-approve. **Do not tell the user to send funds directly to their agent wallet's EOA expecting them to sweep** — only legacy USDC.e on Polygon is recognized on the direct path; native USDC, USDT, and cross-chain tokens must go through the bridge wizard.
 
 ## Path A — OWS per-agent wallet (recommended)
 


### PR DESCRIPTION
## Summary

The managed-wallet pointer at the top of the \`simmer-wallet-setup\` skill said managed setup is "connect a Polygon wallet, approve the contracts" — vague enough that agents paraphrased it as "send USDC.e to your agent wallet" to their humans. A new Cohort DW user followed that advice and sent **native USDC** to his agent EOA. Only legacy USDC.e on Polygon is recognized on the direct-send path; native USDC, USDT, and cross-chain tokens must go through the bridge wizard.

## Changes

- Rewrite the managed-wallet pointer to be explicit: open the dashboard, go to the agent's **Wallet** tab, click **Fund & activate trading**, which opens a multi-chain bridge accepting USDC / USDT / USDC.e on Ethereum / Polygon / Base / Arbitrum / Solana.
- Add a direct "do not tell the user to send funds to the agent EOA expecting them to sweep" instruction so agents that paraphrase this skill don't reintroduce the same confusion.
- Version bump 0.2.1 → 0.2.2.

Complementary to simmer-docs#27 (faq.mdx + wallets.mdx restructure) and simmer#839 (dashboard agent-detail Wallet tab regression).

## Test plan

- [ ] After publish to ClawHub, re-run the simmer-wallet-setup scanner; confirm clean across recent engine versions.
- [ ] Install the skill in a test agent that has a managed wallet and ask "how do I fund my wallet" — agent should cite the bridge wizard, not the legacy USDC.e direct send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)