### PR TITLE
feat(mcp): MCP distribution layer for Simmer SDK skills (SIM-507)

### DIFF
--- a/add-mcp
+++ b/add-mcp
@@ -1,0 +1,1 @@
+mcp/scripts/add-mcp.sh

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/mcp/.npmignore
+++ b/mcp/.npmignore
@@ -1,0 +1,4 @@
+src/
+tsconfig.json
+node_modules/
+*.tsbuildinfo

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,23 +6,23 @@ Any Claude Code or Claude Desktop user can install with a single command and run
 
 ## Quick start
 
-```bash
-# From the simmer-sdk repo (builds locally)
-./add-mcp
-
-# Or via npx (npm published package)
-./add-mcp --npx
-```
-
-Set your API key first:
+**From the `simmer-sdk` repo** (builds locally, auto-discovers skills):
 
 ```bash
 export SIMMER_API_KEY=sk_live_...   # https://simmer.markets/dashboard
+./add-mcp
+```
+
+**Via npx** (no repo clone needed):
+
+```bash
+export SIMMER_API_KEY=sk_live_...
+claude mcp add simmer -- npx -y @simmer/mcp
 ```
 
 ## What gets registered
 
-After install, Claude gets 18 tools:
+After install, Claude gets two built-in meta-tools plus one tool per discovered skill:
 
 | Tool | Description |
 |------|-------------|
@@ -32,7 +32,7 @@ After install, Claude gets 18 tools:
 
 In Claude, type: `list all simmer skills` to get started.
 
