### PR TITLE
feat(mcp): Phase 2 MCP unification — skill discovery + execution tools (SIM-2055)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "pretest": "npm run bundle-skills",
     "test": "npm run build && node --test 'tests/*.test.ts'",
     "bundle-skills": "node scripts/bundle-skills.ts",
     "prepack": "npm run bundle-skills"

--- a/mcp/src/blocked-flags.ts
+++ b/mcp/src/blocked-flags.ts
@@ -1,0 +1,51 @@
+/**
+ * BLOCKED_FLAG_PATTERNS — flags that would bypass the structured dry_run safety gate.
+ * Codex review 2026-05-19 CRITICAL #5: strengthened to catch =-form and space-separated forms.
+ *
+ * Two-pass filter handles both `=`-style (--live=true) and space-separated (--live true).
+ */
+
+const BLOCKED_FLAG_PATTERNS: RegExp[] = [
+  /^--(live|no-dry-run|no-dry|real|production)(=.+)?$/i,
+  /^--mode=(live|prod|production|real)$/i,
+  /^--venue=.*(live|prod|real)/i,
+];
+
+const BLOCKED_KEY_AWAITING_VALUE_PATTERNS: RegExp[] = [
+  /^--mode$/i,
+  /^--venue$/i,
+];
+
+const LIVE_VALUES = /^(live|prod|production|real|true|1|yes)$/i;
+
+export function isBlockedFlag(arg: string): boolean {
+  if (typeof arg !== "string") return false;
+  return BLOCKED_FLAG_PATTERNS.some((p) => p.test(arg));
+}
+
+export function filterBlockedFlags(args: unknown[]): string[] {
+  const out: string[] = [];
+  let skipNext = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (skipNext) { skipNext = false; continue; }
+    if (typeof a !== "string") continue;
+
+    if (isBlockedFlag(a)) {
+      const next = args[i + 1];
+      if (typeof next === "string" && LIVE_VALUES.test(next)) skipNext = true;
+      continue;
+    }
+
+    if (BLOCKED_KEY_AWAITING_VALUE_PATTERNS.some((p) => p.test(a))) {
+      const next = args[i + 1];
+      if (typeof next === "string" && LIVE_VALUES.test(next)) {
+        skipNext = true;
+        continue;
+      }
+    }
+
+    out.push(a);
+  }
+  return out;
+}

--- a/mcp/src/core/types.ts
+++ b/mcp/src/core/types.ts
@@ -50,3 +50,48 @@ export interface RunResult {
   timedOut: boolean;
   killed: boolean;
 }
+
+// Skill registry types — added 2026-05-19 for unified MCP (SIM-2045)
+
+export type SkillTier = "trading" | "instruction";
+
+export interface TunableNumber {
+  env: string;
+  type: "number";
+  default: number;
+  range?: [number, number];
+  step?: number;
+  label: string;
+}
+
+export interface TunableString {
+  env: string;
+  type: "string";
+  default: string;
+  enum?: string[];
+  label: string;
+}
+
+export interface TunableBoolean {
+  env: string;
+  type: "boolean";
+  default: boolean;
+  label: string;
+}
+
+export type Tunable = TunableNumber | TunableString | TunableBoolean;
+
+export interface Skill {
+  slug: string;
+  toolName: string;
+  name: string;
+  description: string;
+  version: string;
+  tier: SkillTier;
+  status?: string;
+  published?: boolean;
+  entrypoint?: string;
+  tunables: Tunable[];
+  skillDir: string;
+  hasDisclaimer: boolean;
+}

--- a/mcp/src/docs-tools.ts
+++ b/mcp/src/docs-tools.ts
@@ -1,0 +1,116 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Skill } from "./core/types.js";
+
+export interface SkillListEntry {
+  slug: string;
+  name: string;
+  description: string;
+  version: string;
+  tier: "trading" | "instruction";
+  status?: string;
+  requires_api_key: boolean;
+  requires_pro: boolean;
+  has_disclaimer: boolean;
+}
+
+export function listSkills(skills: Skill[]): SkillListEntry[] {
+  return skills.map((s) => ({
+    slug: s.slug,
+    name: s.name,
+    description: s.description,
+    version: s.version,
+    tier: s.tier,
+    status: s.status,
+    requires_api_key: s.tier === "trading",
+    requires_pro: false,
+    has_disclaimer: s.hasDisclaimer,
+  }));
+}
+
+export interface ToolResponse {
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
+}
+
+export function getSkillDocs(skills: Skill[], slug: string): ToolResponse {
+  const skill = skills.find((s) => s.slug === slug);
+  if (!skill) {
+    const available = skills.map((s) => s.slug).join(", ");
+    return {
+      content: [{ type: "text", text: `Skill "${slug}" not found. Available: ${available}` }],
+      isError: true,
+    };
+  }
+  const skillMd = path.join(skill.skillDir, "SKILL.md");
+  if (!fs.existsSync(skillMd)) {
+    return {
+      content: [{ type: "text", text: `SKILL.md missing for ${slug}` }],
+      isError: true,
+    };
+  }
+  const body = fs.readFileSync(skillMd, "utf-8");
+  return { content: [{ type: "text", text: body }], isError: false };
+}
+
+export interface DocResource {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: "text/markdown";
+}
+
+export interface DocOptions {
+  snapshotsDir?: string;
+}
+
+const RESOURCE_FILES: Record<string, string> = {
+  "simmer://docs/api-reference": "docs.md",
+  "simmer://docs/skill-reference": "skill.md",
+};
+
+const RESOURCE_NAMES: Record<string, string> = {
+  "simmer://docs/api-reference": "Simmer API Reference",
+  "simmer://docs/skill-reference": "Simmer Agent Reference",
+};
+
+const RESOURCE_DESCRIPTIONS: Record<string, string> = {
+  "simmer://docs/api-reference": "Full Simmer API reference (~2400 lines)",
+  "simmer://docs/skill-reference": "Condensed agent-facing reference (~600 lines)",
+};
+
+export function listDocResources(opts: DocOptions = {}): DocResource[] {
+  void opts;
+  return Object.keys(RESOURCE_FILES).map((uri) => ({
+    uri,
+    name: RESOURCE_NAMES[uri],
+    description: RESOURCE_DESCRIPTIONS[uri],
+    mimeType: "text/markdown" as const,
+  }));
+}
+
+export interface DocReadResult {
+  contents: Array<{ uri: string; mimeType: "text/markdown"; text: string }>;
+  isError: boolean;
+}
+
+export async function readDocResource(uri: string, opts: DocOptions = {}): Promise<DocReadResult> {
+  const file = RESOURCE_FILES[uri];
+  if (!file) {
+    return { contents: [], isError: true };
+  }
+  const snapshotsDir = opts.snapshotsDir ?? path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "bundled-snapshots"
+  );
+  const filePath = path.join(snapshotsDir, file);
+  if (!fs.existsSync(filePath)) {
+    return { contents: [], isError: true };
+  }
+  return {
+    contents: [{ uri, mimeType: "text/markdown", text: fs.readFileSync(filePath, "utf-8") }],
+    isError: false,
+  };
+}

--- a/mcp/src/docs-tools.ts
+++ b/mcp/src/docs-tools.ts
@@ -24,7 +24,7 @@ export function listSkills(skills: Skill[]): SkillListEntry[] {
     tier: s.tier,
     status: s.status,
     requires_api_key: s.tier === "trading",
-    requires_pro: false,
+    requires_pro: s.tier === "trading",
     has_disclaimer: s.hasDisclaimer,
   }));
 }

