### PR TITLE
fix(sdk): friendly managed-wallet result for set_approvals/ensure_approvals (SIM-1976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.11] — 2026-05-18
+
+### Fixed
+
+- **`set_approvals()` / `ensure_approvals()` return a friendly no-op for managed-wallet users (SIM-1976).** Previously both methods raised `ValueError: No wallet configured. Initialize client with private_key.` whenever the SDK had no local signing key — but managed-wallet users (Simmer custodies the key) have no private key to provide. The error told them to do something they can't do. The methods now probe `/api/sdk/settings`; when `wallet_ownership == "native"`, they return a structured `{managed: True, ...}` response with a message pointing at the server-side activation cascade (which auto-fires on the next Polymarket trade — see PR simmer#887). External-wallet users with no key configured still get the existing `ValueError` — no behavior change for them. Reported via Hannes Altberg's case (support thread 6ef49e7a).
+
 ## [0.17.10] — 2026-05-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.10"
+version = "0.17.11"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3849,6 +3849,78 @@ class SimmerClient:
             path += "?" + "&".join(f"{k}={v}" for k, v in params.items())
         return self._request("GET", path)
 
+    def _probe_managed_wallet(self) -> Optional[Dict[str, Any]]:
+        """Probe the server for a managed-wallet account on this API key.
+
+        Called when the SDK has no local wallet configured but we want to
+        distinguish "managed user — server custodies the key" from "external
+        user who forgot to set WALLET_PRIVATE_KEY". The former should get a
+        friendly no-op response from set_approvals/ensure_approvals; the
+        latter should get the existing "configure your key" error.
+
+        Returns a dict with `wallet_ownership` + `wallet_address` if the
+        probe succeeds, else None. Best-effort — a transient settings-
+        endpoint failure falls back to the conservative legacy raise path.
+        """
+        try:
+            settings = self._request("GET", "/api/sdk/settings")
+        except Exception as e:
+            logger.debug("Managed-wallet probe failed: %s", e)
+            return None
+        ownership = settings.get("wallet_ownership")
+        wallet_addr = settings.get("wallet_address")
+        if ownership and wallet_addr:
+            return {
+                "wallet_ownership": ownership,
+                "wallet_address": wallet_addr,
+                "wallet_uses_deposit_wallet": bool(
+                    settings.get("wallet_uses_deposit_wallet", False)
+                ),
+            }
+        return None
+
+    def _managed_approvals_response(
+        self, probe: Dict[str, Any], method: str
+    ) -> Dict[str, Any]:
+        """Friendly no-op response for managed-wallet users calling
+        set_approvals/ensure_approvals.
+
+        Managed-wallet approvals are signed server-side — by the activation
+        cascade at sign-up + by the SDK trade-endpoint JIT trigger when
+        spender drift is detected. The user has no local signing path and
+        shouldn't be asked to provide a private key they don't have.
+        """
+        uses_dw = bool(probe.get("wallet_uses_deposit_wallet"))
+        if method == "ensure_approvals":
+            return {
+                "ready": True,
+                "missing_transactions": [],
+                "managed": True,
+                "wallet_uses_deposit_wallet": uses_dw,
+                "guide": (
+                    "This account uses a Simmer-managed wallet. Approvals are "
+                    "handled server-side — your next Polymarket trade fires "
+                    "the activation cascade automatically. No SDK action "
+                    "needed."
+                ),
+                "raw_status": None,
+            }
+        return {
+            "set": 0,
+            "skipped": 0,
+            "failed": 0,
+            "managed": True,
+            "wallet_uses_deposit_wallet": uses_dw,
+            "message": (
+                "This account uses a Simmer-managed wallet. Approvals are "
+                "signed server-side by Simmer's activation cascade; your next "
+                "Polymarket trade re-fires it automatically if any spender is "
+                "missing. To grant approvals manually, visit "
+                "simmer.markets/wallets."
+            ),
+            "details": [],
+        }
+
     def ensure_approvals(self) -> Dict[str, Any]:
         """
         Check approvals and return transaction data for any missing ones.
@@ -3861,9 +3933,16 @@ class SimmerClient:
             - ready: True if all approvals are set
             - missing_transactions: List of tx data for missing approvals
             - guide: Human-readable status message
+            - managed: True when the account is a Simmer-managed wallet
+              (server custodies the key). When present and True, the SDK
+              has no work to do — the server handles approvals via the
+              activation cascade. `ready` is True, `missing_transactions`
+              is empty, `raw_status` is None.
 
         Raises:
-            ValueError: If no wallet is configured
+            ValueError: If no wallet is configured AND the account is not
+                managed by Simmer (i.e., an external-wallet user who hasn't
+                set WALLET_PRIVATE_KEY).
 
         Example:
             result = client.ensure_approvals()
@@ -3874,6 +3953,13 @@ class SimmerClient:
                     print(f"Send tx to {tx['to']}: {tx['description']}")
         """
         if not self._wallet_address:
