### PR TITLE
fix(skills): skip sell loop on resolved markets — weather + elon-tweets (SIM-2046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Skills — 2026-05-19
+
+### Fixed
+
+- **Skip sell loop on resolved markets — polymarket-weather-trader v1.21.1, kalshi-weather-trader v1.0.7, polymarket-elon-tweets v1.3.3 (SIM-2046, root cause SIM-2044).** All three skills were retrying sells indefinitely on resolved markets, generating 2,319 failed sell attempts across 24 wallets over 14 days. Root cause: the exit loop didn't check `position.status` before attempting a sell; Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell", and the skill retried every cycle until `auto_redeem()` claimed the shares. Fix: added `status == "resolved"` guard immediately after the minimum-shares check. `auto_redeem()` at the top of each cycle handles the actual payout. Also changed silent `except: pass` on `auto_redeem()` to log the exception at `force=True` so future failures surface in skill logs.
+
 ## [0.17.11] — 2026-05-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **Skip sell loop on resolved markets — polymarket-weather-trader v1.21.1, kalshi-weather-trader v1.0.7, polymarket-elon-tweets v1.3.3 (SIM-2046, root cause SIM-2044).** All three skills were retrying sells indefinitely on resolved markets, generating 2,319 failed sell attempts across 24 wallets over 14 days. Root cause: the exit loop didn't check `position.status` before attempting a sell; Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell", and the skill retried every cycle until `auto_redeem()` claimed the shares. Fix: added `status == "resolved"` guard immediately after the minimum-shares check. `auto_redeem()` at the top of each cycle handles the actual payout. Also changed silent `except: pass` on `auto_redeem()` to log the exception at `force=True` so future failures surface in skill logs.
+- **Skip sell loop on resolved markets — polymarket-weather-trader v1.21.1, kalshi-weather-trader v1.0.7, polymarket-elon-tweets v1.3.3 (SIM-2046).** All three skills could retry sells indefinitely on resolved markets while waiting for `auto_redeem()` to claim the winning shares. Root cause: the exit loop didn't check `position.status` before attempting a sell; Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell", and the skill retried every cycle. Fix: added `status == "resolved"` guard immediately after the minimum-shares check. `auto_redeem()` at the top of each cycle handles the actual payout. Also changed silent `except: pass` on `auto_redeem()` to log the exception at `force=True` so future failures surface in skill logs.
 
 ## [0.17.11] — 2026-05-18
 

--- a/skills/kalshi-weather-trader/SKILL.md
+++ b/skills/kalshi-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: kalshi-weather-trader
 description: Trade Kalshi weather markets using NOAA forecasts via Simmer SDK and DFlow on Solana. Port of the popular polymarket-weather-trader. Use when user wants to trade temperature markets on Kalshi, automate weather bets, or check NOAA forecasts.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.6"
+  version: "1.0.7"
   displayName: Kalshi Weather Trader
   difficulty: intermediate
   attribution: Strategy inspired by gopfan2, powered by DFlow

--- a/skills/kalshi-weather-trader/weather_trader.py
+++ b/skills/kalshi-weather-trader/weather_trader.py
@@ -686,6 +686,9 @@ def check_exit_opportunities(dry_run: bool = False, use_safeguards: bool = True)
         if shares < MIN_SHARES_PER_ORDER:
             continue
 
+        if pos.get("status") == "resolved":
+            continue  # auto_redeem at top of next cycle handles this
+
         if current_price >= EXIT_THRESHOLD:
             exits_found += 1
             print(f"  📤 {question}...")
@@ -781,8 +784,8 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         for r in redeemed:
             if r.get("success"):
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
-    except Exception:
-        pass  # Non-critical — don't block trading
+    except Exception as e:
+        log(f"  ⚠️  auto_redeem failed: {e}", force=True)
 
     # Show portfolio if smart sizing enabled
     if smart_sizing:

--- a/skills/polymarket-elon-tweets/SKILL.md
+++ b/skills/polymarket-elon-tweets/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-elon-tweets
 description: 'Trade Polymarket "Elon Musk # tweets" markets using XTracker post count data. Buys adjacent range buckets when combined cost < $1 for structural edge. Use when user wants to trade tweet count markets, automate Elon tweet bets, check XTracker stats, or run noovd-style trading.'
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.2"
+  version: "1.3.3"
   displayName: Polymarket Elon Tweet Trader
   difficulty: advanced
   attribution: Strategy inspired by @noovd

--- a/skills/polymarket-elon-tweets/elon_tweets.py
+++ b/skills/polymarket-elon-tweets/elon_tweets.py
@@ -564,6 +564,9 @@ def check_exit_opportunities(dry_run=True, use_safeguards=True):
         if shares < MIN_SHARES_PER_ORDER:
             continue
 
+        if pos.status == "resolved":
+            continue  # auto_redeem at top of next cycle handles this
+
         if current_price >= EXIT_THRESHOLD:
             exits_found += 1
             print(f"  📤 {question}...")
@@ -627,8 +630,8 @@ def run_strategy(dry_run=True, positions_only=False, show_config=False,
         for r in redeemed:
             if r.get("success"):
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
-    except Exception:
-        pass  # Non-critical — don't block trading
+    except Exception as e:
+        log(f"  ⚠️  auto_redeem failed: {e}", force=True)
 
     # Balance pre-flight: skip cleanly when wallet is underfunded instead of
     # looping on rejected trades. Helper is collateral-agnostic — checks pUSD

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.21.0"
+  version: "1.21.1"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -1037,6 +1037,9 @@ def check_exit_opportunities(dry_run: bool = False, use_safeguards: bool = True)
         if shares < MIN_SHARES_PER_ORDER:
             continue
 
+        if pos.get("status") == "resolved":
+            continue  # auto_redeem at top of next cycle handles this
+
         if current_price >= EXIT_THRESHOLD:
             exits_found += 1
             print(f"  📤 {question}...")
@@ -1152,8 +1155,8 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         for r in redeemed:
             if r.get("success"):
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
-    except Exception:
-        pass  # Non-critical — don't block trading
+    except Exception as e:
+        log(f"  ⚠️  auto_redeem failed: {e}", force=True)
 
     # Balance pre-flight: skip cleanly when wallet is underfunded instead of
     # looping on rejected trades. Helper is collateral-agnostic — checks pUSD


### PR DESCRIPTION
## Summary

3 skills were retrying sells indefinitely on resolved Polymarket/Kalshi markets, generating **2,319 failed sell attempts across 24 wallets** in 14 days (root cause discovered in SIM-2044, user Ernesto's 1,336 failed sells on weather-trader). Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell"; the skill retried every cycle until `auto_redeem()` claimed the shares.

## Changes

- `skills/polymarket-weather-trader/weather_trader.py`: Added `status == "resolved"` guard after min-shares check in exit loop (positions are dicts — uses `pos.get()`). Changed silent `except: pass` on `auto_redeem()` to `log(f"⚠️ auto_redeem failed: {e}", force=True)`. Bumped to v1.21.1.
- `skills/kalshi-weather-trader/weather_trader.py`: Same pattern — `pos.get("status") == "resolved"` guard + `auto_redeem` logging. Bumped to v1.0.7.
- `skills/polymarket-elon-tweets/elon_tweets.py`: Same fix — `pos.status == "resolved"` guard (positions are `Position` dataclass — attribute access). Same `auto_redeem` logging fix. Bumped to v1.3.3.
- `CHANGELOG.md`: Entry documenting the fix, referencing SIM-2046 and SIM-2044.
- `SKILL.md` files: Version bumps for all 3 skills.

## Platform impact

- 24 wallets affected, 2,319 failed sell API calls over 14 days
- Fix is a no-op fast path — resolved positions just skip to the next position without touching any orders or funds
- `auto_redeem()` at the top of each cycle continues to handle the actual payout

## Tests

- `py_compile` passes for all 3 modified files ✓
- No `SIMMER_API_KEY` available in this agent environment; full test-skill harness not run (requires live API key)

## Risk tier

B — pure no-op-fast-path on sell side, no fund-flow change, identical diff in 3 places

Closes SIM-2046
Refs SIM-2044