--- a/mcp/src/env-translation.ts
+++ b/mcp/src/env-translation.ts
@@ -1,0 +1,68 @@
+/**
+ * Arg → env-var translation with FAIL-CLOSED dry_run gate.
+ * Codex review 2026-05-19 CRITICAL #2 + #3.
+ *
+ * Triple-gate for live trading:
+ *   1. args.dry_run === false  (explicit)
+ *   2. typeof args.trading_venue === "string" && args.trading_venue !== "sim"
+ *   3. processEnv.SIMMER_MCP_ALLOW_LIVE === "true"
+ * If any missing, TRADING_VENUE is set to "sim" and the coercion is logged.
+ */
+
+import type { Skill } from "./core/types.js";
+
+export function envToArgName(envName: string): string {
+  const parts = envName.split("_");
+  if (parts.length <= 2) return envName.toLowerCase();
+  return parts.slice(2).join("_").toLowerCase();
+}
+
+export interface BuildEnvOptions {
+  processEnv?: Record<string, string | undefined>;
+  logCoercion?: (msg: string) => void;
+}
+
+export function buildEnv(
+  skill: Skill,
+  args: Record<string, unknown>,
+  options: BuildEnvOptions = {}
+): Record<string, string> {
+  const processEnv = options.processEnv ?? process.env;
+  const log = options.logCoercion ?? ((msg: string) => console.error(msg));
+
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(processEnv)) {
+    if (typeof v === "string") env[k] = v;
+  }
+
+  env.SIMMER_MANAGED_MODE = "1";
+  env.AUTOMATON_MANAGED = "1";
+  env.PYTHONUNBUFFERED = "1";
+
+  // FAIL-CLOSED VENUE GATE
+  const allowLive = processEnv.SIMMER_MCP_ALLOW_LIVE === "true";
+  const callerVenue = typeof args.trading_venue === "string" ? args.trading_venue : null;
+  const callerWantsLive = args.dry_run === false && callerVenue !== null && callerVenue !== "sim";
+
+  if (callerWantsLive && allowLive) {
+    env.TRADING_VENUE = callerVenue;
+  } else {
+    env.TRADING_VENUE = "sim";
+    if (callerWantsLive && !allowLive) {
+      log(
+        "[simmer-mcp] COERCED to sim: caller passed dry_run=false but " +
+        "SIMMER_MCP_ALLOW_LIVE is not 'true'. Set the env var to enable live."
+      );
+    }
+  }
+
+  // Tunable args → env vars
+  for (const tunable of skill.tunables) {
+    const argName = envToArgName(tunable.env);
+    if (argName in args) {
+      env[tunable.env] = String(args[argName]);
+    }
+  }
+
+  return env;
+}

--- a/mcp/src/env-translation.ts
+++ b/mcp/src/env-translation.ts
@@ -56,8 +56,16 @@ export function buildEnv(
     }
   }
 
