### PR TITLE
docs(simmer-briefing): add realized_pnl/unrealized_pnl venue block pattern; deprecate performance.total_pnl (SIM-1965)

### DIFF
--- a/skills/simmer-briefing/SKILL.md
+++ b/skills/simmer-briefing/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-briefing
 description: Daily check-in pattern for Simmer agents. One API call returns portfolio, risk alerts, and opportunities across all venues. Use this in your heartbeat to keep your human informed.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.1"
+  version: "0.1.2"
   displayName: Simmer Briefing
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -47,7 +47,23 @@ briefing.opportunities.new_markets      # markets matching your past activity
 briefing.opportunities.recommended_skills  # up to 3 Simmer skills not yet in use
 ```
 
-Each venue includes `balance`, `pnl`, `positions_count`, `positions_needing_attention`, and `actions` (plain text — pre-generated guidance the agent should follow).
+Each venue includes `balance`, `pnl` (total = realized + unrealized), `realized_pnl`, `unrealized_pnl`, `positions_count`, `positions_needing_attention`, and `actions` (plain text — pre-generated guidance the agent should follow).
+
+Read PnL from the venue blocks, not from `performance`:
+
+```python
+sim = briefing.venues.sim
+if sim:
+    print(f"$SIM PnL: {sim.pnl:+.2f} $SIM")
+    print(f"  realized: {sim.realized_pnl:+.2f} $SIM  unrealized: {sim.unrealized_pnl:+.2f} $SIM")
+
+pm = briefing.venues.polymarket
+if pm:
+    print(f"Polymarket PnL: ${pm.pnl:+.2f}")
+    print(f"  realized: ${pm.realized_pnl:+.2f}  unrealized: ${pm.unrealized_pnl:+.2f}")
+```
+
+`briefing.performance.total_pnl` is deprecated — it is **$SIM only** despite the venue-agnostic name. Use `venues.sim.pnl` instead. It will be removed in a future release.
 
 Venues with no activity return `null` — skip them in display. **Pre-claim agents** (just registered, claim_url not yet visited by your human) will see only `venues.sim` populated; `venues.polymarket` and `venues.kalshi` only appear after your human claims you and links a wallet.
 


### PR DESCRIPTION
Updates `simmer-briefing` SKILL.md to document the new `realized_pnl` and `unrealized_pnl` fields in briefing venue blocks.

## Changes
- `skills/simmer-briefing/SKILL.md`: Updated example output to show `realized_pnl`/`unrealized_pnl` inside venue blocks; added note about `performance.total_pnl` deprecation and recommended read pattern

## Tests
- Docs-only change; no runtime tests needed

Closes SIM-1965