+            # SIM-1976: distinguish managed (server-side approvals) from
+            # external-with-no-key (real misconfiguration). Probe the server
+            # before raising so managed users get a friendly result instead
+            # of a misleading "configure private_key" error.
+            probe = self._probe_managed_wallet()
+            if probe and probe.get("wallet_ownership") == "native":
+                return self._managed_approvals_response(probe, "ensure_approvals")
             raise ValueError(
                 "No wallet configured. Initialize client with private_key."
             )
@@ -3913,10 +3999,18 @@ class SimmerClient:
               pathway (approvals must be set via the dashboard instead).
               When present and True, set/skipped/failed are all 0 and no
               transactions are submitted.
+            - managed: True if the account is a Simmer-managed wallet
+              (server custodies the key). When present and True, no SDK
+              transactions are submitted — approvals are signed server-
+              side by the activation cascade. set/skipped/failed are all
+              0; check `result.get("managed")` to branch.
 
         Raises:
-            ValueError: If no wallet is configured
-            ImportError: If eth-account is not installed
+            ValueError: If no wallet is configured AND the account is not
+                managed by Simmer (i.e., an external-wallet user who hasn't
+                set WALLET_PRIVATE_KEY).
+            ImportError: If eth-account is not installed (external-wallet
+                path only).
 
         Example:
             client = SimmerClient(api_key="...")  # WALLET_PRIVATE_KEY auto-detected
@@ -3925,6 +4019,12 @@ class SimmerClient:
             print(f"Set {result['set']} approvals, skipped {result['skipped']}")
         """
         if not self._wallet_address:
+            # SIM-1976: managed-wallet users (no local key) get a friendly
+            # no-op instead of a misleading "configure private_key" error.
+            # The server-side activation cascade handles their approvals.
+            probe = self._probe_managed_wallet()
+            if probe and probe.get("wallet_ownership") == "native":
+                return self._managed_approvals_response(probe, "set_approvals")
             raise ValueError(
                 "No wallet configured. Set WALLET_PRIVATE_KEY env var or pass private_key to constructor "
                 "(or set OWS_WALLET / pass ows_wallet for OWS-managed signing)."

--- a/tests/test_set_approvals_managed.py
+++ b/tests/test_set_approvals_managed.py
@@ -1,0 +1,140 @@
+"""
+Tests for set_approvals() / ensure_approvals() managed-wallet friendly-result
+short-circuit (SIM-1976).
+
+Managed-wallet users (Simmer custodies the key) have no local private_key to
+provide, so the old `raise ValueError("No wallet configured. Initialize
+client with private_key.")` told them to do something they can't. Both
+methods now probe `/api/sdk/settings`; when `wallet_ownership == "native"`,
+they return a structured `{managed: True, ...}` response.
+
+External-wallet users with no key configured must still get the existing
+`ValueError` — no behavior change for them.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_no_wallet_client():
+    """SimmerClient with no local wallet — simulates a managed user OR
+    an external user who forgot to set WALLET_PRIVATE_KEY. The branch is
+    decided by what /api/sdk/settings returns."""
+    from simmer_sdk.client import SimmerClient
+
+    client = SimmerClient.__new__(SimmerClient)
+    client._wallet_address = None
+    client._private_key = None
+    client._ows_wallet = None
+    client._uses_deposit_wallet = False
+    client._deposit_wallet_address = None
+    return client
+
+
+def _settings_for(ownership: str, wallet: str = "0xAAAA000000000000000000000000000000000001",
+                  uses_dw: bool = False) -> dict:
+    return {
+        "sdk_real_trading_enabled": True,
+        "wallet_address": wallet,
+        "wallet_ownership": ownership,
+        "polymarket_allowances_set": True,
+        "wallet_uses_deposit_wallet": uses_dw,
+        "deposit_wallet_address": None,
+    }
+
+
+class TestSetApprovalsManagedShortCircuit:
+    def test_managed_returns_structured_response(self):
+        """Managed user — set_approvals returns dict, not raise."""
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("native"))
+        result = client.set_approvals()
+        assert isinstance(result, dict)
+
+    def test_managed_marks_managed_true(self):
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("native"))
+        assert client.set_approvals().get("managed") is True
+
+    def test_managed_counts_are_zero(self):
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("native"))
+        result = client.set_approvals()
+        assert result["set"] == 0
+        assert result["skipped"] == 0
+        assert result["failed"] == 0
+
+    def test_managed_message_points_at_server(self):
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("native"))
+        msg = client.set_approvals().get("message", "")
+        # Don't pin exact wording, but the user should see the structural
+        # facts: server-handled, no SDK action, dashboard fallback.
+        assert "managed" in msg.lower()
+        assert "server" in msg.lower()
+        assert "simmer.markets" in msg.lower()
+
+    def test_managed_no_tx_submitted(self):
+        """Confirm we never call _send_tx / _request to /api/tx/* or
+        try to import eth-account on the managed path."""
+        client = _make_no_wallet_client()
+        # If anything other than /api/sdk/settings is requested, fail loudly
+        client._request = MagicMock(side_effect=lambda method, path, **kw:
+            _settings_for("native") if path == "/api/sdk/settings"
+            else (_ for _ in ()).throw(AssertionError(f"unexpected request: {method} {path}")))
+        # No exception — only the settings probe should have run
+        client.set_approvals()
+
+
+class TestSetApprovalsExternalNoKeyStillRaises:
+    def test_external_no_key_raises_value_error(self):
+        """External user with no local key — must still raise (their
+        misconfiguration is real). SIM-1976 only widens the managed path."""
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("external"))
+        with pytest.raises(ValueError, match="No wallet configured"):
+            client.set_approvals()
+
+    def test_settings_probe_failure_falls_through_to_raise(self):
+        """If /api/sdk/settings throws (network blip, server down),
+        fall through to the legacy raise — conservative, no silent no-op."""
+        client = _make_no_wallet_client()
+        client._request = MagicMock(side_effect=RuntimeError("network down"))
+        with pytest.raises(ValueError, match="No wallet configured"):
+            client.set_approvals()
+
+    def test_settings_missing_ownership_falls_through_to_raise(self):
+        """Older server that doesn't return wallet_ownership at all —
+        treat as unknown and raise."""
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value={
+            "sdk_real_trading_enabled": True,
+            "wallet_address": "0xAAAA000000000000000000000000000000000001",
+        })
+        with pytest.raises(ValueError, match="No wallet configured"):
+            client.set_approvals()
+
+
+class TestEnsureApprovalsManagedShortCircuit:
+    def test_managed_returns_ready_true(self):
+        """ensure_approvals on managed user — ready=True, no missing_transactions."""
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("native"))
+        result = client.ensure_approvals()
+        assert result.get("ready") is True
+        assert result.get("missing_transactions") == []
+        assert result.get("managed") is True
+
+    def test_managed_guide_explains(self):
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("native"))
+        guide = client.ensure_approvals().get("guide", "")
+        assert "managed" in guide.lower()
+        assert "server" in guide.lower()
+
+    def test_external_no_key_still_raises(self):
+        client = _make_no_wallet_client()
+        client._request = MagicMock(return_value=_settings_for("external"))
+        with pytest.raises(ValueError, match="No wallet configured"):
+            client.ensure_approvals()