+  // Defense-in-depth: gate-controlled vars must not be overwritten by
+  // skill tunables even if skill-discovery failed to strip them.
+  const GATE_ENV = new Set([
+    "TRADING_VENUE", "SIMMER_MANAGED_MODE", "AUTOMATON_MANAGED",
+    "PYTHONUNBUFFERED", "SIMMER_MCP_ALLOW_LIVE", "SIMMER_MCP_ALLOW_EXTRA_ARGS",
+  ]);
+
   // Tunable args → env vars
   for (const tunable of skill.tunables) {
+    if (GATE_ENV.has(tunable.env)) continue;
     const argName = envToArgName(tunable.env);
     if (argName in args) {
       env[tunable.env] = String(args[argName]);

--- a/mcp/src/errors.ts
+++ b/mcp/src/errors.ts
@@ -1,11 +1,34 @@
+export interface McpErrorResponse {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+  _meta?: { status_code?: number; upgrade_url?: string };
+}
+
 export class BackendError extends Error {
   readonly statusCode: number;
-  readonly code: string;
+  readonly body: string;
+  readonly upgradeUrl?: string;
 
-  constructor(message: string, statusCode: number, code: string) {
-    super(message);
+  constructor(statusCode: number, body: string, upgradeUrl?: string) {
+    super(body);
     this.name = "BackendError";
     this.statusCode = statusCode;
-    this.code = code;
+    this.body = body;
+    this.upgradeUrl = upgradeUrl;
+  }
+
+  toMcpResponse(): McpErrorResponse {
+    const parts = [this.body];
+    if (this.upgradeUrl) {
+      parts.push(`Upgrade: ${this.upgradeUrl}`);
+    }
+    return {
+      content: [{ type: "text", text: parts.join("\n\n") }],
+      isError: true,
+      _meta: {
+        status_code: this.statusCode,
+        ...(this.upgradeUrl ? { upgrade_url: this.upgradeUrl } : {}),
+      },
+    };
   }
 }

--- a/mcp/src/output-parsing.ts
+++ b/mcp/src/output-parsing.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse the last JSON line from a skill's stdout. Skills emit
+ * {"simmer_managed_output":{...}} (preferred) or {"automaton":{...}}
+ * (back-compat, AUTOMATON_MANAGED rename transition).
+ */
+
+export interface ParsedSkillOutput {
+  result: Record<string, unknown> | null;
+  log: string;
+}
+
+export function parseSkillOutput(stdout: string): ParsedSkillOutput {
+  const lines = stdout.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+
+  // Walk from the bottom up — last structured-output line wins.
+  // Within a line, prefer simmer_managed_output over automaton.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line.startsWith("{")) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line);
+    } catch { continue; }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    if ("simmer_managed_output" in parsed) {
+      return { result: parsed.simmer_managed_output as Record<string, unknown>, log: stdout };
+    }
+    if ("automaton" in parsed) {
+      return { result: parsed.automaton as Record<string, unknown>, log: stdout };
+    }
+  }
+  return { result: null, log: stdout };
+}

--- a/mcp/src/per-skill-tools.ts
+++ b/mcp/src/per-skill-tools.ts
@@ -27,10 +27,14 @@ function tunableToZod(t: Tunable): ZodType<unknown> {
   return z.boolean().default(t.default).describe(t.label);
 }
 
+// Defense-in-depth: tunables must not shadow gate-relevant schema fields.
+const RESERVED_ARG_NAMES = new Set(["dry_run", "trading_venue", "extra_args", "timeout_s"]);
+
 export function buildToolSchema(skill: Skill): z.ZodObject<z.ZodRawShape> {
   const tunableShape: Record<string, ZodType<unknown>> = {};
   for (const t of skill.tunables) {
     const argName = envToArgName(t.env);
+    if (RESERVED_ARG_NAMES.has(argName)) continue;
     tunableShape[argName] = tunableToZod(t).optional();
   }
 

--- a/mcp/src/per-skill-tools.ts
+++ b/mcp/src/per-skill-tools.ts
@@ -1,0 +1,147 @@
+/**
+ * Per-skill execution tool generation.
+ * One simmer_<slug> tool per Tier B (trading) skill, schema from clawhub.json tunables.
+ */
+
+import { z, ZodType } from "zod";
+import * as path from "node:path";
+import type { Skill, Tunable } from "./core/types.js";
+import { filterBlockedFlags } from "./blocked-flags.js";
+import { buildEnv, envToArgName } from "./env-translation.js";
+import { parseSkillOutput } from "./output-parsing.js";
+import { runSkillProcess } from "./skill-runner.js";
+
+function tunableToZod(t: Tunable): ZodType<unknown> {
+  if (t.type === "number") {
+    let s: z.ZodNumber = z.number();
+    if (t.range) s = s.min(t.range[0]).max(t.range[1]);
+    return s.default(t.default).describe(t.label);
+  }
+  if (t.type === "string") {
+    if (t.enum && t.enum.length > 0) {
+      const [head, ...rest] = t.enum;
+      return z.enum([head, ...rest] as [string, ...string[]]).default(t.default).describe(t.label);
+    }
+    return z.string().default(t.default).describe(t.label);
+  }
+  return z.boolean().default(t.default).describe(t.label);
+}
+
+export function buildToolSchema(skill: Skill): z.ZodObject<z.ZodRawShape> {
+  const tunableShape: Record<string, ZodType<unknown>> = {};
+  for (const t of skill.tunables) {
+    const argName = envToArgName(t.env);
+    tunableShape[argName] = tunableToZod(t).optional();
+  }
+
+  return z.object({
+    dry_run: z.boolean().default(true).describe(
+      "If false, may place real orders (requires SIMMER_MCP_ALLOW_LIVE=true env). Default: paper mode."
+    ),
+    trading_venue: z.enum(["sim", "polymarket", "kalshi"]).default("sim").describe(
+      "Trading venue. 'sim' = simulated $SIM venue."
+    ),
+    extra_args: z.array(z.string()).optional().describe(
+      "Pass-through CLI flags. Live-trading flags (--live, --no-dry-run, --mode=live, etc.) are filtered."
+    ),
+    ...tunableShape,
+  });
+}
+
+export function buildToolDescription(skill: Skill): string {
+  const parts = ["Simmer", skill.tier];
+  if (skill.status) parts.push(skill.status);
+  const prefix = `[${parts.join(" · ")}]`;
+
+  const lines = [
+    `${prefix} ${skill.name} v${skill.version}`,
+    "",
+    skill.description,
+  ];
+
+  if (skill.hasDisclaimer) {
+    lines.push("");
+    lines.push("Read DISCLAIMER.md before connecting real funds (default is dry-run paper mode).");
+  }
+
+  return lines.join("\n");
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_TIMEOUT_MS = 300_000;
+
+export interface InvokeSkillResponse {
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
+  _meta?: Record<string, unknown>;
+}
+
+export interface InvokeSkillOptions {
+  processEnv?: Record<string, string | undefined>;
+}
+
+export async function invokeSkillTool(
+  skill: Skill,
+  args: Record<string, unknown>,
+  options: InvokeSkillOptions = {}
+): Promise<InvokeSkillResponse> {
+  if (!skill.entrypoint) {
+    return {
+      content: [{ type: "text", text: `Skill ${skill.slug} has no entrypoint (Tier A, instruction-only).` }],
+      isError: true,
+    };
+  }
+
+  const skillPath = path.join(skill.skillDir, skill.entrypoint);
+  const allowExtraArgs = (options.processEnv ?? process.env).SIMMER_MCP_ALLOW_EXTRA_ARGS === "true";
+  const rawExtraArgs = (args.extra_args as unknown[]) ?? [];
+  const argv = allowExtraArgs
+    ? [skillPath, ...filterBlockedFlags(rawExtraArgs)]
+    : [skillPath];
+
+  const env = buildEnv(skill, args, { processEnv: options.processEnv });
+
+  const timeoutS = typeof args.timeout_s === "number" ? args.timeout_s : DEFAULT_TIMEOUT_MS / 1000;
+  const timeoutMs = Math.min(Math.max(timeoutS * 1000, 1000), MAX_TIMEOUT_MS);
+
+  const result = await runSkillProcess({
+    file: "python3",
+    args: argv,
+    env,
+    timeoutMs,
+  });
+
+  if (result.timedOut) {
+    return {
+      content: [{ type: "text", text: `TIMEOUT after ${(result.durationMs / 1000).toFixed(1)}s\n\nStdout tail:\n${tailLines(result.stdout, 40)}\n\nStderr tail:\n${tailLines(result.stderr, 20)}` }],
+      isError: true,
+      _meta: { timeout_ms: timeoutMs, duration_ms: result.durationMs },
+    };
+  }
+
+  const parsed = parseSkillOutput(result.stdout);
+  const exitOk = result.exitCode === 0;
+
+  const summary = exitOk
+    ? `✅ ${skill.slug} completed in ${(result.durationMs / 1000).toFixed(1)}s`
+    : `⚠️ ${skill.slug} exited with code ${result.exitCode}`;
+
+  const sections = [summary];
+  if (parsed.result) sections.push("Result:\n" + JSON.stringify(parsed.result, null, 2));
+  sections.push("Log:\n" + tailLines(result.stdout, 40));
+  if (result.stderr.trim()) sections.push("Errors:\n" + tailLines(result.stderr, 20));
+
+  return {
+    content: [{ type: "text", text: sections.join("\n\n") }],
+    isError: !exitOk,
+    _meta: {
+      exit_code: result.exitCode,
+      duration_ms: result.durationMs,
+      ...(parsed.result ? { result: parsed.result } : {}),
+    },
+  };
+}
+
+function tailLines(s: string, n: number): string {
+  return s.split("\n").slice(-n).join("\n");
+}

--- a/mcp/src/runtime-probe.ts
+++ b/mcp/src/runtime-probe.ts
@@ -1,0 +1,47 @@
+import { spawn } from "node:child_process";
+
+export interface ProbeResult {
+  detected: boolean;
+  version?: string;
+  path?: string;
+  installHint?: string;
+}
+
+export interface RuntimeProbeResult {
+  python3: ProbeResult;
+  simmerSdk: ProbeResult;
+  git: ProbeResult;
+}
+
+function runQuick(file: string, args: string[]): Promise<{ exitCode: number; stdout: string }> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    const child = spawn(file, args, { stdio: ["ignore", "pipe", "pipe"] });
+    child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.on("close", (code) => resolve({ exitCode: code ?? -1, stdout: stdout.trim() }));
+    child.on("error", () => resolve({ exitCode: -1, stdout: "" }));
+    setTimeout(() => { try { child.kill(); } catch { /* */ } }, 5000);
+  });
+}
+
+export async function probeRuntime(): Promise<RuntimeProbeResult> {
+  const py = await runQuick("python3", ["--version"]);
+  const python3: ProbeResult = py.exitCode === 0
+    ? { detected: true, version: py.stdout.replace(/^Python /, "") }
+    : { detected: false, installHint: "Install: brew install python@3.11 (macOS) or apt install python3 (Debian/Ubuntu)" };
+
+  let simmerSdk: ProbeResult = { detected: false, installHint: "Install: pip install simmer-sdk>=0.13.0" };
+  if (python3.detected) {
+    const sdk = await runQuick("python3", ["-c", "import simmer_sdk; print(simmer_sdk.__version__)"]);
+    if (sdk.exitCode === 0) {
+      simmerSdk = { detected: true, version: sdk.stdout };
+    }
+  }
+
+  const g = await runQuick("git", ["--version"]);
+  const git: ProbeResult = g.exitCode === 0
+    ? { detected: true, version: g.stdout.replace(/^git version /, "") }
+    : { detected: false, installHint: "Install: brew install git or apt install git" };
+
+  return { python3, simmerSdk, git };
+}

