### PR TITLE
feat(skill): polymarket-sports-trader (Template tier) v0.1.0

### DIFF
--- a/skills/polymarket-sports-trader/DISCLAIMER.md
+++ b/skills/polymarket-sports-trader/DISCLAIMER.md
@@ -1,0 +1,48 @@
+# Disclaimer
+
+This skill is a **framework**, not a production trading system. Read this
+in full before connecting it to a wallet with real funds.
+
+## No financial advice
+
+Nothing in this skill constitutes financial, investment, or trading
+advice. The default strategy implemented here is a starting point, not a
+tested edge. Suitability for any account size or risk tolerance is your
+responsibility to assess.
+
+## Default parameters are not validated
+
+Default parameters are calibrated for testing the plumbing, not for live
+profit. They have not been validated to produce positive returns under
+current market conditions. Run paper mode for an extended period before
+scaling beyond default position sizes.
+
+## Automated trading carries irreversible risk
+
+When this skill runs with `--live`, it places real on-chain orders.
+On-chain trades cannot be recalled. Strategy errors, signal lag, market
+regime shifts, and operator misconfiguration can produce losses
+exceeding any specific position size.
+
+## Risk monitoring may not apply to all market types
+
+Stop-loss and take-profit monitors run on a fixed schedule. Markets that
+resolve faster than the monitor cycle cannot be exited automatically.
+Position sizing is the only risk control on these markets — set it
+conservatively.
+
+## Use of this skill is at your own risk
+
+By installing and running this skill you agree that the authors are not
+liable for any losses, direct or indirect, that arise from its use. This
+applies regardless of skill provenance — official Simmer skills,
+community skills, and skills imported from external repositories all
+carry this same disclaimer.
+
+## Where to learn more before going live
+
+- The skill's own `SKILL.md` documents the strategy and parameters
+- Your trading venue's documentation covers fee structure, order types,
+  and resolution rules
+- Simmer SDK documentation covers paper mode, dry-run flags, and
+  position monitoring