### PR DESCRIPTION
## Summary

- **Bug**: managed-wallet users (Simmer custodies the key) calling `set_approvals()` or `ensure_approvals()` hit `ValueError: No wallet configured. Initialize client with private_key.` — but they have no private_key to provide.
- **Fix**: probe `/api/sdk/settings`; when `wallet_ownership == \"native\"`, return a structured `{managed: True, ...}` response pointing at the server-side activation cascade (auto-fires on next Polymarket trade, shipped in simmer PR #887).
- **No behavior change** for external-wallet users with missing keys — they still raise.

## Trigger

Hannes Altberg, AgentMail thread 6ef49e7a. Managed wallet, hit the unhelpful error after upgrading to 0.17.10. simmer PR #887 makes the server-side cascade handle his case automatically; this PR closes the SDK-side UX gap so the next managed user gets accurate guidance instead of a misleading error.

## Diff

| File | Change |
|---|---|
| `simmer_sdk/client.py` | New `_probe_managed_wallet()` + `_managed_approvals_response()` helpers. Both `ensure_approvals()` and `set_approvals()` probe before raising. Docstrings updated to document the `managed` key. |
| `tests/test_set_approvals_managed.py` | 11 new tests covering managed short-circuit + external-no-key-still-raises + probe-failure-falls-through. |
| `pyproject.toml` | `0.17.10` → `0.17.11`. |
| `CHANGELOG.md` | `[0.17.11]` entry documenting the fix. |

## Test plan

- [x] `pytest tests/test_set_approvals_managed.py tests/test_set_approvals_dw.py` — 20/20 pass
- [x] Full SDK suite — 318 pass; 4 pre-existing OWS-env failures unrelated to this change (verified by running on `origin/main` first)
- [x] `python3 -c \"from simmer_sdk.client import SimmerClient\"` — imports clean
- [ ] After merge: publish 0.17.11 to PyPI

## Why this is the right shape

- **Conservative.** External-wallet misconfiguration still raises (real bug, user should fix it).
- **Backward compatible.** Existing keys in the response dict (`set`, `skipped`, `failed`, `details` for `set_approvals`; `ready`, `missing_transactions`, `guide`, `raw_status` for `ensure_approvals`) are unchanged. The new `managed: True` key is additive.
- **Mirrors the existing deposit-wallet pattern** (`deposit_wallet_user: True`) — same shape, same caller-branching idiom, parallel docstring updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)