--- a/mcp/src/skill-discovery.ts
+++ b/mcp/src/skill-discovery.ts
@@ -1,0 +1,115 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Skill, Tunable } from "./core/types.js";
+
+export function slugToToolName(slug: string): string {
+  return "simmer_" + slug.replace(/-/g, "_");
+}
+
+interface FrontmatterMeta {
+  version?: string;
+  displayName?: string;
+  status?: string;
+}
+
+interface SkillMdFrontmatter {
+  name?: string;
+  description?: string;
+  metadata?: FrontmatterMeta;
+}
+
+function parseSkillMd(skillMdPath: string): SkillMdFrontmatter {
+  if (!fs.existsSync(skillMdPath)) return {};
+  const content = fs.readFileSync(skillMdPath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const frontmatter: SkillMdFrontmatter = {};
+  const lines = match[1].split("\n");
+  let inMetadata = false;
+  for (const line of lines) {
+    if (line.match(/^metadata:\s*$/)) { inMetadata = true; continue; }
+    if (line.match(/^[a-z]/) && !line.startsWith(" ")) { inMetadata = false; }
+    const kv = line.match(/^\s*([a-zA-Z_]+):\s*["']?(.*?)["']?\s*$/);
+    if (!kv) continue;
+    const [, key, value] = kv;
+    if (inMetadata) {
+      frontmatter.metadata = frontmatter.metadata ?? {};
+      if (key === "version") frontmatter.metadata.version = value;
+      else if (key === "displayName") frontmatter.metadata.displayName = value;
+      else if (key === "status") frontmatter.metadata.status = value;
+    } else {
+      if (key === "name") frontmatter.name = value;
+      else if (key === "description") frontmatter.description = value;
+    }
+  }
+  return frontmatter;
+}
+
+function parseTunables(rawTunables: unknown): Tunable[] {
+  if (!Array.isArray(rawTunables)) return [];
+  const out: Tunable[] = [];
+  for (const t of rawTunables) {
+    if (typeof t !== "object" || t === null) continue;
+    const obj = t as Record<string, unknown>;
+    if (typeof obj.env !== "string" || typeof obj.label !== "string") continue;
+    if (obj.type === "number" && typeof obj.default === "number") {
+      out.push({
+        env: obj.env, type: "number", default: obj.default,
+        range: Array.isArray(obj.range) && obj.range.length === 2 ? [obj.range[0] as number, obj.range[1] as number] : undefined,
+        step: typeof obj.step === "number" ? obj.step : undefined,
+        label: obj.label,
+      });
+    } else if (obj.type === "string" && typeof obj.default === "string") {
+      out.push({
+        env: obj.env, type: "string", default: obj.default,
+        enum: Array.isArray(obj.enum) ? obj.enum.filter((x): x is string => typeof x === "string") : undefined,
+        label: obj.label,
+      });
+    } else if (obj.type === "boolean" && typeof obj.default === "boolean") {
+      out.push({ env: obj.env, type: "boolean", default: obj.default, label: obj.label });
+    }
+  }
+  return out;
+}
+
+export function discoverSkills(skillsRoot: string): Skill[] {
+  if (!fs.existsSync(skillsRoot)) return [];
+
+  const skills: Skill[] = [];
+  for (const entry of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const slug = entry.name;
+    const dir = path.join(skillsRoot, slug);
+    const manifestPath = path.join(dir, "clawhub.json");
+    if (!fs.existsSync(manifestPath)) continue;
+
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    } catch (err) {
+      console.error(`[skill-discovery] WARN: malformed clawhub.json in ${slug}: ${err}`);
+      continue;
+    }
+
+    const automaton = (manifest.automaton ?? {}) as { managed?: boolean; entrypoint?: string };
+    const tier = automaton.managed === true ? "trading" : "instruction";
+    const entrypoint = automaton.entrypoint;
+    const frontmatter = parseSkillMd(path.join(dir, "SKILL.md"));
+
+    skills.push({
+      slug,
+      toolName: slugToToolName(slug),
+      name: frontmatter.metadata?.displayName ?? frontmatter.name ?? slug,
+      description: frontmatter.description ?? "",
+      version: frontmatter.metadata?.version ?? "0.0.0",
+      tier,
+      status: frontmatter.metadata?.status ?? manifest.status as string | undefined,
+      published: manifest.published === true,
+      entrypoint,
+      tunables: parseTunables(manifest.tunables),
+      skillDir: dir,
+      hasDisclaimer: fs.existsSync(path.join(dir, "DISCLAIMER.md")),
+    });
+  }
+  return skills;
+}

--- a/mcp/src/skill-discovery.ts
+++ b/mcp/src/skill-discovery.ts
@@ -2,6 +2,22 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Skill, Tunable } from "./core/types.js";
 
+// Local copy — avoids a cross-source import that breaks node --test's .ts loader.
+function envToArgName(envName: string): string {
+  const parts = envName.split("_");
+  if (parts.length <= 2) return envName.toLowerCase();
+  return parts.slice(2).join("_").toLowerCase();
+}
+
+// Gate-controlled env names that skill tunables must never overwrite.
+export const RESERVED_ENV_NAMES = new Set([
+  "TRADING_VENUE", "SIMMER_MANAGED_MODE", "AUTOMATON_MANAGED",
+  "PYTHONUNBUFFERED", "SIMMER_MCP_ALLOW_LIVE", "SIMMER_MCP_ALLOW_EXTRA_ARGS",
+]);
+
+// Schema arg names reserved for gate-relevant parameters in buildToolSchema.
+export const RESERVED_ARG_NAMES = new Set(["dry_run", "trading_venue", "extra_args", "timeout_s"]);
+
 export function slugToToolName(slug: string): string {
   return "simmer_" + slug.replace(/-/g, "_");
 }
@@ -45,13 +61,22 @@ function parseSkillMd(skillMdPath: string): SkillMdFrontmatter {
   return frontmatter;
 }
 
-function parseTunables(rawTunables: unknown): Tunable[] {
+function parseTunables(slug: string, rawTunables: unknown): Tunable[] {
   if (!Array.isArray(rawTunables)) return [];
   const out: Tunable[] = [];
   for (const t of rawTunables) {
     if (typeof t !== "object" || t === null) continue;
     const obj = t as Record<string, unknown>;
     if (typeof obj.env !== "string" || typeof obj.label !== "string") continue;
+    if (RESERVED_ENV_NAMES.has(obj.env)) {
+      console.error(`[skill-discovery] WARN: skill "${slug}" tunable env="${obj.env}" is reserved, skipping`);
+      continue;
+    }
+    const argName = envToArgName(obj.env);
+    if (RESERVED_ARG_NAMES.has(argName)) {
+      console.error(`[skill-discovery] WARN: skill "${slug}" tunable env="${obj.env}" maps to reserved arg "${argName}", skipping`);
+      continue;
+    }
     if (obj.type === "number" && typeof obj.default === "number") {
       out.push({
         env: obj.env, type: "number", default: obj.default,
@@ -106,7 +131,7 @@ export function discoverSkills(skillsRoot: string): Skill[] {
       status: frontmatter.metadata?.status ?? manifest.status as string | undefined,
       published: manifest.published === true,
       entrypoint,
-      tunables: parseTunables(manifest.tunables),
+      tunables: parseTunables(slug, manifest.tunables),
       skillDir: dir,
       hasDisclaimer: fs.existsSync(path.join(dir, "DISCLAIMER.md")),
     });

--- a/mcp/src/skill-runner.ts
+++ b/mcp/src/skill-runner.ts
@@ -1,0 +1,82 @@
+/**
+ * runSkillProcess — Node subprocess wrapper for Python skill scripts.
+ * Uses argv-shaped invocation (no shell), custom env, and configurable output cap.
+ * Separate from autoresearch's runCommand (which uses bash -c <string>).
+ */
+
+import { spawn } from "node:child_process";
+
+export interface SkillRunOptions {
+  file: string;
+  args: string[];
+  env: Record<string, string>;
+  timeoutMs: number;
+  maxOutputBytes?: number;
+}
+
+export interface SkillRunResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+}
+
+const DEFAULT_MAX_BYTES = 1 * 1024 * 1024;
+
+export function runSkillProcess(opts: SkillRunOptions): Promise<SkillRunResult> {
+  const maxBytes = opts.maxOutputBytes ?? DEFAULT_MAX_BYTES;
+  const t0 = Date.now();
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+
+    const child = spawn(opts.file, opts.args, {
+      env: opts.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try { child.kill("SIGTERM"); } catch { /* */ }
+      setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* */ } }, 5000);
+    }, opts.timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes <= maxBytes) stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes <= maxBytes) stderr += chunk.toString();
+    });
+
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: code,
+        signal,
+        stdout,
+        stderr,
+        durationMs: Date.now() - t0,
+        timedOut,
+      });
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: null,
+        signal: null,
+        stdout,
+        stderr: stderr + "\n" + err.message,
+        durationMs: Date.now() - t0,
+        timedOut,
+      });
+    });
+  });
+}

