### PR TITLE
fix(scripts): publish.sh defaults published to true (opt-out)

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,7 +6,8 @@
 # Example: ./scripts/publish.sh skills/fastloop
 #
 # Safety:
-#   - Only publishes if SKILL.md has `published: true`
+#   - Skills publish by default. Add `published: false` to SKILL.md frontmatter
+#     to opt OUT (mirrors npm's `private: true` convention).
 #   - Refuses if clawhub.json has `"publish": false`
 #   - Slug comes from `name:` field (no folder name guessing)
 #   - Version comes from `version:` field (matches --version flag)
@@ -55,9 +56,13 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-if [ "$PUBLISHED" != "true" ]; then
-  echo "❌ Skill '$NAME' is not marked for publishing (published: $PUBLISHED)"
-  echo "   Add 'published: true' to $SKILL_MD frontmatter to enable"
+# Publishing defaults to true. Only refuse if explicitly opted out.
+# (Of 18 skills in skills/ at 2026-05-18, only 1 had an explicit `published:`
+#  field — the prior opt-in guard was performative and forced every other
+#  publish to bypass this script entirely.)
+if [ "$PUBLISHED" = "false" ]; then
+  echo "❌ Skill '$NAME' is marked 'published: false' in $SKILL_MD"
+  echo "   Remove or flip the flag if you intend to publish."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Flip the `published` guard from opt-in to opt-out. Skills publish by default; only refuse if `published: false` is set explicitly.
- The `clawhub.json` `publish: false` guard is unchanged — that one's a stronger "do not publish" signal (broken/private/draft).
- Update the top-of-file comment to document the new convention.

## Why

Of 18 skills in `skills/` at 2026-05-18, only 1 (`simmer-wallet-setup`) had an explicit top-level `published: true` in its frontmatter. The other 17 silently bypassed `bash scripts/publish.sh` via direct `npx clawhub publish` invocations because the guard refused them. The opt-in safety check was performative — it caught nothing because nobody was using the script.

Opt-out (npm `private: true` style) matches actual usage: most skills here ARE meant to publish. Surfaced by the subagent investigating PR #85 (frontmatter `metadata.version` parser).

The two PRs are independent fixes to the same script — #85 fixes the version parsing one guard up, this fixes the published default one guard down. They can land in either order.

## Test plan

- [x] Smoke test with `published: false` → refused with clear message
- [x] Smoke test with no `published` field → passes guard, proceeds to staging
- [ ] Optional after merge: bash `scripts/publish.sh skills/polymarket-fast-loop` should now reach the publish step (currently blocks on the version-parsing bug fixed by #85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)