--- a/skills/polymarket-sports-trader/SKILL.md
+++ b/skills/polymarket-sports-trader/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: polymarket-sports-trader
+description: 'Autonomous Polymarket sports trader. Scans NBA / NFL / soccer / MLB / tennis markets, asks an LLM for a fair-value YES probability, trades on divergence. Template-tier skill — generic LLM-driven signal, no validated edge. Use when user wants to trade sports prediction markets autonomously, set up sports-edge bot, or experiment with LLM-driven Polymarket strategies.'
+metadata:
+  author: Simmer (@simmer_markets)
+  version: "0.1.0"
+  displayName: Polymarket Sports Trader
+  difficulty: advanced
+  tier: template
+---
+# Polymarket Sports Trader
+
+> 🚨 **Framework, not a production trading system.** Read [DISCLAIMER.md](./DISCLAIMER.md) before connecting to a wallet with real funds.
+
+Trade Polymarket sports markets (NBA, NFL, soccer, MLB, tennis) using a generic LLM-driven divergence signal: at each scan the skill asks your chosen LLM for a fair-value YES probability, compares to the live market price, and trades when the gap exceeds a configurable threshold.
+
+## When to Use This Skill
+
+Use this skill when the user wants to:
+
+- Run an autonomous sports-trading agent on Polymarket
+- Scan NBA / NFL / soccer / MLB / tennis markets for LLM-derived divergence opportunities
+- Wire an OpenRouter / Anthropic / OpenAI key to a Polymarket trading bot
+- Experiment with LLM-vs-market calibration on prediction markets
+
+This is a **Template-tier capability skill**: it gives your agent the ability to trade sports markets autonomously, but the default signal — "ask an LLM for a fair value" — is not backtested and makes no edge claim. Pair with conservative sizing or use as a starting point for your own signal.
+
+## How the Strategy Works
+
+Each scan cycle the skill:
+
+1. **Discovers sports markets** — pulls Polymarket sports markets via the Simmer SDK (`category='sports'`), filtered by volume.
+2. **Requests an LLM fair value** — sends each market's question + price + resolution time to your LLM (OpenAI-compatible API, OpenRouter by default), asks for `fair_yes` in 0–1 with a confidence rating.
+3. **Computes edge** — `edge = fair_yes − market_yes_price`.
+4. **Trades on divergence** — if `|edge| ≥ divergence_min` (default 8%), buys the side the model favors at your configured position size.
+5. **Tags trades** with `source: "sdk:sports-trader"` so the Simmer portfolio splits P&L by skill.
+
+### Safeguards
+
+- Extreme prices (default: <5% or >95%) are skipped — most "edge" at those levels is noise.
+- Markets with no LLM signal (timeout, parse failure, missing key) are skipped, not faked.
+- `max_trades_per_run` caps how many fills a single cycle can produce.
+- LLM cost is bounded by `max_markets_per_run` × per-call cost.
+
+### Edge thesis (honest version)
+
+LLMs on public market context generally don't beat tight in-game odds. The plausible edges this template can exploit are:
+
+- **Pre-game mispricing** between the announcement window and tip-off, when news (injury, line movement, lineup) leaks unevenly.
+- **Long-tail player-prop calibration**, where the public crowd is thinner and Bayesian priors matter.
+
+Validated tier (with backtest evidence) is on the roadmap — track it in the Simmer skill catalog.
+
+## Setup Flow
+
+When user asks to install or configure this skill:
+
+1. **Install the Simmer SDK**
+   ```bash
+   pip install simmer-sdk
+   ```
+
+2. **Ask for Simmer API key**
+   - From [simmer.markets/dashboard](https://simmer.markets/dashboard) → SDK tab
+   - Set as `SIMMER_API_KEY`
+
+3. **Ask for wallet private key** (external-wallet only)
+   - Polymarket wallet private key (the wallet that holds pUSD / USDC.e)
+   - Set as `WALLET_PRIVATE_KEY`
+   - The SDK signs orders automatically when this is set; no manual signing code needed.
+   - Managed wallets do NOT need this — the server signs.
+
+4. **Ask for LLM API key**
+   - OpenRouter is the default (`https://openrouter.ai/api/v1`), works with `anthropic/claude-haiku-4.5`. Cheap and adequate.
+   - Anthropic direct: set `llm_base_url=https://api.anthropic.com/v1` and an `anthropic/claude-haiku-4-5` model id (varies by provider).
+   - OpenAI direct: set `llm_base_url=https://api.openai.com/v1` and `gpt-4.1-mini` (or similar).
+   - Set the key as `LLM_API_KEY`. `OPENROUTER_API_KEY` and `OPENAI_API_KEY` are also recognized.
+
+5. **Confirm tunables** (or accept defaults)
+   - Max position USD (default $5)
+   - Divergence threshold (default 8 percentage points)
+   - Max trades per run (default 4)
+   - Auto-import (default false — when true, the skill imports top sports markets that aren't on Simmer yet, consuming your daily import quota)
+
+6. **Set up cron** (disabled by default — user must explicitly schedule)
+
+## Configuration
+
+| Setting              | Env Variable                      | Config Key             | Default                                  | Description |
+|----------------------|-----------------------------------|------------------------|------------------------------------------|-------------|
+| Min market volume    | `SIMMER_SPORTS_MIN_VOLUME`        | `min_volume_usd`       | 25000                                    | Skip sports markets with 24h volume below this. |
+| Max markets/run      | `SIMMER_SPORTS_MAX_MARKETS`       | `max_markets_per_run`  | 8                                        | Caps LLM calls per cycle. |
+| Divergence threshold | `SIMMER_SPORTS_DIVERGENCE_MIN`    | `divergence_min`       | 0.08                                     | Required `|fair − market|` to trigger a trade. |
+| Max position USD     | `SIMMER_SPORTS_MAX_POSITION`      | `max_position_usd`     | 5.00                                     | USD per trade. |
+| Min position USD     | `SIMMER_SPORTS_MIN_POSITION`      | `min_position_usd`     | 2.00                                     | Floor when using smart sizing. |
+| Sizing pct           | `SIMMER_SPORTS_SIZING_PCT`        | `sizing_pct`           | 0.05                                     | % of USDC balance when `--smart-sizing`. |
+| Max trades/run       | `SIMMER_SPORTS_MAX_TRADES`        | `max_trades_per_run`   | 4                                        | Hard cap on fills per cycle. |
+| Extreme price floor  | `SIMMER_SPORTS_PRICE_FLOOR`       | `extreme_price_floor`  | 0.05                                     | Skip if YES price below this. |
+| Extreme price ceil   | `SIMMER_SPORTS_PRICE_CEIL`        | `extreme_price_ceil`   | 0.95                                     | Skip if YES price above this. |
+| Slippage cap         | `SIMMER_SPORTS_SLIPPAGE_MAX`      | `slippage_max_pct`     | 0.05                                     | Reserved for future fill-quality gate. |
+| Auto-import          | `SIMMER_SPORTS_AUTO_IMPORT`       | `auto_import`          | false                                    | If true, import sports markets not yet on Simmer. |
+| Order type           | `SIMMER_SPORTS_ORDER_TYPE`        | `order_type`           | GTC                                      | GTC (good-til-cancelled) or FAK (fill-and-kill). |
+| LLM base URL         | `SIMMER_SPORTS_LLM_BASE_URL`      | `llm_base_url`         | `https://openrouter.ai/api/v1`           | OpenAI-compatible chat endpoint. |
+| LLM model            | `SIMMER_SPORTS_LLM_MODEL`         | `llm_model`            | `anthropic/claude-haiku-4.5`             | Model id (provider-specific). |
+| LLM timeout (s)      | `SIMMER_SPORTS_LLM_TIMEOUT`       | `llm_timeout_secs`     | 30                                       | Per-call HTTP timeout. |
+
+Config priority: `config.json` > env vars > defaults.
+
+## Running the Skill
+
+```bash
+# Dry run — scan, show signals, no trades
+python sports_trader.py
+
+# Execute real trades
+python sports_trader.py --live
+
+# Smart sizing (% of balance, capped at max_position_usd)
+python sports_trader.py --live --smart-sizing
+
+# Show open sports positions
+python sports_trader.py --positions
+
+# Show config
+python sports_trader.py --config
+
+# Update config
+python sports_trader.py --set divergence_min=0.10
+python sports_trader.py --set auto_import=true
+
+# Quiet mode (only print trades + errors — good for cron)
+python sports_trader.py --live --quiet
+```
+
+## Source Tagging
+
+All trades are tagged `source: "sdk:sports-trader"`. This means:
+
+- Portfolio splits P&L by skill so you can see whether sports trading is +EV for you specifically.
+- Other skills won't sell your sports positions.
+
+## Troubleshooting
+
+**"No sports markets to evaluate"**
+- Simmer hasn't imported any active sports markets yet. Run `python sports_trader.py --set auto_import=true` to let the skill import what's needed (consumes daily import quota — 10/day free, 50/day Pro).
+
+**"llm signal unavailable" on every market**
+- `LLM_API_KEY` is not set, or the provider rejected the request. Verify the key works with a direct `curl` to your `llm_base_url`. Many OpenRouter models require an account funding step before they accept traffic.
+
+**"External wallet requires a pre-signed order"**
+- `WALLET_PRIVATE_KEY` is not set. The SDK signs orders automatically when this env var is present — no manual signing code needed.
+- Fix: `export WALLET_PRIVATE_KEY=0x<your-polymarket-wallet-private-key>`.
+
+**"Balance shows $0 but I have funds on Polygon"**
+- Polymarket V2 uses **pUSD** (1:1 backed by USDC.e). If your wallet holds USDC.e or native USDC, migrate at [simmer.markets/dashboard](https://simmer.markets/dashboard) (one click, ~30 s). Full guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration).
+
+**"API key invalid"**
+- Get a new Simmer key from [simmer.markets/dashboard](https://simmer.markets/dashboard) → SDK tab.

--- a/skills/polymarket-sports-trader/clawhub.json
+++ b/skills/polymarket-sports-trader/clawhub.json
@@ -1,0 +1,115 @@
+{
+  "emoji": "🏀",
+  "primaryEnv": "SIMMER_API_KEY",
+  "requires": {
+    "env": [
+      "SIMMER_API_KEY"
+    ],
+    "pip": [
+      "simmer-sdk>=0.11.1"
+    ]
+  },
+  "envVars": [
+    {
+      "name": "SIMMER_API_KEY",
+      "required": true,
+      "description": "Your Simmer SDK API key — get from simmer.markets/dashboard"
+    },
+    {
+      "name": "WALLET_PRIVATE_KEY",
+      "required": false,
+      "description": "Only needed for external-wallet self-custody trading. Not required for managed wallets."
+    },
+    {
+      "name": "LLM_API_KEY",
+      "required": true,
+      "description": "OpenAI-compatible LLM key — OpenRouter / Anthropic / OpenAI. Provider URL configured via SIMMER_SPORTS_LLM_BASE_URL (defaults to OpenRouter)."
+    }
+  ],
+  "cron": null,
+  "autostart": false,
+  "automaton": {
+    "managed": true,
+    "entrypoint": "sports_trader.py"
+  },
+  "tunables": [
+    {
+      "env": "SIMMER_SPORTS_MAX_POSITION",
+      "type": "number",
+      "default": 5,
+      "range": [
+        1,
+        100
+      ],
+      "step": 1,
+      "label": "Max position size (USD)"
+    },
+    {
+      "env": "SIMMER_SPORTS_DIVERGENCE_MIN",
+      "type": "number",
+      "default": 0.08,
+      "range": [
+        0.02,
+        0.30
+      ],
+      "step": 0.01,
+      "label": "Divergence threshold"
+    },
+    {
+      "env": "SIMMER_SPORTS_MAX_TRADES",
+      "type": "number",
+      "default": 4,
+      "range": [
+        1,
+        20
+      ],
+      "step": 1,
+      "label": "Max trades per run"
+    },
+    {
+      "env": "SIMMER_SPORTS_MAX_MARKETS",
+      "type": "number",
+      "default": 8,
+      "range": [
+        1,
+        25
+      ],
+      "step": 1,
+      "label": "Max markets scanned per run"
+    },
+    {
+      "env": "SIMMER_SPORTS_MIN_VOLUME",
+      "type": "number",
+      "default": 25000,
+      "range": [
+        1000,
+        500000
+      ],
+      "step": 1000,
+      "label": "Minimum 24h market volume (USD)"
+    },
+    {
+      "env": "SIMMER_SPORTS_SIZING_PCT",
+      "type": "number",
+      "default": 0.05,
+      "range": [
+        0.01,
+        0.5
+      ],
+      "step": 0.01,
+      "label": "Position size as % of balance (smart-sizing)"
+    },
+    {
+      "env": "SIMMER_SPORTS_AUTO_IMPORT",
+      "type": "boolean",
+      "default": false,
+      "label": "Auto-import sports markets not yet on Simmer"
+    },
+    {
+      "env": "SIMMER_SPORTS_LLM_MODEL",
+      "type": "string",
+      "default": "anthropic/claude-haiku-4.5",
+      "label": "LLM model id (OpenAI-compatible)"
+    }
+  ]
+}

--- a/skills/polymarket-sports-trader/scripts/status.py
+++ b/skills/polymarket-sports-trader/scripts/status.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Sports-trader status — balance + sports-tagged open positions.
+
+Usage:
+    python scripts/status.py
+    python scripts/status.py --positions   # Detailed position list
+"""
+
+import argparse
+import os
+import sys
+
+sys.stdout.reconfigure(line_buffering=True)
+
+TRADE_SOURCE = "sdk:sports-trader"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simmer sports-trader status")
+    parser.add_argument("--positions", action="store_true", help="Show detailed positions")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("SIMMER_API_KEY")
+    if not api_key:
+        print("❌ SIMMER_API_KEY not set. Get one from simmer.markets/dashboard → SDK tab.")
+        sys.exit(1)
+
+    try:
+        from simmer_sdk import SimmerClient
+    except ImportError:
+        print("❌ simmer-sdk not installed. Run: pip install simmer-sdk")
+        sys.exit(1)
+
+    venue = os.environ.get("TRADING_VENUE", "polymarket")
+    client = SimmerClient(api_key=api_key, venue=venue)
+
+    try:
+        portfolio = client.get_portfolio()
+    except Exception as e:
+        print(f"❌ Failed to fetch portfolio: {e}")
+        sys.exit(1)
+
+    if isinstance(portfolio, dict):
+        balance = portfolio.get("balance_usdc") or portfolio.get("balance") or 0.0
+        exposure = portfolio.get("total_exposure", 0.0)
+        positions_count = portfolio.get("positions_count", 0)
+    else:
+        balance = getattr(portfolio, "balance_usdc", 0.0)
+        exposure = getattr(portfolio, "total_exposure", 0.0)
+        positions_count = getattr(portfolio, "positions_count", 0)
+
+    print("=" * 50)
+    print("🏀 SPORTS TRADER STATUS")
+    print("=" * 50)
+    print(f"  Available balance: ${balance:,.2f}")
+    print(f"  Total exposure:    ${exposure:,.2f}")
+    print(f"  Open positions:    {positions_count}")
+
+    try:
+        positions = client.get_positions(source=TRADE_SOURCE)
+    except Exception as e:
+        print(f"\n⚠️  Failed to fetch sports positions: {e}")
+        return
+
+    print(f"\n  Sports-trader positions: {len(positions)}")
+
+    if args.positions and positions:
+        print("\n" + "=" * 50)
+        for p in positions:
+            question = (getattr(p, "market_question", "") or "")[:60]
+            shares = getattr(p, "shares", 0.0)
+            avg = getattr(p, "avg_price", 0.0)
+            print(f"  {question:<62} {shares:>8.2f} shares @ {avg:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/polymarket-sports-trader/sports_trader.py
+++ b/skills/polymarket-sports-trader/sports_trader.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""
+Simmer Polymarket Sports Trader Skill (Template tier).
+
+Scans Polymarket sports markets, asks an LLM (OpenAI-compatible API — defaults
+to OpenRouter) for a fair-value estimate, trades when the model's fair value
+diverges from the current YES price by a configurable threshold.
+
+This is a FRAMEWORK SKILL. The default strategy is generic LLM-driven divergence
+trading — it has not been backtested against historical sports outcomes and
+makes no edge claim. Read DISCLAIMER.md before using with real funds.
+
+Usage:
+    python sports_trader.py                 # Dry run (scan, show signals, no trades)
+    python sports_trader.py --live          # Execute real trades
+    python sports_trader.py --positions     # Show current sports positions
+    python sports_trader.py --config        # Show config
+    python sports_trader.py --set max_position_usd=10
+
+Requires:
+    pip install simmer-sdk
+    SIMMER_API_KEY    — from simmer.markets/dashboard → SDK tab
+    WALLET_PRIVATE_KEY — for external-wallet trading (managed wallets don't need this)
+    LLM_API_KEY       — OpenRouter / Anthropic / OpenAI key for the fair-value model
+"""
+
+import argparse
+import json
+import os
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+sys.stdout.reconfigure(line_buffering=True)
+
+from simmer_sdk.skill import load_config, update_config, get_config_path
+
+# =============================================================================
+# Identity (source-tag every trade so the catalog can split P&L by skill)
+# =============================================================================
+
+TRADE_SOURCE = "sdk:sports-trader"
+SKILL_SLUG = "polymarket-sports-trader"
+
+# =============================================================================
+# Configuration (config.json > env vars > defaults)
+# =============================================================================
+
+CONFIG_SCHEMA = {
+    "min_volume_usd":      {"env": "SIMMER_SPORTS_MIN_VOLUME",      "default": 25000,  "type": float},
+    "max_markets_per_run": {"env": "SIMMER_SPORTS_MAX_MARKETS",     "default": 8,      "type": int},
+    "divergence_min":      {"env": "SIMMER_SPORTS_DIVERGENCE_MIN",  "default": 0.08,   "type": float},
+    "max_position_usd":    {"env": "SIMMER_SPORTS_MAX_POSITION",    "default": 5.00,   "type": float},
+    "min_position_usd":    {"env": "SIMMER_SPORTS_MIN_POSITION",    "default": 2.00,   "type": float},
+    "sizing_pct":          {"env": "SIMMER_SPORTS_SIZING_PCT",      "default": 0.05,   "type": float},
+    "max_trades_per_run":  {"env": "SIMMER_SPORTS_MAX_TRADES",      "default": 4,      "type": int},
+    "extreme_price_floor": {"env": "SIMMER_SPORTS_PRICE_FLOOR",     "default": 0.05,   "type": float},
+    "extreme_price_ceil":  {"env": "SIMMER_SPORTS_PRICE_CEIL",      "default": 0.95,   "type": float},
+    "slippage_max_pct":    {"env": "SIMMER_SPORTS_SLIPPAGE_MAX",    "default": 0.05,   "type": float},
+    "auto_import":         {"env": "SIMMER_SPORTS_AUTO_IMPORT",     "default": False,  "type": bool},
+    "order_type":          {"env": "SIMMER_SPORTS_ORDER_TYPE",      "default": "GTC",  "type": str},
+    "llm_base_url":        {"env": "SIMMER_SPORTS_LLM_BASE_URL",    "default": "https://openrouter.ai/api/v1", "type": str},
+    "llm_model":           {"env": "SIMMER_SPORTS_LLM_MODEL",       "default": "anthropic/claude-haiku-4.5", "type": str},
+    "llm_timeout_secs":    {"env": "SIMMER_SPORTS_LLM_TIMEOUT",     "default": 30,     "type": int},
+}
+
+_config = load_config(CONFIG_SCHEMA, __file__, slug=SKILL_SLUG)
+
+
+def _g(key):
+    return _config.get(key, CONFIG_SCHEMA[key]["default"])
+
+
+# =============================================================================
+# SDK client
+# =============================================================================
+
+_client = None
+
+
+def get_client(live=True):
+    """Lazy-init SimmerClient singleton."""
+    global _client
+    if _client is None:
+        try:
+            from simmer_sdk import SimmerClient
+        except ImportError:
+            print("Error: simmer-sdk not installed. Run: pip install simmer-sdk")
+            sys.exit(1)
+        api_key = os.environ.get("SIMMER_API_KEY")
+        if not api_key:
+            print("Error: SIMMER_API_KEY not set. Get from simmer.markets/dashboard → SDK tab.")
+            sys.exit(1)
+        venue = os.environ.get("TRADING_VENUE", "polymarket")
+        _client = SimmerClient(api_key=api_key, venue=venue, live=live)
+    return _client
+
+
+# =============================================================================
+# Market discovery
+# =============================================================================
+
+def scan_sports_markets():
+    """
+    Discover sports markets to evaluate.
+
+    Strategy: pull Simmer's `get_markets` first (already-imported, fastest path
+    to trade-readiness), filter to Polymarket sports markets. If `auto_import`
+    is enabled, also pull `list_importable_markets(category='sports')` and
+    import the top by volume.
+    """
+    client = get_client()
+    candidates = []
+
+    try:
+        already = client.get_markets(status="active", import_source="polymarket", limit=100)
+    except Exception as e:
+        print(f"  scan: failed to fetch active markets — {e}")
+        already = []
+
+    # We don't have a category filter on get_markets; lean on the importable
+    # endpoint to identify which already-imported markets are sports.
+    sports_question_set = set()
+    try:
+        importable = client.list_importable_markets(
+            category="sports",
+            min_volume=_g("min_volume_usd"),
+            limit=50,
+        )
+        sports_question_set = {(m.get("question") or "").strip().lower() for m in importable}
+    except Exception as e:
+        print(f"  scan: list_importable_markets failed — {e}")
+        importable = []
+
+    for m in already:
+        q = (m.question or "").strip().lower()
+        if q in sports_question_set:
+            candidates.append(m)
+
+    if _g("auto_import") and len(candidates) < _g("max_markets_per_run"):
+        # Pull most-liquid sports markets we don't yet have, import them.
+        have_questions = {(m.question or "").strip().lower() for m in already}
+        for m in sorted(importable, key=lambda x: x.get("volume_24h", 0), reverse=True):
+            q = (m.get("question") or "").strip().lower()
+            if not q or q in have_questions:
+                continue
+            url = m.get("url")
+            if not url:
+                continue
+            try:
+                result = client.import_market(url)
+            except Exception as e:
+                print(f"  import: {q[:60]} — {e}")
+                continue
+            new_id = result.get("market_id") if isinstance(result, dict) else None
+            if new_id:
+                full = client.get_market_by_id(new_id)
+                if full:
+                    candidates.append(full)
+            if len(candidates) >= _g("max_markets_per_run"):
+                break
+
+    return candidates[: _g("max_markets_per_run")]
+
+
+# =============================================================================
+# LLM fair-value signal (OpenAI-compatible HTTP, OpenRouter default)
+# =============================================================================
+
+FAIR_VALUE_PROMPT_TEMPLATE = """You are a sports trader pricing a binary YES/NO market on Polymarket.
+
+Market: {question}
+Resolves at: {resolves_at}
+Current YES price: {yes_price:.4f} (probability the market resolves YES)
+
+Estimate the fair YES probability based on public information you have. If you
+are uncertain, return a probability closer to the current market price — do
+not invent edge.
+
+Respond with a single JSON object on one line, no prose:
+{{"fair_yes": <float 0-1>, "confidence": <"low"|"medium"|"high">, "reasoning": <one-sentence string>}}
+"""
+
+
+def llm_fair_value(question, resolves_at, yes_price):
+    """
+    Ask an OpenAI-compatible LLM for a fair-value YES probability.
+
+    Returns dict {fair_yes, confidence, reasoning} or None on failure.
+    """
+    key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        return None
+
+    base_url = _g("llm_base_url").rstrip("/")
+    prompt = FAIR_VALUE_PROMPT_TEMPLATE.format(
+        question=question,
+        resolves_at=resolves_at or "unknown",
+        yes_price=yes_price,
+    )
+    payload = {
+        "model": _g("llm_model"),
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "max_tokens": 200,
+    }
+    body = json.dumps(payload).encode()
+    req = Request(
+        f"{base_url}/chat/completions",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {key}",
+        },
+    )
+    try:
+        with urlopen(req, timeout=_g("llm_timeout_secs")) as resp:
+            data = json.loads(resp.read().decode())
+    except (HTTPError, URLError, json.JSONDecodeError, TimeoutError) as e:
+        print(f"  llm: error — {e}")
+        return None
+
+    try:
+        content = data["choices"][0]["message"]["content"].strip()
+        # Some providers wrap with ```json blocks; extract first {...}
+        start = content.find("{")
+        end = content.rfind("}")
+        if start == -1 or end == -1:
+            return None
+        parsed = json.loads(content[start : end + 1])
+    except (KeyError, ValueError, json.JSONDecodeError):
+        return None
+
+    fair = parsed.get("fair_yes")
+    if not isinstance(fair, (int, float)) or not (0.0 <= float(fair) <= 1.0):
+        return None
+    return {
+        "fair_yes": float(fair),
+        "confidence": parsed.get("confidence", "medium"),
+        "reasoning": parsed.get("reasoning", ""),
+    }
+
+
+# =============================================================================
+# Signal → trade decision
+# =============================================================================
+
+def evaluate_market(market):
+    """
+    Return a trade decision dict for one market, or None to skip.
+
+    Decision dict: {side, amount, fair_yes, market_price, edge, reasoning}.
+    """
+    yes_price = market.external_price_yes
+    if yes_price is None:
+        yes_price = market.current_probability
+    if yes_price is None:
+        return {"skip": True, "reason": "no yes price available"}
+
+    if yes_price <= _g("extreme_price_floor") or yes_price >= _g("extreme_price_ceil"):
+        return {"skip": True, "reason": f"extreme price {yes_price:.3f}"}
+
+    signal = llm_fair_value(market.question, market.resolves_at, yes_price)
+    if signal is None:
+        return {"skip": True, "reason": "llm signal unavailable"}
+
+    fair = signal["fair_yes"]
+    edge = fair - yes_price  # positive → underpriced YES; negative → overpriced YES
+
+    if abs(edge) < _g("divergence_min"):
+        return {"skip": True, "reason": f"edge {edge:+.3f} below threshold"}
+
+    side = "yes" if edge > 0 else "no"
+    return {
+        "skip": False,
+        "side": side,
+        "fair_yes": fair,
+        "market_price": yes_price,
+        "edge": edge,
+        "confidence": signal["confidence"],
+        "reasoning": signal.get("reasoning", ""),
+    }
+
+
+# =============================================================================
+# Portfolio + sizing
+# =============================================================================
+
+def get_portfolio():
+    try:
+        return get_client().get_portfolio()
+    except Exception:
+        return None
+
+
+def calculate_position_size(smart_sizing):
+    """Compute USD per trade. Smart sizing scales with balance; otherwise fixed."""
+    if not smart_sizing:
+        return _g("max_position_usd")
+    portfolio = get_portfolio()
+    if not portfolio:
+        return _g("max_position_usd")
+    balance = (portfolio.get("balance_usdc") or portfolio.get("balance") or 0.0) if isinstance(portfolio, dict) else 0.0
+    sized = balance * _g("sizing_pct")
+    return max(_g("min_position_usd"), min(_g("max_position_usd"), sized))
+
+
+def execute_trade(market_id, side, amount, reasoning=None, signal_data=None):
+    """Execute a buy trade with source tagging."""
+    try:
+        result = get_client().trade(
+            market_id=market_id,
+            side=side,
+            amount=amount,
+            source=TRADE_SOURCE,
+            skill_slug=SKILL_SLUG,
+            reasoning=reasoning,
+            signal_data=signal_data,
+            order_type=(_g("order_type") or "GTC").upper(),
+        )
+        return {
+            "success": result.success,
+            "trade_id": result.trade_id,
+            "shares": result.shares_bought,
+            "error": result.error,
+            "simulated": result.simulated,
+            "order_status": result.order_status,
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# =============================================================================
+# Main run loop
+# =============================================================================
+
+def run_strategy(dry_run=True, positions_only=False, show_config=False,
+                 smart_sizing=False, quiet=False):
+    if show_config:
+        path = get_config_path(__file__)
+        print(f"⚙️  Config ({path}):")
+        for key, spec in CONFIG_SCHEMA.items():
+            print(f"  {key:<22} {_config.get(key, spec['default'])}")
+        return
+
+    if positions_only:
+        try:
+            positions = get_client().get_positions(source=TRADE_SOURCE)
+        except Exception as e:
+            print(f"Error fetching positions: {e}")
+            return
+        if not positions:
+            print("No sports-trader positions.")
+            return
+        print(f"📊 Open positions ({len(positions)}):")
+        for p in positions:
+            print(f"  {p.market_question[:60]:<62} {p.shares:>8.2f} shares @ {getattr(p, 'avg_price', 0):.3f}")
+        return
+
+    print("🏀 Simmer Sports Trader")
+    print("=" * 50)
+    if dry_run:
+        print("(dry run — no orders placed. Use --live to execute.)")
+
+    candidates = scan_sports_markets()
+    if not candidates:
+        print("No sports markets to evaluate. Try --set auto_import=true.")
+        return
+
+    print(f"📋 Evaluating {len(candidates)} market(s)…")
+    trades_done = 0
+    max_trades = _g("max_trades_per_run")
+
+    for market in candidates:
+        if trades_done >= max_trades:
+            print(f"  reached max_trades_per_run={max_trades}, stopping")
+            break
+        decision = evaluate_market(market)
+        question = (market.question or "")[:60]
+        if decision.get("skip"):
+            if not quiet:
+                print(f"  - {question:<62} skip: {decision.get('reason')}")
+            continue
+        side = decision["side"]
+        fair = decision["fair_yes"]
+        price = decision["market_price"]
+        edge = decision["edge"]
+        amount = calculate_position_size(smart_sizing)
+        reasoning = decision.get("reasoning") or ""
+        print(f"  → {question:<62} {side.upper():>3} fair={fair:.3f} mkt={price:.3f} edge={edge:+.3f} confidence={decision['confidence']}")
+        print(f"     ↳ {reasoning}")
+
+        if dry_run:
+            continue
+
+        result = execute_trade(
+            market_id=market.id,
+            side=side,
+            amount=amount,
+            reasoning=reasoning,
+            signal_data={"fair_yes": fair, "market_price": price, "edge": edge, "confidence": decision["confidence"]},
+        )
+        if result.get("error"):
+            print(f"     ✗ trade error: {result['error']}")
+            continue
+        if result.get("success"):
+            print(f"     ✓ bought {result.get('shares', 0):.2f} shares (trade {result.get('trade_id')})")
+            trades_done += 1
+        else:
+            status = result.get("order_status")
+            print(f"     ↺ order status: {status}")
+            trades_done += 1
+
+    print()
+    print(f"📊 Summary: {len(candidates)} scanned · {trades_done} trades")
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    parser.add_argument("--live", action="store_true", help="Execute real trades (default: dry run)")
+    parser.add_argument("--positions", action="store_true", help="Show current positions")
+    parser.add_argument("--config", action="store_true", help="Show config")
+    parser.add_argument("--set", action="append", default=[], metavar="key=value", help="Update config (e.g. max_position_usd=10)")
+    parser.add_argument("--smart-sizing", action="store_true", help="Size positions as a percentage of balance")
+    parser.add_argument("--quiet", action="store_true", help="Only print on trades and errors")
+    args = parser.parse_args()
+
+    if args.set:
+        updates = {}
+        for item in args.set:
+            if "=" not in item:
+                print(f"--set expects key=value, got: {item}")
+                sys.exit(1)
+            key, value = item.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if key in CONFIG_SCHEMA:
+                type_fn = CONFIG_SCHEMA[key].get("type", str)
+                try:
+                    if type_fn is bool:
+                        value = value.lower() in ("1", "true", "yes", "on")
+                    else:
+                        value = type_fn(value)
+                except (ValueError, TypeError):
+                    pass
+            updates[key] = value
+        if updates:
+            update_config(updates, __file__)
+            print(f"✅ Config updated: {updates}")
+            print(f"   Saved to: {get_config_path(__file__)}")
+        return
+
+    run_strategy(
+        dry_run=not args.live,
+        positions_only=args.positions,
+        show_config=args.config,
+        smart_sizing=args.smart_sizing,
+        quiet=args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/polymarket-sports-trader/tests/test_signal.py
+++ b/skills/polymarket-sports-trader/tests/test_signal.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for the sports-trader decision logic.
+
+Pure-unit: no network calls, no SDK required. We stub simmer_sdk.skill before
+importing sports_trader so the module's load_config call doesn't try to read
+config.json from disk.
+"""
+
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+
+def _mock_cfg():
+    return {
+        "min_volume_usd": 25000,
+        "max_markets_per_run": 8,
+        "divergence_min": 0.08,
+        "max_position_usd": 5.0,
+        "min_position_usd": 2.0,
+        "sizing_pct": 0.05,
+        "max_trades_per_run": 4,
+        "extreme_price_floor": 0.05,
+        "extreme_price_ceil": 0.95,
+        "slippage_max_pct": 0.05,
+        "auto_import": False,
+        "order_type": "GTC",
+        "llm_base_url": "https://openrouter.ai/api/v1",
+        "llm_model": "anthropic/claude-haiku-4.5",
+        "llm_timeout_secs": 30,
+    }
+
+
+with patch.dict("sys.modules", {"simmer_sdk": MagicMock(), "simmer_sdk.skill": MagicMock()}):
+    skill_module = types.ModuleType("simmer_sdk.skill")
+    skill_module.load_config = lambda schema, file, slug=None: _mock_cfg()
+    skill_module.update_config = lambda *a, **kw: None
+    skill_module.get_config_path = lambda *a, **kw: "/tmp/config.json"
+    sys.modules["simmer_sdk"] = MagicMock()
+    sys.modules["simmer_sdk.skill"] = skill_module
+
+    import sports_trader as st
+
+
+def _market(yes_price=0.50, current_probability=0.50, question="LAL vs BOS — Lakers win", resolves_at=None):
+    return SimpleNamespace(
+        id="m-1",
+        question=question,
+        external_price_yes=yes_price,
+        current_probability=current_probability,
+        resolves_at=resolves_at,
+    )
+
+
+class TestExtremePriceSkip(unittest.TestCase):
+    """Markets above the ceiling or below the floor are skipped before we burn an LLM call."""
+
+    def test_skip_above_ceiling(self):
+        with patch.object(st, "llm_fair_value") as fake_llm:
+            d = st.evaluate_market(_market(yes_price=0.97))
+            self.assertTrue(d.get("skip"))
+            self.assertIn("extreme price", d.get("reason", ""))
+            fake_llm.assert_not_called()
+
+    def test_skip_below_floor(self):
+        with patch.object(st, "llm_fair_value") as fake_llm:
+            d = st.evaluate_market(_market(yes_price=0.02))
+            self.assertTrue(d.get("skip"))
+            self.assertIn("extreme price", d.get("reason", ""))
+            fake_llm.assert_not_called()
+
+    def test_no_price_skip(self):
+        with patch.object(st, "llm_fair_value") as fake_llm:
+            d = st.evaluate_market(_market(yes_price=None, current_probability=None))
+            self.assertTrue(d.get("skip"))
+            self.assertIn("no yes price", d.get("reason", ""))
+            fake_llm.assert_not_called()
+
+
+class TestLLMUnavailable(unittest.TestCase):
+    def test_skip_when_llm_returns_none(self):
+        with patch.object(st, "llm_fair_value", return_value=None):
+            d = st.evaluate_market(_market(yes_price=0.50))
+            self.assertTrue(d.get("skip"))
+            self.assertEqual(d.get("reason"), "llm signal unavailable")
+
+
+class TestDivergenceThreshold(unittest.TestCase):
+    """The divergence_min threshold (default 0.08) gates whether a trade fires."""
+
+    def test_below_threshold_skipped(self):
+        with patch.object(st, "llm_fair_value", return_value={"fair_yes": 0.55, "confidence": "medium", "reasoning": "."}):
+            d = st.evaluate_market(_market(yes_price=0.50))
+            self.assertTrue(d.get("skip"))
+            self.assertIn("below threshold", d.get("reason", ""))
+
+    def test_exactly_threshold_skipped(self):
+        # edge = 0.08 with divergence_min 0.08 → strict-less-than → skip
+        with patch.object(st, "llm_fair_value", return_value={"fair_yes": 0.58, "confidence": "medium", "reasoning": "."}):
+            d = st.evaluate_market(_market(yes_price=0.50))
+            self.assertTrue(d.get("skip"))
+
+    def test_above_threshold_yes_buy(self):
+        with patch.object(st, "llm_fair_value", return_value={"fair_yes": 0.70, "confidence": "high", "reasoning": "starter back"}):
+            d = st.evaluate_market(_market(yes_price=0.50))
+            self.assertFalse(d.get("skip"))
+            self.assertEqual(d["side"], "yes")
+            self.assertAlmostEqual(d["edge"], 0.20, places=4)
+
+    def test_above_threshold_no_buy(self):
+        with patch.object(st, "llm_fair_value", return_value={"fair_yes": 0.30, "confidence": "high", "reasoning": "injury news"}):
+            d = st.evaluate_market(_market(yes_price=0.50))
+            self.assertFalse(d.get("skip"))
+            self.assertEqual(d["side"], "no")
+            self.assertAlmostEqual(d["edge"], -0.20, places=4)
+
+
+class TestPositionSizing(unittest.TestCase):
+    def test_fixed_sizing_returns_max_position(self):
+        size = st.calculate_position_size(smart_sizing=False)
+        self.assertEqual(size, 5.0)
+
+    def test_smart_sizing_caps_at_max(self):
+        with patch.object(st, "get_portfolio", return_value={"balance_usdc": 100_000}):
+            # 5% of $100k = $5000 → capped at max_position_usd = $5
+            size = st.calculate_position_size(smart_sizing=True)
+            self.assertEqual(size, 5.0)
+
+    def test_smart_sizing_floors_at_min(self):
+        with patch.object(st, "get_portfolio", return_value={"balance_usdc": 10}):
+            # 5% of $10 = $0.50 → floored at min_position_usd = $2
+            size = st.calculate_position_size(smart_sizing=True)
+            self.assertEqual(size, 2.0)
+
+    def test_smart_sizing_no_portfolio_falls_back(self):
+        with patch.object(st, "get_portfolio", return_value=None):
+            size = st.calculate_position_size(smart_sizing=True)
+            self.assertEqual(size, 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Capability skill that lets an autonomous Simmer agent trade Polymarket sports markets (NBA / NFL / soccer / MLB / tennis) using an LLM-driven divergence signal. Shipped as a **Template-tier** skill — generic playbook, no backtested edge, standard \`DISCLAIMER.md\` callout up front.

Direct response to [@cobotgg's sports-agent launch](https://x.com/cobotgg/status/2056408121430646837) — same surface area (live odds + LLM analysis + autonomous exec), shipped as an installable skill on Simmer's catalog.

### How the strategy works

1. Scans Polymarket sports markets via the SDK (\`category='sports'\`, filtered by 24h volume).
2. For each market, asks an OpenAI-compatible LLM (OpenRouter default; configurable via \`llm_base_url\`) for a \`fair_yes\` probability.
3. Computes \`edge = fair_yes − market_price\`; trades when \`|edge| ≥ divergence_min\` (default 8pp).
4. Tags trades with \`source=sdk:sports-trader\` so the catalog splits P&L by skill.

### Tier + framing

**Template, not Validated** — explicit and visible:
- \`DISCLAIMER.md\` is the verbatim Tier B template from \`_dev/active/_skill-disclaimer-rollout/proposal.md\`.
- \`SKILL.md\` has the framework-not-production callout up top.
- Includes an honest "edge thesis" section: pre-game window mispricing (injury/lineup leaks) and long-tail player props are where this template *might* find edge. Tight in-game spreads are explicitly called out as the regime where generic LLM-on-context loses.

### Safeguards

- Extreme-price skip (default \`<5%\` or \`>95%\` YES).
- No-LLM-key short-circuit (skip the market, don't fabricate a signal).
- \`max_markets_per_run\` + \`max_trades_per_run\` cap both LLM cost and fill exposure per cycle.
- Auto-import disabled by default — opt-in if the user wants the skill consuming their daily Polymarket import quota.

## Test plan

- [x] \`python -m unittest skills.polymarket-sports-trader.tests.test_signal\` — 12 unit tests pass (extreme-price skip, LLM-unavailable skip, divergence threshold gating, sizing under smart/fixed/no-portfolio).
- [x] \`python sports_trader.py --config\` shows the full config table.
- [x] \`python sports_trader.py --set divergence_min=0.10\` persists to \`config.json\`.
- [x] \`python sports_trader.py --help\` renders cleanly (caught + fixed a \`%\` literal in help text mid-smoke-test).
- [ ] **Reviewer**: dry-run scan with a real \`SIMMER_API_KEY\` + \`LLM_API_KEY\` (OpenRouter) — verify it finds markets, requests fair values, prints decisions without placing trades.
- [ ] **Reviewer**: ClawHub manifest renders correctly (8 tunables, 3 env vars, \`automaton.entrypoint=sports_trader.py\`).
- [ ] **Adrian**: confirm the SKILL.md framing matches the validated/template gate we're rolling out, and the disclaimer language is acceptable for ClawHub publication.

## Follow-ups

- Validated tier: backtest historical Polymarket NBA odds → outcomes, define a specific edge thesis (likely injury/lineup news → market lag), ship \`polymarket-sports-trader@1.0.0\` with \`backtest_evidence.md\`. Tracked under the [skill EV validation gap](../simmer/_dev/active/_skill-catalog-reshape/) workstream.
- Add cobotgg to competitor base (\`simmer-labs/shared-knowledge/intel/\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)