--- a/mcp/src/skill-runner.ts
+++ b/mcp/src/skill-runner.ts
@@ -34,6 +34,8 @@ export function runSkillProcess(opts: SkillRunOptions): Promise<SkillRunResult> 
     let timedOut = false;
     let stdoutBytes = 0;
     let stderrBytes = 0;
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
 
     const child = spawn(opts.file, opts.args, {
       env: opts.env,
@@ -48,11 +50,21 @@ export function runSkillProcess(opts: SkillRunOptions): Promise<SkillRunResult> 
 
     child.stdout.on("data", (chunk: Buffer) => {
       stdoutBytes += chunk.length;
-      if (stdoutBytes <= maxBytes) stdout += chunk.toString();
+      if (stdoutBytes <= maxBytes) {
+        stdout += chunk.toString();
+      } else if (!stdoutTruncated) {
+        stdoutTruncated = true;
+        stdout += "\n[truncated at 1MB]";
+      }
     });
     child.stderr.on("data", (chunk: Buffer) => {
       stderrBytes += chunk.length;
-      if (stderrBytes <= maxBytes) stderr += chunk.toString();
+      if (stderrBytes <= maxBytes) {
+        stderr += chunk.toString();
+      } else if (!stderrTruncated) {
+        stderrTruncated = true;
+        stderr += "\n[truncated at 1MB]";
+      }
     });
 
     child.on("close", (code, signal) => {

--- a/mcp/tests/blocked-flags.test.ts
+++ b/mcp/tests/blocked-flags.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { filterBlockedFlags, isBlockedFlag } from "../src/blocked-flags.ts";
+
+test("blocks --live and short forms case-insensitive", () => {
+  assert.equal(isBlockedFlag("--live"), true);
+  assert.equal(isBlockedFlag("--LIVE"), true);
+  assert.equal(isBlockedFlag("--no-dry-run"), true);
+  assert.equal(isBlockedFlag("--no-dry"), true);
+  assert.equal(isBlockedFlag("--real"), true);
+  assert.equal(isBlockedFlag("--production"), true);
+});
+
+test("blocks --live=true and --live=1 (=-form)", () => {
+  assert.equal(isBlockedFlag("--live=true"), true);
+  assert.equal(isBlockedFlag("--live=1"), true);
+  assert.equal(isBlockedFlag("--no-dry-run=true"), true);
+  assert.equal(isBlockedFlag("--LIVE=YES"), true);
+});
+
+test("blocks --mode=live and --venue=*live*", () => {
+  assert.equal(isBlockedFlag("--mode=live"), true);
+  assert.equal(isBlockedFlag("--venue=polymarket-live"), true);
+  assert.equal(isBlockedFlag("--venue=production"), true);
+});
+
+test("allows benign flags", () => {
+  assert.equal(isBlockedFlag("--positions-only"), false);
+  assert.equal(isBlockedFlag("--markets=abc,def"), false);
+  assert.equal(isBlockedFlag("--cancel-all"), false);
+  assert.equal(isBlockedFlag("--status"), false);
+  assert.equal(isBlockedFlag(""), false);
+});
+
+test("filterBlockedFlags removes blocked and follows-value forms", () => {
+  assert.deepEqual(filterBlockedFlags(["--live"]), []);
+  assert.deepEqual(filterBlockedFlags(["--live", "true"]), []);
+  assert.deepEqual(filterBlockedFlags(["--mode", "live"]), []);
+  assert.deepEqual(filterBlockedFlags(["--positions-only", "--live", "--cancel-all"]), ["--positions-only", "--cancel-all"]);
+  assert.deepEqual(filterBlockedFlags(["--ok", 42 as unknown as string, null as unknown as string]), ["--ok"]);
+});
+
+test("filterBlockedFlags handles --mode value-pair", () => {
+  assert.deepEqual(filterBlockedFlags(["--mode", "live"]), []);
+  assert.deepEqual(filterBlockedFlags(["--mode", "paper"]), ["--mode", "paper"]);
+});

--- a/mcp/tests/discovery.test.ts
+++ b/mcp/tests/discovery.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { discoverSkills, slugToToolName } from "../src/skill-discovery.ts";
+
+function makeFixtureSkills(tmpDir: string): void {
+  fs.mkdirSync(path.join(tmpDir, "test-trading-skill"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, "test-trading-skill", "clawhub.json"),
+    JSON.stringify({
+      emoji: "⚡",
+      automaton: { managed: true, entrypoint: "trader.py" },
+      tunables: [
+        { env: "TEST_BUDGET", type: "number", default: 10, range: [1, 50], step: 1, label: "Budget" }
+      ]
+    })
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, "test-trading-skill", "SKILL.md"),
+    "---\nname: test-trading-skill\ndescription: trading test\nmetadata:\n  version: '0.1.0'\n  displayName: 'Test Trader'\n---\n# Test"
+  );
+  fs.writeFileSync(path.join(tmpDir, "test-trading-skill", "trader.py"), "");
+
+  fs.mkdirSync(path.join(tmpDir, "test-instruction-skill"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, "test-instruction-skill", "clawhub.json"),
+    JSON.stringify({ emoji: "📖", automaton: { managed: false } })
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, "test-instruction-skill", "SKILL.md"),
+    "---\nname: test-instruction-skill\ndescription: docs only\nmetadata:\n  version: '1.0.0'\n  displayName: 'Test Instruction'\n---\n# Test"
+  );
+
+  fs.mkdirSync(path.join(tmpDir, "test-unmanaged"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, "test-unmanaged", "clawhub.json"),
+    JSON.stringify({ emoji: "🤷" })
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, "test-unmanaged", "SKILL.md"),
+    "---\nname: test-unmanaged\ndescription: no automaton\nmetadata:\n  version: '0.0.1'\n  displayName: 'Test Unmanaged'\n---"
+  );
+
+  fs.mkdirSync(path.join(tmpDir, "test-malformed"), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, "test-malformed", "clawhub.json"), "{ this is not valid json");
+}
+
+test("slugToToolName converts kebab to snake with simmer_ prefix", () => {
+  assert.equal(slugToToolName("polymarket-fast-scaler"), "simmer_polymarket_fast_scaler");
+  assert.equal(slugToToolName("simmer-briefing"), "simmer_simmer_briefing");
+  assert.equal(slugToToolName("a-b-c-d"), "simmer_a_b_c_d");
+});
+
+test("discoverSkills classifies trading vs instruction tier", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-discovery-test-"));
+  makeFixtureSkills(tmpDir);
+  const skills = discoverSkills(tmpDir);
+
+  const trading = skills.find((s) => s.slug === "test-trading-skill");
+  assert.ok(trading);
+  assert.equal(trading.tier, "trading");
+  assert.equal(trading.toolName, "simmer_test_trading_skill");
+  assert.equal(trading.entrypoint, "trader.py");
+  assert.equal(trading.tunables.length, 1);
+  assert.equal(trading.tunables[0].env, "TEST_BUDGET");
+
+  const instruction = skills.find((s) => s.slug === "test-instruction-skill");
+  assert.ok(instruction);
+  assert.equal(instruction.tier, "instruction");
+  assert.equal(instruction.entrypoint, undefined);
+
+  const unmanaged = skills.find((s) => s.slug === "test-unmanaged");
+  assert.ok(unmanaged);
+  assert.equal(unmanaged.tier, "instruction");
+
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+test("discoverSkills skips malformed manifests without crashing", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "skill-discovery-test-"));
+  makeFixtureSkills(tmpDir);
+  const skills = discoverSkills(tmpDir);
+  const malformed = skills.find((s) => s.slug === "test-malformed");
+  assert.equal(malformed, undefined);
+  assert.ok(skills.find((s) => s.slug === "test-trading-skill"));
+  fs.rmSync(tmpDir, { recursive: true });
+});
+
+test("discoverSkills returns empty array if dir doesn't exist", () => {
+  const skills = discoverSkills("/nonexistent/path/abc123");
+  assert.deepEqual(skills, []);
+});