-## Options
+## Options (repo install only)
 
 ```
 ./add-mcp [--global] [--npx]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,52 @@
+# @simmer/mcp
+
+MCP server that exposes all [Simmer SDK](https://simmer.markets) skills as native Claude tools.
+
+Any Claude Code or Claude Desktop user can install with a single command and run prediction-market skills directly from chat.
+
+## Quick start
+
+```bash
+# From the simmer-sdk repo (builds locally)
+./add-mcp
+
+# Or via npx (npm published package)
+./add-mcp --npx
+```
+
+Set your API key first:
+
+```bash
+export SIMMER_API_KEY=sk_live_...   # https://simmer.markets/dashboard
+```
+
+## What gets registered
+
+After install, Claude gets 18 tools:
+
+| Tool | Description |
+|------|-------------|
+| `simmer_list_skills` | Browse all available skills |
+| `simmer_get_skill_docs` | Read a skill's full documentation |
+| `simmer_<slug>` | Run or query a specific skill (one per skill) |
+
+In Claude, type: `list all simmer skills` to get started.
+
+## Options
+
+```
+./add-mcp [--global] [--npx]
+
+  --global   Register globally (Claude Desktop + all projects)
+  --npx      Use npx @simmer/mcp instead of local build
+```
+
+## Trading safety
+
+All automaton skill tools default to `dry_run=true` (paper venue). Real-money execution requires `dry_run: false` explicitly passed in the tool call.
+
+## Requirements
+
+- Node.js 18+
+- [Claude Code](https://claude.ai/code) or Claude Desktop
+- `SIMMER_API_KEY` for most skills

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1197 @@
+{
+  "name": "@simmer/mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@simmer/mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0"
+      },
+      "bin": {
+        "simmer-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -41,5 +41,8 @@
     "dist",
     "scripts",
     "README.md"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@simmer/mcp",
+  "version": "0.1.0",
+  "description": "MCP server that exposes all Simmer SDK skills as Claude tools",
+  "type": "module",
+  "bin": {
+    "simmer-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "keywords": [
+    "mcp",
+    "simmer",
+    "prediction-markets",
+    "claude",
+    "skills"
+  ],
+  "author": "Simmer <hello@simmer.markets>",
+  "license": "MIT",
+  "homepage": "https://simmer.markets",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SpartanLabsXyz/simmer-sdk",
+    "directory": "mcp"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "dist",
+    "scripts",
+    "README.md"
+  ]
+}

--- a/mcp/scripts/add-mcp
+++ b/mcp/scripts/add-mcp
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Thin wrapper so users can run: ./add-mcp from the simmer-sdk root.
-# Delegates to mcp/scripts/add-mcp.sh
-exec "$(dirname "$0")/../mcp/scripts/add-mcp.sh" "$@"

--- a/mcp/scripts/add-mcp
+++ b/mcp/scripts/add-mcp
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Thin wrapper so users can run: ./add-mcp from the simmer-sdk root.
+# Delegates to mcp/scripts/add-mcp.sh
+exec "$(dirname "$0")/../mcp/scripts/add-mcp.sh" "$@"

--- a/mcp/scripts/add-mcp.sh
+++ b/mcp/scripts/add-mcp.sh
@@ -61,7 +61,9 @@ fi
 
 if [ "$USE_NPX" = true ]; then
   echo "📦 Registering via npx @simmer/mcp ..."
-  claude mcp add $SCOPE simmer -- npx -y @simmer/mcp
+  claude mcp add $SCOPE simmer \
+    -e SIMMER_API_KEY="${SIMMER_API_KEY:-}" \
+    -- npx -y @simmer/mcp
 else
   # Build if dist/ doesn't exist or src is newer
   if [ ! -f "$MCP_DIR/dist/index.js" ] || \

--- a/mcp/scripts/add-mcp.sh
+++ b/mcp/scripts/add-mcp.sh
@@ -8,7 +8,18 @@
 
 set -euo pipefail
 
-MCP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Resolve the real path of this script even when invoked through a symlink.
+# Plain `dirname "$0"` returns `.` when $0 is a symlink like `./add-mcp`,
+# which would make MCP_DIR point one level ABOVE the repo root.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  LINK_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$LINK_DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+MCP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$MCP_DIR/.." && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
 

--- a/mcp/scripts/add-mcp.sh
+++ b/mcp/scripts/add-mcp.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# add-mcp — Register Simmer MCP server with Claude Code or Claude Desktop
+#
+# Usage:
+#   ./scripts/add-mcp.sh              # register from the simmer-sdk repo
+#   ./scripts/add-mcp.sh --global     # register globally (Claude Desktop)
+#   ./scripts/add-mcp.sh --npx        # use npx @simmer/mcp (npm install)
+
+set -euo pipefail
+
+MCP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$MCP_DIR/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+
+SCOPE=""
+USE_NPX=false
+
+for arg in "$@"; do
+  case $arg in
+    --global) SCOPE="--global" ;;
+    --npx)    USE_NPX=true ;;
+    --help|-h)
+      echo "Usage: $0 [--global] [--npx]"
+      echo "  --global  Register globally (Claude Desktop + all projects)"
+      echo "  --npx     Use npx @simmer/mcp instead of local build"
+      exit 0
+      ;;
+  esac
+done
+
+echo "🔮 Simmer MCP — registration"
+echo ""
+
+# Verify claude is available
+if ! command -v claude &>/dev/null; then
+  echo "❌ claude CLI not found. Install Claude Code first:"
+  echo "   https://claude.ai/code"
+  exit 1
+fi
+
+# Verify SIMMER_API_KEY is set (most skills need it)
+if [ -z "${SIMMER_API_KEY:-}" ]; then
+  echo "⚠️  SIMMER_API_KEY is not set. Most skills require it."
+  echo "   Get your key: https://simmer.markets/dashboard"
+  echo "   Then: export SIMMER_API_KEY=sk_live_..."
+  echo ""
+  echo "   Continuing registration — set the key before running skills."
+  echo ""
+fi
+
+if [ "$USE_NPX" = true ]; then
+  echo "📦 Registering via npx @simmer/mcp ..."
+  claude mcp add $SCOPE simmer -- npx -y @simmer/mcp
+else
+  # Build if dist/ doesn't exist or src is newer
+  if [ ! -f "$MCP_DIR/dist/index.js" ] || \
+     [ "$MCP_DIR/src/index.ts" -nt "$MCP_DIR/dist/index.js" ]; then
+    echo "🔧 Building MCP server..."
+    if ! command -v npm &>/dev/null; then
+      echo "❌ npm not found. Install Node.js 18+ first."
+      exit 1
+    fi
+    cd "$MCP_DIR"
+    npm install --silent
+    npm run build --silent
+    echo "✅ Built successfully"
+    echo ""
+  fi
+
+  echo "📦 Registering local build with Claude..."
+  claude mcp add $SCOPE simmer \
+    -e SIMMER_API_KEY="${SIMMER_API_KEY:-}" \
+    -e SIMMER_SKILLS_DIR="$SKILLS_DIR" \
+    -- node "$MCP_DIR/dist/index.js"
+fi
+
+echo ""
+echo "✅ Simmer MCP registered as 'simmer'"
+echo ""
+echo "   Available tools:"
+echo "   • simmer_list_skills       — browse all skills"
+echo "   • simmer_get_skill_docs    — read a skill's full documentation"
+echo "   • simmer_<slug>            — run or query a specific skill"
+echo ""
+echo "   In Claude, type: 'list all simmer skills' to get started."
+echo ""
+if [ -z "${SIMMER_API_KEY:-}" ]; then
+  echo "⚠️  Remember to set SIMMER_API_KEY for trading skills:"
+  echo "   export SIMMER_API_KEY=sk_live_..."
+  echo "   Then re-run: $0"
+fi

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -79,13 +79,9 @@ function findSkillsDir(): string | null {
     );
   }
 
-  // 2. Adjacent ../skills/ (repo usage — dist/index.js → mcp/dist/index.js → mcp/ → simmer-sdk/)
-  const repoSkills = path.resolve(__dirname, "../../..", "skills");
+  // 2. Adjacent skills/ (repo usage — mcp/dist/index.js → mcp/ → simmer-sdk/skills/)
+  const repoSkills = path.resolve(__dirname, "..", "..", "skills");
   if (fs.existsSync(repoSkills)) return repoSkills;
-
-  // Also try one level up in case of flat layout
-  const repoSkills2 = path.resolve(__dirname, "..", "..", "skills");
-  if (fs.existsSync(repoSkills2)) return repoSkills2;
 
   // 3. ~/.simmer/skills/ (ClawHub install path)
   const clawHubSkills = path.join(os.homedir(), ".simmer", "skills");

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+/**
+ * Simmer MCP Server
+ *
+ * Exposes all Simmer SDK skills as MCP tools for Claude Desktop / Claude Code.
+ * Each skill becomes a callable tool; automaton skills run as subprocesses,
+ * non-automaton skills return their documentation.
+ *
+ * Skill discovery order:
+ *   1. SIMMER_SKILLS_DIR env var
+ *   2. Adjacent ../skills/ relative to this file (repo usage)
+ *   3. ~/.simmer/skills/ (ClawHub installs)
+ *   4. Python package location (pip install simmer-sdk)
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { spawn, spawnSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ClawHubJson {
+  emoji?: string;
+  primaryEnv?: string;
+  requires?: { env?: string[]; pip?: string[] };
+  envVars?: Array<{ name: string; required?: boolean; description?: string }>;
+  cron?: string | null;
+  autostart?: boolean;
+  automaton?: {
+    managed?: boolean;
+    entrypoint?: string | null;
+  };
+  tunables?: Array<{
+    env: string;
+    type: string;
+    default: unknown;
+    label?: string;
+  }>;
+  publish?: boolean;
+}
+
+interface Skill {
+  slug: string;
+  name: string;
+  description: string;
+  emoji: string;
+  skillDir: string;
+  clawhub: ClawHubJson;
+  skillMdPath: string;
+  isRunnable: boolean;
+  entrypoint: string | null;
+  requiredEnv: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Skill discovery
+// ---------------------------------------------------------------------------
+
+function findSkillsDir(): string | null {
+  // 1. Explicit override
+  if (process.env.SIMMER_SKILLS_DIR) {
+    const d = process.env.SIMMER_SKILLS_DIR;
+    if (fs.existsSync(d)) return d;
+    process.stderr.write(
+      `[simmer-mcp] SIMMER_SKILLS_DIR=${d} does not exist\n`
+    );
+  }
+
+  // 2. Adjacent ../skills/ (repo usage — dist/index.js → mcp/dist/index.js → mcp/ → simmer-sdk/)
+  const repoSkills = path.resolve(__dirname, "../../..", "skills");
+  if (fs.existsSync(repoSkills)) return repoSkills;
+
+  // Also try one level up in case of flat layout
+  const repoSkills2 = path.resolve(__dirname, "..", "..", "skills");
+  if (fs.existsSync(repoSkills2)) return repoSkills2;
+
+  // 3. ~/.simmer/skills/ (ClawHub install path)
+  const clawHubSkills = path.join(os.homedir(), ".simmer", "skills");
+  if (fs.existsSync(clawHubSkills)) return clawHubSkills;
+
+  // 4. Find via Python package
+  try {
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        `import importlib.util, os; spec=importlib.util.find_spec('simmer_sdk'); root=os.path.dirname(os.path.dirname(spec.origin)); print(os.path.join(root,'skills'))`,
+      ],
+      { encoding: "utf8", timeout: 5000 }
+    );
+    if (result.status === 0) {
+      const pySkills = result.stdout.trim();
+      if (fs.existsSync(pySkills)) return pySkills;
+    }
+  } catch {
+    // Python not available or simmer_sdk not installed
+  }
+
+  return null;
+}
+
+function parseSkillMdFrontmatter(
+  content: string
+): Record<string, string> | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const fm: Record<string, string> = {};
+  // Only parse top-level YAML keys (no leading whitespace) to avoid picking
+  // up nested fields like envVars[].description overwriting the skill description.
+  for (const line of match[1].split("\n")) {
+    if (!line || line[0] === " " || line[0] === "\t" || line[0] === "-") continue;
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line
+      .slice(colonIdx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (key && value) fm[key] = value;
+  }
+  return fm;
+}
+
+function discoverSkills(skillsDir: string): Skill[] {
+  const skills: Skill[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+  } catch {
+    return skills;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillDir = path.join(skillsDir, entry.name);
+    const clawHubPath = path.join(skillDir, "clawhub.json");
+    const skillMdPath = path.join(skillDir, "SKILL.md");
+
+    if (!fs.existsSync(clawHubPath)) continue;
+
+    let clawhub: ClawHubJson;
+    try {
+      clawhub = JSON.parse(fs.readFileSync(clawHubPath, "utf8"));
+    } catch {
+      continue;
+    }
+
+    // Respect publish: false flag
+    if (clawhub.publish === false) continue;
+
+    // Extract description from SKILL.md frontmatter
+    let description = `Simmer skill: ${entry.name}`;
+    let displayName = entry.name;
+    if (fs.existsSync(skillMdPath)) {
+      const content = fs.readFileSync(skillMdPath, "utf8");
+      const fm = parseSkillMdFrontmatter(content);
+      if (fm) {
+        if (fm.description) description = fm.description;
+        if (fm.displayName) displayName = fm.displayName;
+      }
+    }
+
+    const automaton = clawhub.automaton ?? {};
+    const entrypoint = automaton.entrypoint ?? null;
+
+    // A skill is "runnable" if it has an entrypoint OR a Python script in the dir
+    let isRunnable = !!entrypoint;
+    let resolvedEntrypoint = entrypoint;
+
+    if (!isRunnable) {
+      // Check for standalone Python scripts (like wallet_xray.py, x402_cli.py)
+      const pyFiles = fs
+        .readdirSync(skillDir)
+        .filter((f) => f.endsWith(".py") && !f.startsWith("_"));
+      if (pyFiles.length > 0) {
+        isRunnable = true;
+        resolvedEntrypoint = pyFiles[0];
+      }
+    }
+
+    skills.push({
+      slug: entry.name,
+      name: displayName,
+      description,
+      emoji: clawhub.emoji ?? "🔮",
+      skillDir,
+      clawhub,
+      skillMdPath,
+      isRunnable,
+      entrypoint: resolvedEntrypoint,
+      requiredEnv: clawhub.requires?.env ?? [],
+    });
+  }
+
+  return skills.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+// ---------------------------------------------------------------------------
+// Tool name helpers
+// ---------------------------------------------------------------------------
+
+function slugToToolName(slug: string): string {
+  // polymarket-btc-up-down-trader → simmer_polymarket_btc_up_down_trader
+  return "simmer_" + slug.replace(/-/g, "_");
+}
+
+// ---------------------------------------------------------------------------
+// Skill execution
+// ---------------------------------------------------------------------------
+
+function runSkill(
+  skill: Skill,
+  args: Record<string, unknown>,
+  timeoutMs: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (!skill.isRunnable || !skill.entrypoint) {
+      reject(new Error("Skill has no runnable entrypoint"));
+      return;
+    }
+
+    const scriptPath = path.join(skill.skillDir, skill.entrypoint);
+    if (!fs.existsSync(scriptPath)) {
+      reject(new Error(`Entrypoint not found: ${scriptPath}`));
+      return;
+    }
+
+    const env: Record<string, string> = { ...process.env } as Record<
+      string,
+      string
+    >;
+    env.AUTOMATON_MANAGED = "1";
+    env.PYTHONUNBUFFERED = "1";
+
+    // Pass any extra env overrides from args
+    if (args.trading_venue && typeof args.trading_venue === "string") {
+      env.TRADING_VENUE = args.trading_venue;
+    }
+    if (args.dry_run === true) {
+      env.TRADING_VENUE = "sim";
+    }
+
+    // Build CLI args for scripts that accept them (wallet_xray, x402, etc.)
+    const cliArgs: string[] = [];
+    if (args.wallet_address && typeof args.wallet_address === "string") {
+      cliArgs.push(args.wallet_address);
+    }
+    if (args.compare_address && typeof args.compare_address === "string") {
+      cliArgs.push(args.compare_address);
+      cliArgs.push("--compare");
+    }
+    if (args.json_output === true) {
+      cliArgs.push("--json");
+    }
+    if (args.extra_args && Array.isArray(args.extra_args)) {
+      cliArgs.push(...(args.extra_args as string[]));
+    }
+
+    const child = spawn("python3", [scriptPath, ...cliArgs], {
+      env,
+      cwd: skill.skillDir,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (d: Buffer) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d: Buffer) => {
+      stderr += d.toString();
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve(
+        `[timeout after ${timeoutMs / 1000}s]\n\nStdout:\n${stdout}\n\nStderr:\n${stderr}`
+      );
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code === 0 || stdout.length > 0) {
+        const output = stdout || "(no output)";
+        const extra = stderr ? `\n\n[stderr]\n${stderr}` : "";
+        resolve(output + extra);
+      } else {
+        reject(
+          new Error(
+            `Skill exited with code ${code}\n\nStderr:\n${stderr}\n\nStdout:\n${stdout}`
+          )
+        );
+      }
+    });
+  });
+}
+
+function getSkillDocs(skill: Skill): string {
+  if (!fs.existsSync(skill.skillMdPath)) {
+    return `# ${skill.name}\n\n${skill.description}\n\nNo documentation available.`;
+  }
+  return fs.readFileSync(skill.skillMdPath, "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const skillsDir = findSkillsDir();
+
+  let skills: Skill[] = [];
+  if (skillsDir) {
+    skills = discoverSkills(skillsDir);
+    process.stderr.write(
+      `[simmer-mcp] Loaded ${skills.length} skills from ${skillsDir}\n`
+    );
+  } else {
+    process.stderr.write(
+      "[simmer-mcp] No skills directory found. Set SIMMER_SKILLS_DIR or install simmer-sdk.\n"
+    );
+  }
+
+  const server = new Server(
+    { name: "simmer-mcp", version: "0.1.0" },
+    { capabilities: { tools: {} } }
+  );
+
+  // -------------------------------------------------------------------------
+  // List tools
+  // -------------------------------------------------------------------------
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const tools = [
+      {
+        name: "simmer_list_skills",
+        description:
+          "List all available Simmer SDK skills with their descriptions and status.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+      {
+        name: "simmer_get_skill_docs",
+        description:
+          "Get full documentation for a specific Simmer skill (returns SKILL.md content).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            slug: {
+              type: "string",
+              description:
+                "Skill slug, e.g. 'polymarket-btc-up-down-trader'. Use simmer_list_skills to see all slugs.",
+            },
+          },
+          required: ["slug"],
+        },
+      },
+    ];
+
+    for (const skill of skills) {
+      const isAutomaton = skill.clawhub.automaton?.managed === true;
+      const toolName = slugToToolName(skill.slug);
+
+      const properties: Record<string, unknown> = {
+        timeout_seconds: {
+          type: "number",
+          description: "Maximum run time in seconds (default: 120)",
+        },
+      };
+
+      if (isAutomaton) {
+        properties.dry_run = {
+          type: "boolean",
+          description:
+            "If true, runs against the paper-trading $SIM venue (default: true for safety)",
+        };
+        properties.trading_venue = {
+          type: "string",
+          enum: ["sim", "polymarket", "kalshi"],
+          description:
+            "Override trading venue. Defaults to sim (paper). Set to polymarket or kalshi for real money (requires dashboard approval).",
+        };
+      }
+
+      // Wallet xray specific args
+      if (skill.slug === "polymarket-wallet-xray") {
+        properties.wallet_address = {
+          type: "string",
+          description: "Polymarket wallet address (0x...) to analyze",
+        };
+        properties.compare_address = {
+          type: "string",
+          description: "Optional second wallet address to compare against",
+        };
+        properties.json_output = {
+          type: "boolean",
+          description: "Return JSON output instead of formatted text",
+        };
+      }
+
+      // Generic extra args passthrough
+      properties.extra_args = {
+        type: "array",
+        items: { type: "string" },
+        description: "Additional CLI arguments to pass to the skill script",
+      };
+
+      const runVerb = isAutomaton ? "run" : "execute";
+      const safetyNote = isAutomaton
+        ? " Defaults to dry_run=true (paper $SIM venue) for safety."
+        : "";
+      const docsNote = skill.isRunnable
+        ? ""
+        : " This is a reference skill — calling it returns the documentation.";
+
+      tools.push({
+        name: toolName,
+        description: `${skill.emoji} ${skill.description}${docsNote}${safetyNote}`,
+        inputSchema: {
+          type: "object",
+          properties,
+          required: [],
+        },
+      });
+    }
+
+    return { tools };
+  });
+
+  // -------------------------------------------------------------------------
+  // Call tools
+  // -------------------------------------------------------------------------
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args = {} } = request.params;
+
+    // Meta tools
+    if (name === "simmer_list_skills") {
+      if (skills.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No skills found. Set SIMMER_SKILLS_DIR or clone the simmer-sdk repo and re-run.\n\nInstall: pip install simmer-sdk",
+            },
+          ],
+        };
+      }
+
+      const lines = ["# Simmer Skills\n"];
+      for (const skill of skills) {
+        const runnable = skill.isRunnable ? "runnable" : "docs";
+        const automaton =
+          skill.clawhub.automaton?.managed === true ? "automaton" : "";
+        const tags = [runnable, automaton].filter(Boolean).join(", ");
+        lines.push(
+          `**${skill.emoji} ${skill.name}** (\`${skill.slug}\`) [${tags}]`
+        );
+        lines.push(`  ${skill.description}`);
+        if (skill.requiredEnv.length > 0) {
+          lines.push(`  Requires: ${skill.requiredEnv.join(", ")}`);
+        }
+        lines.push("");
+      }
+
+      return { content: [{ type: "text", text: lines.join("\n") }] };
+    }
+
+    if (name === "simmer_get_skill_docs") {
+      const slug = String(args.slug ?? "");
+      const skill = skills.find((s) => s.slug === slug);
+      if (!skill) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Skill '${slug}' not found. Use simmer_list_skills to see available skills.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      return { content: [{ type: "text", text: getSkillDocs(skill) }] };
+    }
+
+    // Per-skill tools
+    const skill = skills.find((s) => slugToToolName(s.slug) === name);
+    if (!skill) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Unknown tool: ${name}. Use simmer_list_skills to see available tools.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // Non-runnable reference skills → return docs
+    if (!skill.isRunnable) {
+      return { content: [{ type: "text", text: getSkillDocs(skill) }] };
+    }
+
+    // Check required env vars
+    const missingEnv = skill.requiredEnv.filter((e) => !process.env[e]);
+    if (missingEnv.length > 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Missing required environment variables: ${missingEnv.join(", ")}\n\nSet them and restart the MCP server, or run:\n  export ${missingEnv[0]}=your_value`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const timeoutMs = typeof args.timeout_seconds === "number"
+      ? args.timeout_seconds * 1000
+      : 120_000;
+
+    // Default automaton skills to dry_run (paper trading) for safety
+    const effectiveArgs = {
+      ...args,
+      dry_run:
+        skill.clawhub.automaton?.managed === true
+          ? (args.dry_run !== false)  // default true unless explicitly false
+          : args.dry_run,
+    };
+
+    try {
+      const output = await runSkill(skill, effectiveArgs, timeoutMs);
+      return { content: [{ type: "text", text: output }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Error running skill: ${msg}` }],
+        isError: true,
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write("[simmer-mcp] Server started\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`[simmer-mcp] Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -263,7 +263,15 @@ function runSkill(
       cliArgs.push("--json");
     }
     if (args.extra_args && Array.isArray(args.extra_args)) {
-      cliArgs.push(...(args.extra_args as string[]));
+      // Strip flags that bypass the dry-run safety default. The MCP layer
+      // sets TRADING_VENUE=sim when dry_run=true, but if the skill reads
+      // --live from argv first, CLI wins over env. Block live-trading
+      // flags here so other agents can't bypass dry_run via extra_args.
+      const BLOCKED_FLAGS = /^--(live|no-dry-run|no-dry|real|production)$/i;
+      const filtered = (args.extra_args as string[]).filter(
+        (a) => typeof a === "string" && !BLOCKED_FLAGS.test(a)
+      );
+      cliArgs.push(...filtered);
     }
 
     const child = spawn("python3", [scriptPath, ...cliArgs], {

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds `@simmer/mcp` — a TypeScript MCP server that exposes all Simmer SDK skills as native Claude tools. Claude Desktop and Claude Code users can install with one command.

## Install

```bash
# From the simmer-sdk repo clone:
./add-mcp

# With npx (once published to npm):
claude mcp add simmer -- npx -y @simmer/mcp
```

## What ships

- **`mcp/src/index.ts`**: `@modelcontextprotocol/sdk` stdio server. Discovers skills from `SIMMER_SKILLS_DIR`, adjacent `../skills/`, `~/.simmer/skills/`, or the Python package location.
- **Registers**: `simmer_list_skills`, `simmer_get_skill_docs`, + one tool per skill (16 skills → 18 total tools)
- **Automaton skills** (`managed: true`): run as Python subprocesses with `AUTOMATON_MANAGED=1`, default `dry_run=true` (paper $SIM venue) for safety
- **Reference skills** (`managed: false`): return their `SKILL.md` documentation
- **`mcp/scripts/add-mcp.sh`**: Registration script (`claude mcp add`). Supports `--global` and `--npx` flags.
- **`add-mcp`**: Root-level symlink for convenience

## Tests

- MCP `tools/list` returns 18 tools with correct descriptions (verified descriptions aren't overwritten by nested YAML `envVars[].description`)
- `simmer_list_skills` tool call returns all 16 skills with metadata
- `simmer_get_skill_docs` returns SKILL.md content
- TypeScript builds clean (`tsc` zero errors)
- Server startup: `Loaded 16 skills from ./skills` confirmed

## Docs impact

Yes — new distribution method for SDK skills. `mcp/` directory is the new package root.

## Skills affected

None modified. New MCP layer only.

Closes SIM-507