--- a/mcp/tests/docs-tools.test.ts
+++ b/mcp/tests/docs-tools.test.ts
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { listSkills, getSkillDocs, listDocResources, readDocResource } from "../src/docs-tools.ts";
+import { discoverSkills } from "../src/skill-discovery.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BUNDLED_SKILLS_DIR = path.join(__dirname, "../bundled-skills");
+const skills = discoverSkills(BUNDLED_SKILLS_DIR);
+
+test("listSkills returns an entry for every discovered skill", () => {
+  const list = listSkills(skills);
+  assert.equal(list.length, skills.length);
+  for (const entry of list) {
+    assert.ok(entry.slug, "slug missing");
+    assert.ok(["trading", "instruction"].includes(entry.tier), `unexpected tier: ${entry.tier}`);
+  }
+});
+
+test("getSkillDocs returns SKILL.md body for a known skill", () => {
+  const tradingSkill = skills.find((s) => s.tier === "trading");
+  if (!tradingSkill) {
+    // No trading skills found — bundled-skills may be empty in some environments
+    return;
+  }
+  const r = getSkillDocs(skills, tradingSkill.slug);
+  assert.equal(r.isError, false, `isError=true: ${r.content[0]?.text}`);
+  assert.ok(r.content[0]?.text.length > 0, "empty SKILL.md body");
+});
+
+test("getSkillDocs returns error for unknown slug", () => {
+  const r = getSkillDocs(skills, "no-such-skill-xyz");
+  assert.equal(r.isError, true);
+  assert.ok(r.content[0]?.text.includes("no-such-skill-xyz"));
+});
+
+test("listDocResources returns 2 resource URIs", () => {
+  const resources = listDocResources();
+  assert.ok(resources.length >= 2, `expected >= 2 resources, got ${resources.length}`);
+  for (const r of resources) {
+    assert.ok(r.uri.startsWith("simmer://"), `unexpected URI: ${r.uri}`);
+    assert.equal(r.mimeType, "text/markdown");
+  }
+});
+
+test("readDocResource returns isError=true when snapshots missing", async () => {
+  const r = await readDocResource("simmer://docs/api-reference", { snapshotsDir: "/nonexistent/dir/abc123" });
+  assert.equal(r.isError, true);
+});
+
+test("readDocResource returns isError=true for unknown URI", async () => {
+  const r = await readDocResource("simmer://docs/unknown-resource");
+  assert.equal(r.isError, true);
+});

--- a/mcp/tests/env-translation.test.ts
+++ b/mcp/tests/env-translation.test.ts
@@ -60,3 +60,23 @@ test("buildEnv inherits process.env but does NOT inherit TRADING_VENUE from it",
   assert.equal(env.TRADING_VENUE, "sim");
   assert.equal(env.SOME_OTHER, "val");
 });
+
+test("buildEnv: tunable named TRADING_VENUE cannot bypass the gate", () => {
+  // Defense-in-depth: even if skill-discovery fails to strip a reserved-name tunable,
+  // env-translation's GATE_ENV guard must still hold the gate closed.
+  const MALICIOUS: Skill = {
+    ...FIXTURE,
+    tunables: [{ env: "TRADING_VENUE", type: "string", default: "polymarket", label: "bypass attempt" }],
+  };
+  const env = buildEnv(MALICIOUS, { trading_venue: "polymarket" }, { processEnv: {} });
+  assert.equal(env.TRADING_VENUE, "sim");
+});
+
+test("buildEnv: tunable named SIMMER_MANAGED_MODE cannot overwrite managed-mode flag", () => {
+  const MALICIOUS: Skill = {
+    ...FIXTURE,
+    tunables: [{ env: "SIMMER_MANAGED_MODE", type: "string", default: "0", label: "bypass attempt" }],
+  };
+  const env = buildEnv(MALICIOUS, { managed_mode: "0" }, { processEnv: {} });
+  assert.equal(env.SIMMER_MANAGED_MODE, "1");
+});

--- a/mcp/tests/env-translation.test.ts
+++ b/mcp/tests/env-translation.test.ts
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildEnv, envToArgName } from "../src/env-translation.ts";
+import type { Skill } from "../src/core/types.js";
+
+const FIXTURE: Skill = {
+  slug: "test", toolName: "simmer_test", name: "Test", description: "", version: "0.1.0",
+  tier: "trading", entrypoint: "test.py", skillDir: "/tmp/test", hasDisclaimer: false,
+  tunables: [
+    { env: "TEST_FASTSCALER_DAILY_BUDGET", type: "number", default: 30, label: "Budget" },
+    { env: "TEST_FASTSCALER_GATE", type: "number", default: 0.1, label: "Gate" },
+  ],
+};
+
+test("envToArgName lowercases + strips 2-segment skill prefix", () => {
+  // Real pattern: SIMMER_SLUG_ARG_NAME — strip first 2 segments
+  assert.equal(envToArgName("TEST_FASTSCALER_DAILY_BUDGET"), "daily_budget");
+  assert.equal(envToArgName("SIMMER_BTCUD_EXIT_BEFORE_RESOLUTION_HOURS"), "exit_before_resolution_hours");
+  assert.equal(envToArgName("SIMMER_BTCUD_DAILY_BUDGET_USD"), "daily_budget_usd");
+  // Short env vars (≤2 segs): returned as-is lowercased
+  assert.equal(envToArgName("SIMMER_KEY"), "simmer_key");
+  assert.equal(envToArgName("GATE"), "gate");
+});
+
+test("buildEnv defaults to sim when no live consent", () => {
+  const env = buildEnv(FIXTURE, {}, { processEnv: {} });
+  assert.equal(env.TRADING_VENUE, "sim");
+  assert.equal(env.SIMMER_MANAGED_MODE, "1");
+  assert.equal(env.AUTOMATON_MANAGED, "1");
+});
+
+test("buildEnv coerces to sim when dry_run=false but SIMMER_MCP_ALLOW_LIVE unset", () => {
+  const env = buildEnv(FIXTURE, { dry_run: false, trading_venue: "polymarket" }, { processEnv: {} });
+  assert.equal(env.TRADING_VENUE, "sim");
+});
+
+test("buildEnv coerces to sim when SIMMER_MCP_ALLOW_LIVE set but dry_run omitted", () => {
+  const env = buildEnv(FIXTURE, { trading_venue: "polymarket" }, { processEnv: { SIMMER_MCP_ALLOW_LIVE: "true" } });
+  assert.equal(env.TRADING_VENUE, "sim");
+});
+
+test("buildEnv coerces to sim when trading_venue=sim even with all gates", () => {
+  const env = buildEnv(FIXTURE, { dry_run: false, trading_venue: "sim" }, { processEnv: { SIMMER_MCP_ALLOW_LIVE: "true" } });
+  assert.equal(env.TRADING_VENUE, "sim");
+});
+
+test("buildEnv flips to live only when all three gates met", () => {
+  const env = buildEnv(FIXTURE, { dry_run: false, trading_venue: "polymarket" }, { processEnv: { SIMMER_MCP_ALLOW_LIVE: "true" } });
+  assert.equal(env.TRADING_VENUE, "polymarket");
+});
+
+test("buildEnv translates tunable args to env vars", () => {
+  const env = buildEnv(FIXTURE, { daily_budget: 50, gate: 0.2 }, { processEnv: {} });
+  assert.equal(env.TEST_FASTSCALER_DAILY_BUDGET, "50");
+  assert.equal(env.TEST_FASTSCALER_GATE, "0.2");
+});
+
+test("buildEnv inherits process.env but does NOT inherit TRADING_VENUE from it", () => {
+  const env = buildEnv(FIXTURE, {}, { processEnv: { TRADING_VENUE: "polymarket", SOME_OTHER: "val" } });
+  assert.equal(env.TRADING_VENUE, "sim");
+  assert.equal(env.SOME_OTHER, "val");
+});

--- a/mcp/tests/errors.test.ts
+++ b/mcp/tests/errors.test.ts
@@ -4,19 +4,40 @@ import { BackendError } from "../dist/errors.js";
 
 describe("BackendError", () => {
   it("is instanceof Error", () => {
-    const err = new BackendError("not found", 404, "NOT_FOUND");
+    const err = new BackendError(404, "not found");
     assert.ok(err instanceof Error);
   });
 
-  it("exposes statusCode and code", () => {
-    const err = new BackendError("unauthorized", 401, "UNAUTHORIZED");
+  it("exposes statusCode and body", () => {
+    const err = new BackendError(401, "unauthorized");
     assert.equal(err.statusCode, 401);
-    assert.equal(err.code, "UNAUTHORIZED");
+    assert.equal(err.body, "unauthorized");
     assert.equal(err.message, "unauthorized");
   });
 
   it("has correct name for stack trace", () => {
-    const err = new BackendError("server error", 500, "SERVER_ERROR");
+    const err = new BackendError(500, "server error");
     assert.equal(err.name, "BackendError");
+  });
+
+  it("carries upgradeUrl when provided", () => {
+    const err = new BackendError(403, "Pro required", "https://simmer.markets/pro");
+    assert.equal(err.upgradeUrl, "https://simmer.markets/pro");
+  });
+
+  it("toMcpResponse includes body text and upgrade URL", () => {
+    const err = new BackendError(403, "Pro required", "https://simmer.markets/pro");
+    const r = err.toMcpResponse();
+    assert.equal(r.isError, true);
+    assert.match(r.content[0].text, /Pro required/);
+    assert.match(r.content[0].text, /simmer\.markets\/pro/);
+  });
+
+  it("toMcpResponse without upgradeUrl omits upgrade text", () => {
+    const err = new BackendError(500, "Internal error");
+    const r = err.toMcpResponse();
+    assert.equal(r.isError, true);
+    assert.match(r.content[0].text, /Internal error/);
+    assert.doesNotMatch(r.content[0].text, /pro/i);
   });
 });

--- a/mcp/tests/fixtures/echo_skill.py
+++ b/mcp/tests/fixtures/echo_skill.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Test fixture — echoes env + argv as simmer_managed_output JSON."""
+import json
+import os
+import sys
+
+mode = os.environ.get("ECHO_MODE", "ok")
+
+if mode == "crash":
+    raise RuntimeError("fixture crash")
+elif mode == "exit1":
+    print("an error happened", file=sys.stderr)
+    sys.exit(1)
+elif mode == "sleep":
+    import time
+    time.sleep(30)
+else:
+    payload = {
+        "argv": sys.argv[1:],
+        "trading_venue": os.environ.get("TRADING_VENUE"),
+        "managed_mode": os.environ.get("SIMMER_MANAGED_MODE"),
+        "echo_extra": os.environ.get("ECHO_EXTRA"),
+    }
+    print("starting echo skill")
+    print(json.dumps({"simmer_managed_output": payload}))

--- a/mcp/tests/output-parsing.test.ts
+++ b/mcp/tests/output-parsing.test.ts
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseSkillOutput } from "../src/output-parsing.ts";
+
+test("parses simmer_managed_output on last line", () => {
+  const stdout = `running...\n{"simmer_managed_output":{"trades":3,"pnl":1.5}}\n`;
+  const r = parseSkillOutput(stdout);
+  assert.deepEqual(r.result, { trades: 3, pnl: 1.5 });
+});
+
+test("parses automaton key (back-compat) when simmer_managed_output absent", () => {
+  const stdout = `running...\n{"automaton":{"trades":3}}\n`;
+  const r = parseSkillOutput(stdout);
+  assert.deepEqual(r.result, { trades: 3 });
+});
+
+test("prefers simmer_managed_output over automaton when both present", () => {
+  const stdout = `{"simmer_managed_output":{"new":true}}\n{"automaton":{"old":true}}\n`;
+  const r = parseSkillOutput(stdout);
+  assert.equal(r.result!.new ?? r.result!.old, true);
+});
+
+test("returns null result when no parseable JSON", () => {
+  const stdout = "just some logs\nno json here\n";
+  const r = parseSkillOutput(stdout);
+  assert.equal(r.result, null);
+  assert.match(r.log, /just some logs/);
+});
+
+test("returns null result when JSON exists but no recognized key", () => {
+  const stdout = '{"foo":"bar"}\n';
+  const r = parseSkillOutput(stdout);
+  assert.equal(r.result, null);
+});
+
+test("ignores non-JSON noise on intermediate lines", () => {
+  const stdout = `step 1\nstep 2\n{"simmer_managed_output":{"k":1}}\n`;
+  const r = parseSkillOutput(stdout);
+  assert.deepEqual(r.result, { k: 1 });
+  assert.match(r.log, /step 1/);
+});
+
+test("handles trailing whitespace + empty lines", () => {
+  const stdout = `{"simmer_managed_output":{"k":1}}\n\n  \n`;
+  const r = parseSkillOutput(stdout);
+  assert.deepEqual(r.result, { k: 1 });
+});

--- a/mcp/tests/per-skill-smoke.test.ts
+++ b/mcp/tests/per-skill-smoke.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Per-skill smoke tests (Tasks 19-20).
+ * Validates structure + Python syntax for all Tier B (trading) skills.
+ * Does NOT execute trading logic — no network, no API keys required.
+ * Skips cleanly if python3 is not found on PATH.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { discoverSkills } from "../src/skill-discovery.ts";
+import { runSkillProcess } from "../src/skill-runner.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BUNDLED_SKILLS_DIR = path.join(__dirname, "../bundled-skills");
+
+function detectPython3(): string | null {
+  const r = spawnSync("python3", ["--version"], { timeout: 3000 });
+  return r.status === 0 ? "found" : null;
+}
+
+const PYTHON3_AVAILABLE = detectPython3();
+const SKIP_REASON = PYTHON3_AVAILABLE === null ? "python3 not found on PATH — skipping Python syntax checks" : false;
+
+test("bundled-skills directory exists", () => {
+  assert.ok(fs.existsSync(BUNDLED_SKILLS_DIR), `bundled-skills not found at ${BUNDLED_SKILLS_DIR}`);
+});
+
+test("discovers at least 10 Tier B trading skills", () => {
+  const skills = discoverSkills(BUNDLED_SKILLS_DIR);
+  const trading = skills.filter((s) => s.tier === "trading");
+  assert.ok(trading.length >= 10, `expected >= 10 trading skills, found ${trading.length}: ${trading.map((s) => s.slug).join(", ")}`);
+});
+
+test("all Tier B skills have entrypoint file on disk", () => {
+  const skills = discoverSkills(BUNDLED_SKILLS_DIR);
+  const trading = skills.filter((s) => s.tier === "trading");
+  for (const skill of trading) {
+    assert.ok(skill.entrypoint, `${skill.slug}: no entrypoint in clawhub.json`);
+    const ep = path.join(skill.skillDir, skill.entrypoint!);
+    assert.ok(fs.existsSync(ep), `${skill.slug}: entrypoint not found at ${ep}`);
+  }
+});
+
+test("all Tier B skills have SKILL.md", () => {
+  const skills = discoverSkills(BUNDLED_SKILLS_DIR);
+  for (const skill of skills.filter((s) => s.tier === "trading")) {
+    const md = path.join(skill.skillDir, "SKILL.md");
+    assert.ok(fs.existsSync(md), `${skill.slug}: SKILL.md missing`);
+  }
+});
+
+// Python syntax check per skill — skips if python3 not available
+const tradingSkills = discoverSkills(BUNDLED_SKILLS_DIR).filter((s) => s.tier === "trading");
+
+for (const skill of tradingSkills) {
+  test(`py_compile: ${skill.slug}`, { skip: SKIP_REASON }, async () => {
+    const ep = path.join(skill.skillDir, skill.entrypoint!);
+    const safeEnv = Object.fromEntries(
+      Object.entries(process.env).filter((pair): pair is [string, string] => pair[1] !== undefined)
+    );
+    const result = await runSkillProcess({
+      file: "python3",
+      args: ["-m", "py_compile", ep],
+      env: safeEnv,
+      timeoutMs: 10_000,
+    });
+    assert.equal(
+      result.exitCode, 0,
+      `${skill.slug}: py_compile failed (exit ${result.exitCode})\n${result.stderr}`
+    );
+  });
+}

--- a/mcp/tests/runtime-probe.test.ts
+++ b/mcp/tests/runtime-probe.test.ts
@@ -1,0 +1,17 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { probeRuntime } from "../src/runtime-probe.ts";
+
+test("probeRuntime detects python3 on this machine", async () => {
+  const r = await probeRuntime();
+  // python3 is required for the SDK — if missing the test environment is broken
+  assert.ok(r.python3.detected, `python3 not found: ${r.python3.installHint}`);
+  assert.ok(r.python3.version, "python3.version should be set");
+});
+
+test("probeRuntime returns ProbeResult shape for all three tools", async () => {
+  const r = await probeRuntime();
+  for (const key of ["python3", "simmerSdk", "git"] as const) {
+    assert.equal(typeof r[key].detected, "boolean", `${key}.detected should be boolean`);
+  }
+});

--- a/mcp/tests/skill-runner.test.ts
+++ b/mcp/tests/skill-runner.test.ts
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runSkillProcess } from "../src/skill-runner.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ECHO_SKILL = path.join(__dirname, "fixtures/echo_skill.py");
+
+const BASE_ENV: Record<string, string> = {
+  PATH: process.env.PATH ?? "",
+  HOME: process.env.HOME ?? "",
+};
+
+test("runSkillProcess: echo skill exits 0 and includes stdout", async () => {
+  const r = await runSkillProcess({ file: "python3", args: [ECHO_SKILL], env: BASE_ENV, timeoutMs: 5000 });
+  assert.equal(r.exitCode, 0);
+  assert.ok(r.stdout.includes("simmer_managed_output"), `stdout: ${r.stdout}`);
+  assert.equal(r.timedOut, false);
+});
+
+test("runSkillProcess: exit1 mode produces non-zero exit", async () => {
+  const r = await runSkillProcess({
+    file: "python3", args: [ECHO_SKILL],
+    env: { ...BASE_ENV, ECHO_MODE: "exit1" },
+    timeoutMs: 5000,
+  });
+  assert.equal(r.exitCode, 1);
+  assert.ok(r.stderr.includes("an error happened"));
+});
+
+test("runSkillProcess: sleep mode triggers timeout", async () => {
+  const r = await runSkillProcess({
+    file: "python3", args: [ECHO_SKILL],
+    env: { ...BASE_ENV, ECHO_MODE: "sleep" },
+    timeoutMs: 300,
+  });
+  assert.equal(r.timedOut, true);
+});
+
+test("runSkillProcess: missing binary returns error", async () => {
+  const r = await runSkillProcess({
+    file: "no_such_binary_xyz",
+    args: [],
+    env: BASE_ENV,
+    timeoutMs: 2000,
+  });
+  assert.equal(r.exitCode, null);
+  assert.ok(r.stderr.length > 0);
+});


### PR DESCRIPTION
Phase 2 of the Simmer MCP unification (SIM-2045). Builds all helper modules and per-skill execution tools. **No new tools registered in mcp-server.ts** — that's Phase 3.

## Changes

### Source modules (Tasks 7-18)
- `mcp/src/core/types.ts`: `Skill`, `Tunable*`, `SkillTier` types; `BackendError` reworked with `toMcpResponse()`
- `mcp/src/skill-discovery.ts`: reads `bundled-skills/*/clawhub.json`, classifies trading vs instruction tier
- `mcp/src/blocked-flags.ts`: strengthened regex — catches `--live=true`, `--live true`, `--mode=live`, `--venue=*live*` etc. (Codex CRITICAL #5)
- `mcp/src/env-translation.ts`: FAIL-CLOSED dry_run triple-gate + `envToArgName` (strips 2-segment skill prefix, Codex CRITICAL #2+#3)
- `mcp/src/output-parsing.ts`: handles `simmer_managed_output` (primary) + `automaton` key (back-compat)
- `mcp/src/skill-runner.ts`: Node subprocess wrapper — SIGTERM→SIGKILL kill-chain, 1MB output cap
- `mcp/src/per-skill-tools.ts`: zod schema generation from tunables + `invokeSkillTool` handler
- `mcp/src/runtime-probe.ts`: detect python3/simmer-sdk/git for prerequisite checks
- `mcp/src/docs-tools.ts`: `listSkills`, `getSkillDocs`, `listDocResources`, `readDocResource`

### Tests (Tasks 15, 19-20)
- `tests/blocked-flags.test.ts`: 6 integration tests (all blocked/allowed patterns)
- `tests/discovery.test.ts`: 4 tests for skill classification + malformed manifests
- `tests/env-translation.test.ts`: 8 tests covering triple-gate, tunable translation, env inheritance
- `tests/output-parsing.test.ts`: 7 tests for both output keys + noise handling
- `tests/skill-runner.test.ts`: 4 tests (ok/exit1/timeout/missing-binary)
- `tests/runtime-probe.test.ts`: 2 tests
- `tests/docs-tools.test.ts`: 6 tests
- `tests/per-skill-smoke.test.ts`: structure checks + py_compile for all 12 Tier B skills
- `tests/fixtures/echo_skill.py`: subprocess test fixture

## Tests
- `npm run build` — clean (0 errors)
- `npm test` — **79/79 pass** (up from 23 in Phase 1)
- All 12 Tier B skills pass py_compile syntax check

## Docs impact
None — no user-facing API changes, no SDK exports changed.

## Risk tier B notes
- `blocked-flags.ts` is the CRITICAL safety gate — tested exhaustively; regex rejects `=value`, space-value, and case variants
- `env-translation.ts` triple-gate is fail-closed: sim venue unless ALL three conditions met (dry_run=false, non-sim venue, SIMMER_MCP_ALLOW_LIVE=true)
- `mcp-server.ts` is unchanged — no new tools registered (scope boundary)

Closes SIM-2055