### PR TITLE
feat(mcp): Phase 3 MCP unification — SimmerApi refactor, troubleshoot port, Pro gate, full wiring (SIM-2056)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,31 @@ jobs:
           else
             echo "No tests directory — skipping"
           fi
+
+  mcp-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Python (for per-skill execution + py_compile tests)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python SDK (for runtime-probe test)
+        run: pip install -e .
+
+      - name: Install MCP dependencies
+        working-directory: mcp
+        run: npm ci
+
+      - name: Build + test MCP package
+        working-directory: mcp
+        run: npm test

--- a/mcp/CONTRIBUTING.md
+++ b/mcp/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to simmer-autoresearch (MCP)
+
+## Development setup
+
+```bash
+cd mcp
+npm install
+npm run bundle-skills   # bundles skills + snapshots into dist artefacts
+npm run build           # TypeScript → dist/
+npm test                # build + all tests (104 tests)
+```
+
+## Manual smoke checklist (Phase 4 publish gate)
+
+Run these before tagging a release:
+
+```bash
+# 1. Build + tests clean
+npm test
+
+# 2. Free-tier: exactly 3 tools (no API key)
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}' | \
+printf '%s\n{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n' | \
+SIMMER_API_KEY="" node dist/mcp-server.js 2>/dev/null | grep '"id":2'
+# Expected: tools array with 3 entries (list_skills, get_skill_docs, troubleshoot_error)
+
+# 3. Pro-tier: 19+ tools (with API key)
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n' | \
+SIMMER_API_KEY="sk_test_any" node dist/mcp-server.js 2>/dev/null | grep '"id":2'
+# Expected: tools array with 26 entries (3 + 4 autoresearch + 19 per-skill)
+
+# 4. Resources present
+printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}\n' | \
+SIMMER_API_KEY="" node dist/mcp-server.js 2>/dev/null | grep '"id":2'
+# Expected: resources array with 2+ simmer:// URIs
+
+# 5. Pack check — verify no sensitive files included
+npm pack --dry-run
+# Verify dist/, skills/, bundled-skills/, LICENSE are included
+# Verify tests/, src/, node_modules/, *.env NOT included
+
+# 6. Startup log looks correct
+SIMMER_API_KEY="" node dist/mcp-server.js </dev/null 2>&1 | head -5
+# Expected: [simmer-mcp] v<version> | tools: 3 (free only) | skills: 19 bundled
+```
+
+## Test structure
+
+| File | What it tests |
+|---|---|
+| `tests/api.test.ts` | `SimmerApi.checkPro()` + `backtest()` BackendError relay |
+| `tests/pro-gate.test.ts` | 403 Pro-gate MCP response shape |
+| `tests/troubleshoot.test.ts` | `troubleshootError()` live API + local fallback |
+| `tests/mcp-protocol.test.ts` | Full JSON-RPC wire protocol (tools/list count, resources/list) |
+| `tests/docs-tools.test.ts` | `listSkills()`, `getSkillDocs()`, `listDocResources()` |
+| `tests/env-translation.test.ts` | Live-trading gate (dry_run/SIMMER_MCP_ALLOW_LIVE) |
+| `tests/blocked-flags.test.ts` | CLI flag sanitization for extra_args |
+| `tests/discovery.test.ts` | Skill discovery from bundled-skills |
+| `tests/errors.test.ts` | `BackendError` + `toMcpResponse()` |
+| `tests/output-parsing.test.ts` | `simmer_managed_output` JSON parsing |
+| `tests/per-skill-smoke.test.ts` | Entrypoint + SKILL.md presence + py_compile |
+| `tests/runtime-probe.test.ts` | python3/git/simmer-sdk detection |
+| `tests/scoring.test.ts` | Confidence scoring math |
+| `tests/skill-runner.test.ts` | Process execution + timeout |
+| `tests/state.test.ts` | JSONL state read/write/reconstruction |
+
+## Architecture
+
+```
+src/
+  mcp-server.ts      — entry point, registers all tools + resources
+  api.ts             — SimmerApi class (BackendError on 4xx/5xx, checkPro)
+  errors.ts          — BackendError + McpErrorResponse
+  docs-tools.ts      — listSkills, getSkillDocs, doc resources
+  troubleshoot.ts    — troubleshootError (live + local fallback)
+  runtime-probe.ts   — python3/git/simmer-sdk detection
+  per-skill-tools.ts — buildToolSchema, buildToolDescription, invokeSkillTool
+  skill-discovery.ts — discoverSkills (reads bundled-skills/)
+  skill-runner.ts    — runSkillProcess (subprocess execution)
+  blocked-flags.ts   — filterBlockedFlags (live-trading CLI flag sanitization)
+  env-translation.ts — buildEnv (tunables → env vars, live-trading gate)
+  output-parsing.ts  — parseSkillOutput (simmer_managed_output JSON)
+  core/              — types, scoring, state, git, runner
+```
+
+## Release process (Phase 4)
+
+1. Bump `version` in `package.json`
+2. Update `BUNDLED_VERSION` constant in `mcp-server.ts`
+3. Run smoke checklist above
+4. `npm pack --dry-run` to verify manifest
+5. `npm publish` (requires npm login with access to the `simmer-autoresearch` package)
+6. Post announcement to `#releases`

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,97 @@
+# simmer-autoresearch
+
+MCP server that gives your AI agent access to Simmer trading skill management, experiment tracking, and AI-powered market research.
+
+[![npm version](https://badge.fury.io/js/simmer-autoresearch.svg)](https://www.npmjs.com/package/simmer-autoresearch)
+
+## Install
+
+```bash
+npx simmer-autoresearch install-skill
+```
+
+This installs the `SKILL.md` for your agent runtime (OpenClaw / Hermes). For Claude Code, paste the content into your project's `CLAUDE.md`.
+
+## Claude Desktop config
+
+```json
+{
+  "mcpServers": {
+    "simmer": {
+      "command": "npx",
+      "args": ["-y", "simmer-autoresearch"],
+      "env": {
+        "SIMMER_API_KEY": "sk_live_..."
+      }
+    }
+  }
+}
+```
+
+Get your API key from [simmer.markets/dashboard](https://simmer.markets/dashboard).
+
+## Tools by tier
+
+### Free (no API key)
+
+| Tool | Description |
+|---|---|
+| `list_skills` | List all bundled Simmer trading skills with tier and Pro requirements |
+| `get_skill_docs` | Get full SKILL.md for a specific skill |
+| `troubleshoot_error` | Look up a Simmer API error and get a fix |
+
+### Pro (requires SIMMER_API_KEY)
+
+| Tool | Description |
+|---|---|
+| `init_experiment` | Initialize an autoresearch session for a skill |
+| `run_experiment` | Run a shell command as a timed experiment |
+| `log_experiment` | Record experiment result (keep/discard/crash) with git commit |
+| `backtest_experiment` | Replay historical trades against new config (server-side) |
+| `simmer_<slug>` × 19 | Execute a specific trading skill in paper or live mode |
+
+### MCP Resources (always available)
+
+| URI | Description |
+|---|---|
+| `simmer://docs/api-reference` | Full Simmer API reference |
+| `simmer://docs/skill-reference` | Agent-facing skill reference |
+
+## Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SIMMER_API_KEY` | For Pro tools | API key from simmer.markets/dashboard |
+| `SIMMER_API_URL` | No | Override API base URL (default: `https://api.simmer.markets`) |
+| `AUTORESEARCH_MAX_EXPERIMENTS` | No | Cap experiments per session (default: 50) |
+| `SIMMER_MCP_ALLOW_LIVE` | No | Set `true` to allow live trading via per-skill tools |
+| `SIMMER_MCP_ALLOW_EXTRA_ARGS` | No | Set `true` to pass `extra_args` through to skill CLI |
+
+## Bundled skills (19)
+
+Trading skills included in this package. Each has a corresponding `simmer_<slug>` MCP tool when `SIMMER_API_KEY` is set:
+
+- `polymarket-fast-loop` — High-frequency Polymarket market maker
+- `polymarket-ai-divergence` — AI signal vs market price divergence
+- `polymarket-mert-sniper` — Sniping mispriced markets
+- `polymarket-signal-sniper` — Signal-based sniper
+- `polymarket-fast-scaler` — Position scaling on conviction
+- `polymarket-market-maker` — Two-sided GTC quoting
+- `polymarket-copytrading` — Copy top traders
+- `polymarket-btc-up-down-trader` — BTC direction trader
+- `polymarket-nothing-ever-happens` — Status-quo bias strategy
+- `polymarket-weather-trader` — Weather market specialist
+- `polymarket-elon-tweets` — Elon tweet signal trader
+- `kalshi-weather-trader` — Kalshi weather markets
+
+And 7 instruction-only (Tier A) skills for agent context.
+
+## Requirements
+
+- Node.js 18+
+- Python 3.9+ (for per-skill execution)
+- `pip install simmer-sdk>=0.13.0` (for per-skill execution)
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, test structure, and release checklist.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -10,6 +10,7 @@
     "dist/",
     "skills/",
     "bundled-skills/",
+    "bundled-snapshots/",
     "LICENSE"
   ],
   "scripts": {

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -1,5 +1,7 @@
 // Simmer-specific — not tracked against upstream
 
+import { BackendError } from "./errors.js";
+
 export interface SkillOutcome {
   trades: number;
   pnl: number;
@@ -54,6 +56,47 @@ export class SimmerApi {
       "Content-Type": "application/json",
       "x-mcp-version": this.mcpVersion,
     };
+  }
+
+  private async timedFetch(url: string, init?: RequestInit, timeoutMs = 5000): Promise<Response> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: ctrl.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async extractDetail(resp: Response): Promise<string> {
+    try {
+      const body = (await resp.json()) as Record<string, unknown>;
+      if (typeof body.detail === "string") return body.detail;
+    } catch { /* ignore parse errors */ }
+    return `HTTP ${resp.status}`;
+  }
+
+  /**
+   * Lightweight Pro-tier check. Probes /api/sdk/autoresearch/state with a
+   * canary slug. Throws BackendError(403) if the user doesn't have Pro.
+   * Swallows network errors and non-403 failures — those are transient and
+   * should not block local experiment execution.
+   */
+  async checkPro(): Promise<void> {
+    try {
+      const resp = await this.timedFetch(
+        `${this.apiUrl}/api/sdk/autoresearch/state?skill_slug=__probe__`,
+        { headers: this.headers() },
+      );
+      if (resp.status === 403) {
+        const detail = await this.extractDetail(resp);
+        throw new BackendError(403, detail, "https://simmer.markets/pro");
+      }
+      // Any other status (200, 404, 500, etc.) is not a Pro gate — skip.
+    } catch (e) {
+      if (e instanceof BackendError) throw e;
+      // Network failure or timeout — non-blocking; skip the check.
+    }
   }
 
   async getOutcomes(skillSlug: string, since: string): Promise<SkillOutcome | null> {
@@ -112,27 +155,31 @@ export class SimmerApi {
     }
   }
 
+  /**
+   * Runs a backtest. Throws BackendError on 4xx/5xx so callers can relay the
+   * error cleanly (403 → upgrade prompt, 401 → invalid key, etc.).
+   */
   async backtest(params: {
     skill_slug: string;
     config: Record<string, number>;
     days?: number;
     venue?: string;
-  }): Promise<BacktestResult | null> {
-    try {
-      const resp = await fetch(`${this.apiUrl}/api/sdk/autoresearch/backtest`, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify({
-          skill_slug: params.skill_slug,
-          config: params.config,
-          days: params.days ?? 7,
-          venue: params.venue ?? "sim",
-        }),
-      });
-      if (!resp.ok) return null;
-      return await resp.json();
-    } catch {
-      return null;
+  }): Promise<BacktestResult> {
+    const resp = await fetch(`${this.apiUrl}/api/sdk/autoresearch/backtest`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({
+        skill_slug: params.skill_slug,
+        config: params.config,
+        days: params.days ?? 7,
+        venue: params.venue ?? "sim",
+      }),
+    });
+    if (!resp.ok) {
+      const detail = await this.extractDetail(resp);
+      const upgradeUrl = resp.status === 403 ? "https://simmer.markets/pro" : undefined;
+      throw new BackendError(resp.status, detail, upgradeUrl);
     }
+    return (await resp.json()) as BacktestResult;
   }
 }

--- a/mcp/src/docs-tools.ts
+++ b/mcp/src/docs-tools.ts
@@ -30,6 +30,7 @@ export function listSkills(skills: Skill[]): SkillListEntry[] {
 }
 
 export interface ToolResponse {
+  [key: string]: unknown;
   content: Array<{ type: "text"; text: string }>;
   isError: boolean;
 }

--- a/mcp/src/errors.ts
+++ b/mcp/src/errors.ts
@@ -1,4 +1,5 @@
 export interface McpErrorResponse {
+  [key: string]: unknown;
   content: Array<{ type: "text"; text: string }>;
   isError: true;
   _meta?: { status_code?: number; upgrade_url?: string };

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -21,7 +21,6 @@ if (process.argv[2] === "install-skill") {
   const home = process.env.HOME || process.env.USERPROFILE || "";
   const runtimes: { name: string; dir: string }[] = [];
 
-  // Detect runtimes
   const openclawDir = path.join(home, ".openclaw", "skills", "autoresearch");
   if (fs.existsSync(path.join(home, ".openclaw"))) {
     runtimes.push({ name: "OpenClaw", dir: openclawDir });
@@ -52,15 +51,6 @@ if (process.argv[2] === "install-skill") {
 
 // ---------------------------------------------------------------------------
 // Auto-refresh installed SKILL.md from the bundled copy.
-//
-// SKILL.md is written to ~/.openclaw/skills/... and ~/.hermes/skills/... at
-// install time. It never updates afterwards — agents keep reading a stale
-// copy across npm upgrades. On every MCP server boot, if a runtime dir
-// already has an installed SKILL.md whose content differs from the bundled
-// version, silently overwrite it so the fix propagates on restart.
-//
-// Only touches dirs the user already opted into (presence of ~/.openclaw or
-// ~/.hermes). Never creates new install paths on its own.
 // ---------------------------------------------------------------------------
 
 function refreshInstalledSkills(): void {
@@ -77,15 +67,14 @@ function refreshInstalledSkills(): void {
   ];
 
   for (const t of targets) {
-    if (!fs.existsSync(t.file)) continue; // only refresh what's already installed
+    if (!fs.existsSync(t.file)) continue;
     try {
       const current = fs.readFileSync(t.file, "utf-8");
       if (current === bundled) continue;
       fs.writeFileSync(t.file, bundled);
-      console.error(`[autoresearch] Refreshed ${t.name} SKILL.md (${t.file})`);
+      console.error(`[simmer-mcp] Refreshed ${t.name} SKILL.md (${t.file})`);
     } catch (e) {
-      // Non-fatal — don't block MCP startup on a refresh hiccup
-      console.error(`[autoresearch] Could not refresh ${t.name} SKILL.md: ${e instanceof Error ? e.message : String(e)}`);
+      console.error(`[simmer-mcp] Could not refresh ${t.name} SKILL.md: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 }
@@ -93,7 +82,7 @@ function refreshInstalledSkills(): void {
 refreshInstalledSkills();
 
 // ---------------------------------------------------------------------------
-// MCP Server
+// MCP Server imports
 // ---------------------------------------------------------------------------
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -117,11 +106,15 @@ import {
 import { runCommand } from "./core/runner.js";
 import { gitAutoCommit, gitRevert } from "./core/git.js";
 import { SimmerApi } from "./api.js";
+import { BackendError } from "./errors.js";
+import { discoverSkills } from "./skill-discovery.js";
+import { buildToolSchema, buildToolDescription, invokeSkillTool } from "./per-skill-tools.js";
+import { listSkills, getSkillDocs, listDocResources, readDocResource } from "./docs-tools.js";
+import { troubleshootError } from "./troubleshoot.js";
+import { probeRuntime } from "./runtime-probe.js";
 
 // ---------------------------------------------------------------------------
-// Bundled version — single source of truth for this MCP server build.
-// Bumped at every release; compared to npm registry on boot to surface
-// stale-install warnings to the agent.
+// Bundled version
 // ---------------------------------------------------------------------------
 
 const BUNDLED_VERSION = "2.3.0";
@@ -135,21 +128,23 @@ const apiUrl = process.env.SIMMER_API_URL || "https://api.simmer.markets";
 const maxExperiments = Math.max(0, Number(process.env.AUTORESEARCH_MAX_EXPERIMENTS) || 50);
 const workspaceDir = process.cwd();
 
-if (!apiKey) {
-  console.error("[autoresearch] WARNING: SIMMER_API_KEY not set. API sync disabled.");
-}
-
 const simmer = apiKey ? new SimmerApi(apiKey, apiUrl, BUNDLED_VERSION) : null;
 
+if (!apiKey) {
+  console.error("[simmer-mcp] No SIMMER_API_KEY set — only free tools available (list_skills, get_skill_docs, troubleshoot_error).");
+}
+
 // ---------------------------------------------------------------------------
-// Version check — on boot, fetch the latest published version from npm and
-// log a noisy warning if the bundled version is behind. Non-blocking; if
-// the registry is unreachable, the check silently no-ops. Agents see the
-// stderr in their tool-call output and can relay the nudge to the user.
+// Skill discovery (bundled at build time)
 // ---------------------------------------------------------------------------
 
-// Returns positive if a > b, negative if a < b, 0 if equal. Compares the
-// numeric major.minor.patch prefix; ignores pre-release / build suffixes.
+const BUNDLED_SKILLS_DIR = path.join(__dirname, "..", "bundled-skills");
+const skills = discoverSkills(BUNDLED_SKILLS_DIR);
+
+// ---------------------------------------------------------------------------
+// Version check (non-blocking)
+// ---------------------------------------------------------------------------
+
 function compareSemver(a: string, b: string): number {
   const parse = (v: string): number[] =>
     v.split("-")[0].split(".").map((p) => parseInt(p, 10) || 0);
@@ -172,31 +167,39 @@ async function checkLatestVersion(): Promise<void> {
     const data = (await resp.json()) as { version?: string };
     const latest = data.version;
     if (!latest) return;
-    // Only warn when bundled is BEHIND latest. Local pre-release builds
-    // (bundled ahead of registry) silently no-op.
     if (compareSemver(BUNDLED_VERSION, latest) >= 0) return;
     console.error(
-      `[autoresearch] ⚠ Update available: simmer-autoresearch ${BUNDLED_VERSION} → ${latest}. ` +
-      `Restart your agent session to pick up the latest. ` +
-      `If you pinned a version in your MCP config, update it and restart.`,
+      `[simmer-mcp] ⚠ Update available: simmer-autoresearch ${BUNDLED_VERSION} → ${latest}. ` +
+      `Restart your agent session to pick up the latest.`,
     );
   } catch {
-    // Registry unreachable, offline, etc. — non-fatal. Skip silently.
+    // Registry unreachable — non-fatal.
   }
 }
 
-// Fire-and-forget; don't block server boot on the network call.
 checkLatestVersion();
 
 // ---------------------------------------------------------------------------
-// State
+// State (autoresearch)
 // ---------------------------------------------------------------------------
 
 let state: ExperimentState = reconstructState(workspaceDir);
 if (state.results.length > 0) {
   console.error(
-    `[autoresearch] Restored ${state.results.length} experiments from JSONL (segment ${state.currentSegment})`,
+    `[simmer-mcp] Restored ${state.results.length} experiments from JSONL (segment ${state.currentSegment})`,
   );
+}
+
+// ---------------------------------------------------------------------------
+// Pro-gate helper (Task 22 — Codex CRITICAL #1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Verifies the API key has Pro access before running an experiment.
+ * Throws BackendError(403) if not Pro; swallows network failures (non-blocking).
+ */
+async function assertProForRunExperiment(api: SimmerApi): Promise<void> {
+  await api.checkPro();
 }
 
 // ---------------------------------------------------------------------------
@@ -208,404 +211,509 @@ const server = new McpServer({
   version: BUNDLED_VERSION,
 });
 
-// --- init_experiment ---
+// ===========================================================================
+// FREE TOOLS — always available, no API key required
+// ===========================================================================
 
 server.tool(
-  "init_experiment",
-  "Initialize the experiment session. Call once before the first run_experiment to set the name, primary metric, unit, and direction. Writes config to autoresearch.jsonl.",
-  {
-    name: z.string().describe('Human-readable name (e.g. "Optimizing polymarket-ai-divergence for P&L")'),
-    metric_name: z.string().describe('Primary metric name (e.g. "pnl", "trades", "sharpe")'),
-    skill_slug: z.string().describe('Skill slug for API tracking (e.g. "polymarket-fast-loop")'),
-    metric_unit: z.string().optional().describe('Unit (e.g. "$", "%", "")'),
-    direction: z.enum(["lower", "higher"]).optional().describe('Whether "lower" or "higher" is better. Default: "higher"'),
-  },
-  async ({ name, metric_name, skill_slug, metric_unit, direction }) => {
-    const isReinit = state.results.length > 0;
-
-    state.name = name;
-    state.skillSlug = skill_slug;
-    state.metricName = metric_name;
-    state.consecutiveCrashes = 0;
-    state.paused = false;
-    state.metricUnit = metric_unit ?? "$";
-    if (direction) state.bestDirection = direction;
-
-    // If no local history, try API resume
-    if (!isReinit && simmer) {
-      try {
-        const apiState = await simmer.getResumeState(skill_slug);
-        if (apiState && apiState.last_experiment_number > 0) {
-          state.bestMetric = apiState.best_metric;
-          state.bestDirection = apiState.best_direction ?? state.bestDirection;
-          state.currentSegment = apiState.current_segment;
-          for (let i = 1; i <= apiState.last_experiment_number; i++) {
-            state.results.push({
-              commit: "",
-              metric: 0,
-              metrics: {},
-              status: "keep",
-              description: "(restored from API)",
-              timestamp: 0,
-              segment: apiState.current_segment,
-              confidence: null,
-            });
-          }
-          return {
-            content: [{
-              type: "text" as const,
-              text: `✅ Resumed from API: "${name}"\n` +
-                `${apiState.last_experiment_number} previous experiments (segment ${apiState.current_segment})\n` +
-                `Best ${state.metricName}: ${formatNum(apiState.best_metric, state.metricUnit)}\n` +
-                `Continuing from experiment #${apiState.last_experiment_number + 1}`,
-            }],
-          };
-        }
-      } catch {
-        // Fall through to fresh init
-      }
-    }
-
-    if (isReinit) state.currentSegment++;
-    state.bestMetric = null;
-    state.secondaryMetrics = [];
-
-    const configData = {
-      type: "config",
-      name: state.name,
-      skillSlug: state.skillSlug,
-      metricName: state.metricName,
-      metricUnit: state.metricUnit,
-      bestDirection: state.bestDirection,
-    };
-
-    try {
-      if (isReinit) {
-        appendJsonl(workspaceDir, configData);
-      } else {
-        writeJsonl(workspaceDir, configData);
-      }
-    } catch (e) {
-      return {
-        content: [{ type: "text" as const, text: `⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}` }],
-        isError: true,
-      };
-    }
-
-    const reinitNote = isReinit ? " (re-initialized — previous results archived, new baseline needed)" : "";
+  "list_skills",
+  "List all Simmer trading skills available in this package. Returns slug, name, version, tier, and whether the skill requires a Pro plan.",
+  {},
+  async () => {
+    const list = listSkills(skills);
     return {
       content: [{
         type: "text" as const,
-        text: `✅ Experiment initialized: "${name}"${reinitNote}\n` +
-          `Metric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)\n` +
-          (maxExperiments > 0 ? `Budget: ${maxExperiments} experiments this session\n` : "") +
-          `Config written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
+        text: JSON.stringify(list, null, 2),
       }],
     };
   },
 );
 
-// --- run_experiment ---
+server.tool(
+  "get_skill_docs",
+  "Get the full SKILL.md documentation for a specific Simmer skill. Includes description, parameters, usage examples, and troubleshooting tips.",
+  { slug: z.string().describe("Skill slug (e.g. 'polymarket-fast-loop')") },
+  async ({ slug }) => {
+    const r = getSkillDocs(skills, slug);
+    return r;
+  },
+);
 
 server.tool(
-  "run_experiment",
-  "Run a shell command as an experiment. Times execution, captures output, detects pass/fail.",
-  {
-    command: z.string().describe("Shell command to run"),
-    timeout_seconds: z.number().optional().describe("Kill after this many seconds (default: 600)"),
-  },
-  async ({ command, timeout_seconds }) => {
-    if (state.paused) {
-      return {
-        content: [{ type: "text" as const, text: "🛑 Autoresearch is paused due to crashes. Fix the issue, then call init_experiment to resume." }],
-        isError: true,
-      };
+  "troubleshoot_error",
+  "Look up a Simmer API error and get a fix. Pass the error message or JSON response from a failed API call. Returns a matched fix or falls back to docs.",
+  { error_text: z.string().describe("The error message or response body from a failed Simmer API call") },
+  async ({ error_text }) => {
+    const r = await troubleshootError(error_text, apiUrl);
+    const parts: string[] = [];
+    if (r.matched) {
+      parts.push(`✅ Matched: ${r.fix}`);
+    } else {
+      parts.push(`ℹ️ No pattern match. ${r.fix}`);
     }
-    if (maxExperiments > 0 && state.results.length >= maxExperiments) {
+    if (r.source) parts.push(`(source: ${r.source})`);
+    return { content: [{ type: "text" as const, text: parts.join("\n\n") }] };
+  },
+);
+
+// ===========================================================================
+// MCP RESOURCES — doc snapshots (always available)
+// ===========================================================================
+
+for (const docResource of listDocResources()) {
+  server.resource(
+    docResource.name,
+    docResource.uri,
+    { description: docResource.description, mimeType: docResource.mimeType },
+    async (uri) => {
+      const r = await readDocResource(uri.href);
+      if (r.isError) {
+        return { contents: [{ uri: uri.href, mimeType: "text/markdown" as const, text: `⚠️ Resource unavailable: ${uri.href}` }] };
+      }
+      return { contents: r.contents };
+    },
+  );
+}
+
+// ===========================================================================
+// PRO TOOLS — requires SIMMER_API_KEY
+// ===========================================================================
+
+if (simmer) {
+
+  // --- init_experiment ---
+
+  server.tool(
+    "init_experiment",
+    "Initialize the experiment session. Call once before the first run_experiment to set the name, primary metric, unit, and direction. Writes config to autoresearch.jsonl.",
+    {
+      name: z.string().describe('Human-readable name (e.g. "Optimizing polymarket-ai-divergence for P&L")'),
+      metric_name: z.string().describe('Primary metric name (e.g. "pnl", "trades", "sharpe")'),
+      skill_slug: z.string().describe('Skill slug for API tracking (e.g. "polymarket-fast-loop")'),
+      metric_unit: z.string().optional().describe('Unit (e.g. "$", "%", "")'),
+      direction: z.enum(["lower", "higher"]).optional().describe('Whether "lower" or "higher" is better. Default: "higher"'),
+    },
+    async ({ name, metric_name, skill_slug, metric_unit, direction }) => {
+      const isReinit = state.results.length > 0;
+
+      state.name = name;
+      state.skillSlug = skill_slug;
+      state.metricName = metric_name;
+      state.consecutiveCrashes = 0;
+      state.paused = false;
+      state.metricUnit = metric_unit ?? "$";
+      if (direction) state.bestDirection = direction;
+
+      if (!isReinit && simmer) {
+        try {
+          const apiState = await simmer.getResumeState(skill_slug);
+          if (apiState && apiState.last_experiment_number > 0) {
+            state.bestMetric = apiState.best_metric;
+            state.bestDirection = apiState.best_direction ?? state.bestDirection;
+            state.currentSegment = apiState.current_segment;
+            for (let i = 1; i <= apiState.last_experiment_number; i++) {
+              state.results.push({
+                commit: "",
+                metric: 0,
+                metrics: {},
+                status: "keep",
+                description: "(restored from API)",
+                timestamp: 0,
+                segment: apiState.current_segment,
+                confidence: null,
+              });
+            }
+            return {
+              content: [{
+                type: "text" as const,
+                text: `✅ Resumed from API: "${name}"\n` +
+                  `${apiState.last_experiment_number} previous experiments (segment ${apiState.current_segment})\n` +
+                  `Best ${state.metricName}: ${formatNum(apiState.best_metric, state.metricUnit)}\n` +
+                  `Continuing from experiment #${apiState.last_experiment_number + 1}`,
+              }],
+            };
+          }
+        } catch {
+          // Fall through to fresh init
+        }
+      }
+
+      if (isReinit) state.currentSegment++;
+      state.bestMetric = null;
+      state.secondaryMetrics = [];
+
+      const configData = {
+        type: "config",
+        name: state.name,
+        skillSlug: state.skillSlug,
+        metricName: state.metricName,
+        metricUnit: state.metricUnit,
+        bestDirection: state.bestDirection,
+      };
+
+      try {
+        if (isReinit) {
+          appendJsonl(workspaceDir, configData);
+        } else {
+          writeJsonl(workspaceDir, configData);
+        }
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `⚠️ Failed to write autoresearch.jsonl: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+
+      const reinitNote = isReinit ? " (re-initialized — previous results archived, new baseline needed)" : "";
       return {
         content: [{
           type: "text" as const,
-          text: `🛑 Experiment limit reached (${maxExperiments}). Session complete.\n` +
-            `Review results. To continue, start a new session or set AUTORESEARCH_MAX_EXPERIMENTS higher.`,
+          text: `✅ Experiment initialized: "${name}"${reinitNote}\n` +
+            `Metric: ${state.metricName} (${state.metricUnit || "unitless"}, ${state.bestDirection} is better)\n` +
+            (maxExperiments > 0 ? `Budget: ${maxExperiments} experiments this session\n` : "") +
+            `Config written to autoresearch.jsonl. Now run the baseline with run_experiment.`,
         }],
       };
-    }
+    },
+  );
 
-    const timeout = (timeout_seconds ?? 600) * 1000;
-    const result = await runCommand(command, { timeoutMs: timeout, cwd: workspaceDir });
+  // --- run_experiment (Pro-gated — Task 22, Codex CRITICAL #1) ---
 
-    let text = "";
-    if (result.timedOut) {
-      text += `⏰ TIMEOUT after ${result.durationSeconds.toFixed(1)}s\n`;
-    } else if (!result.passed) {
-      text += `💥 FAILED (exit code ${result.exitCode}) in ${result.durationSeconds.toFixed(1)}s\n`;
-    } else {
-      text += `✅ PASSED in ${result.durationSeconds.toFixed(1)}s\n`;
-    }
+  server.tool(
+    "run_experiment",
+    "Run a shell command as an experiment. Times execution, captures output, detects pass/fail. Requires Pro plan.",
+    {
+      command: z.string().describe("Shell command to run"),
+      timeout_seconds: z.number().optional().describe("Kill after this many seconds (default: 600)"),
+    },
+    async ({ command, timeout_seconds }) => {
+      // Per-call Pro check — Codex CRITICAL #1
+      try {
+        await assertProForRunExperiment(simmer!);
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        throw e;
+      }
 
-    if (state.bestMetric !== null) {
-      text += `📊 Current best ${state.metricName}: ${formatNum(state.bestMetric, state.metricUnit)}\n`;
-    }
-
-    const output = (result.stdout + "\n" + result.stderr).trim();
-    const tail = output.split("\n").slice(-80).join("\n");
-    text += `\nLast 80 lines of output:\n${tail}`;
-
-    return { content: [{ type: "text" as const, text }] };
-  },
-);
-
-// --- log_experiment ---
-
-server.tool(
-  "log_experiment",
-  'Record an experiment result. "keep" auto-commits via git. "discard"/"crash"/"checks_failed" reverts. Reports confidence score after 3+ runs.',
-  {
-    commit: z.string().describe("Git commit hash (short, 7 chars)"),
-    metric: z.number().describe("Primary metric value. 0 for crashes."),
-    status: z.enum(["keep", "discard", "crash", "checks_failed"]).describe("keep if improved, discard if worse, crash if skill broke, checks_failed if ran but post-run checks failed"),
-    description: z.string().describe("Short description of what this experiment tried"),
-    metrics: z.record(z.string(), z.number()).optional().describe('Secondary metrics as { name: value }'),
-    asi: z.record(z.string(), z.unknown()).optional().describe('Actionable Side Information — free-form diagnostics (e.g., {"market_liquidity": "low", "api_latency_ms": 340})'),
-    force: z.boolean().optional().describe("Set true to allow adding a new secondary metric not previously tracked"),
-  },
-  async ({ commit, metric, status, description, metrics: secondaryMetrics, asi, force }) => {
-    const secMetrics: Record<string, number> = secondaryMetrics ?? {};
-    const forceAdd = force ?? false;
-
-    // Validate secondary metrics consistency
-    if (state.secondaryMetrics.length > 0) {
-      const knownNames = new Set(state.secondaryMetrics.map((m) => m.name));
-      const providedNames = new Set(Object.keys(secMetrics));
-
-      const missing = [...knownNames].filter((n) => !providedNames.has(n));
-      if (missing.length > 0) {
+      if (state.paused) {
         return {
-          content: [{
-            type: "text" as const,
-            text: `❌ Missing secondary metrics: ${missing.join(", ")}\n` +
-              `Expected: ${[...knownNames].join(", ")}\nGot: ${[...providedNames].join(", ") || "(none)"}\n` +
-              `Fix: include ${missing.map((m) => `"${m}": <value>`).join(", ")} in metrics.`,
-          }],
+          content: [{ type: "text" as const, text: "🛑 Autoresearch is paused due to crashes. Fix the issue, then call init_experiment to resume." }],
           isError: true,
         };
       }
-
-      const newMetrics = [...providedNames].filter((n) => !knownNames.has(n));
-      if (newMetrics.length > 0 && !forceAdd) {
+      if (maxExperiments > 0 && state.results.length >= maxExperiments) {
         return {
           content: [{
             type: "text" as const,
-            text: `❌ New secondary metric(s) not previously tracked: ${newMetrics.join(", ")}\n` +
-              `Existing: ${[...knownNames].join(", ")}\nCall again with force: true to add, or remove from metrics.`,
+            text: `🛑 Experiment limit reached (${maxExperiments}). Session complete.\n` +
+              `Review results. To continue, start a new session or set AUTORESEARCH_MAX_EXPERIMENTS higher.`,
           }],
-          isError: true,
         };
       }
-    }
 
-    const experiment: ExperimentResult = {
-      commit: commit.slice(0, 7),
-      metric,
-      metrics: secMetrics,
-      status,
-      description,
-      timestamp: Date.now(),
-      segment: state.currentSegment,
-      confidence: null,
-      asi: asi as Record<string, unknown> | undefined,
-    };
+      const timeout = (timeout_seconds ?? 600) * 1000;
+      const result = await runCommand(command, { timeoutMs: timeout, cwd: workspaceDir });
 
-    state.results.push(experiment);
-
-    // Crash safety (crash and checks_failed both count)
-    if (status === "crash" || status === "checks_failed") {
-      state.consecutiveCrashes++;
-      const curCount = currentResults(state.results, state.currentSegment).length;
-      if (curCount === 1) state.paused = true;
-      if (state.consecutiveCrashes >= 3) state.paused = true;
-    } else {
-      state.consecutiveCrashes = 0;
-    }
-
-    // Register new secondary metrics
-    for (const name of Object.keys(secMetrics)) {
-      if (!state.secondaryMetrics.find((m) => m.name === name)) {
-        let unit = "";
-        if (name.includes("pnl") || name.includes("budget")) unit = "$";
-        else if (name.includes("rate") || name.includes("pct")) unit = "%";
-        state.secondaryMetrics.push({ name, unit });
-      }
-    }
-
-    state.bestMetric = findBaselineMetric(state.results, state.currentSegment);
-    state.confidence = computeConfidence(state.results, state.currentSegment, state.bestDirection);
-    experiment.confidence = state.confidence;
-
-    const curCount = currentResults(state.results, state.currentSegment).length;
-    let text = `Logged #${state.results.length}: ${experiment.status} — ${experiment.description}`;
-
-    if (state.bestMetric !== null) {
-      text += `\nBaseline ${state.metricName}: ${formatNum(state.bestMetric, state.metricUnit)}`;
-      if (curCount > 1 && status === "keep" && metric !== 0) {
-        const delta = metric - state.bestMetric;
-        const pct = state.bestMetric !== 0
-          ? ((delta / Math.abs(state.bestMetric)) * 100).toFixed(1)
-          : "∞";
-        const sign = delta > 0 ? "+" : "";
-        text += ` | this: ${formatNum(metric, state.metricUnit)} (${sign}${pct}%)`;
-      }
-    }
-
-    if (Object.keys(secMetrics).length > 0) {
-      const parts: string[] = [];
-      for (const [name, value] of Object.entries(secMetrics)) {
-        const def = state.secondaryMetrics.find((m) => m.name === name);
-        parts.push(`${name}: ${formatNum(value, def?.unit ?? "")}`);
-      }
-      text += `\nSecondary: ${parts.join("  ")}`;
-    }
-
-    // Confidence display
-    if (state.confidence !== null) {
-      const confStr = state.confidence.toFixed(1);
-      if (state.confidence >= 2.0) {
-        text += `\n📊 Confidence: ${confStr}× noise floor — improvement is likely real`;
-      } else if (state.confidence >= 1.0) {
-        text += `\n📊 Confidence: ${confStr}× noise floor — marginal`;
+      let text = "";
+      if (result.timedOut) {
+        text += `⏰ TIMEOUT after ${result.durationSeconds.toFixed(1)}s\n`;
+      } else if (!result.passed) {
+        text += `💥 FAILED (exit code ${result.exitCode}) in ${result.durationSeconds.toFixed(1)}s\n`;
       } else {
-        text += `\n⚠️ Confidence: ${confStr}× noise floor — within noise`;
+        text += `✅ PASSED in ${result.durationSeconds.toFixed(1)}s\n`;
       }
-    }
 
-    text += `\n(${state.results.length} experiments total)`;
-
-    // Git operations
-    if (status === "keep") {
-      const gitResult = await gitAutoCommit(workspaceDir, description, state.metricName, metric, secMetrics);
-      if (gitResult.committed) {
-        text += `\n📝 Git: committed — ${gitResult.message}`;
-        if (gitResult.newSha) experiment.commit = gitResult.newSha;
-      } else {
-        text += `\n📝 Git: ${gitResult.message}`;
+      if (state.bestMetric !== null) {
+        text += `📊 Current best ${state.metricName}: ${formatNum(state.bestMetric, state.metricUnit)}\n`;
       }
-    } else {
-      await gitRevert(workspaceDir);
-      text += `\n📝 Git: reverted (${status})`;
-    }
 
-    // Persist to JSONL after git (so commit hash is correct)
-    try {
-      appendJsonl(workspaceDir, { run: state.results.length, ...experiment });
-    } catch {
-      // Don't fail if write fails
-    }
+      const output = (result.stdout + "\n" + result.stderr).trim();
+      const tail = output.split("\n").slice(-80).join("\n");
+      text += `\nLast 80 lines of output:\n${tail}`;
 
-    // POST to Simmer API (best-effort)
-    if (simmer) {
-      simmer.postExperiment({
-        skill_slug: state.skillSlug ?? "unknown",
-        experiment_number: state.results.length,
-        segment: state.currentSegment,
+      return { content: [{ type: "text" as const, text }] };
+    },
+  );
+
+  // --- log_experiment ---
+
+  server.tool(
+    "log_experiment",
+    'Record an experiment result. "keep" auto-commits via git. "discard"/"crash"/"checks_failed" reverts. Reports confidence score after 3+ runs.',
+    {
+      commit: z.string().describe("Git commit hash (short, 7 chars)"),
+      metric: z.number().describe("Primary metric value. 0 for crashes."),
+      status: z.enum(["keep", "discard", "crash", "checks_failed"]).describe("keep if improved, discard if worse, crash if skill broke, checks_failed if ran but post-run checks failed"),
+      description: z.string().describe("Short description of what this experiment tried"),
+      metrics: z.record(z.string(), z.number()).optional().describe('Secondary metrics as { name: value }'),
+      asi: z.record(z.string(), z.unknown()).optional().describe('Actionable Side Information — free-form diagnostics'),
+      force: z.boolean().optional().describe("Set true to allow adding a new secondary metric not previously tracked"),
+    },
+    async ({ commit, metric, status, description, metrics: secondaryMetrics, asi, force }) => {
+      const secMetrics: Record<string, number> = secondaryMetrics ?? {};
+      const forceAdd = force ?? false;
+
+      if (state.secondaryMetrics.length > 0) {
+        const knownNames = new Set(state.secondaryMetrics.map((m) => m.name));
+        const providedNames = new Set(Object.keys(secMetrics));
+
+        const missing = [...knownNames].filter((n) => !providedNames.has(n));
+        if (missing.length > 0) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: `❌ Missing secondary metrics: ${missing.join(", ")}\n` +
+                `Expected: ${[...knownNames].join(", ")}\nGot: ${[...providedNames].join(", ") || "(none)"}\n` +
+                `Fix: include ${missing.map((m) => `"${m}": <value>`).join(", ")} in metrics.`,
+            }],
+            isError: true,
+          };
+        }
+
+        const newMetrics = [...providedNames].filter((n) => !knownNames.has(n));
+        if (newMetrics.length > 0 && !forceAdd) {
+          return {
+            content: [{
+              type: "text" as const,
+              text: `❌ New secondary metric(s) not previously tracked: ${newMetrics.join(", ")}\n` +
+                `Existing: ${[...knownNames].join(", ")}\nCall again with force: true to add, or remove from metrics.`,
+            }],
+            isError: true,
+          };
+        }
+      }
+
+      const experiment: ExperimentResult = {
+        commit: commit.slice(0, 7),
+        metric,
+        metrics: secMetrics,
         status,
-        metric_name: state.metricName,
-        metric_value: metric === 0 && status === "crash" ? null : metric,
-        metric_unit: state.metricUnit,
-        best_direction: state.bestDirection,
-        secondary_metrics: secMetrics,
         description,
-        commit_hash: experiment.commit,
-      }).catch(() => { /* Silent — JSONL is primary */ });
+        timestamp: Date.now(),
+        segment: state.currentSegment,
+        confidence: null,
+        asi: asi as Record<string, unknown> | undefined,
+      };
 
-      // Verify metric against API (non-blocking)
-      if (status === "keep" && state.metricName?.toLowerCase().includes("pnl")) {
-        simmer.getOutcomes(state.skillSlug ?? "unknown", "").then((apiOutcome) => {
-          if (apiOutcome && apiOutcome.trades > 0 && metric !== null) {
-            const diff = Math.abs(apiOutcome.pnl - metric);
-            if (diff > 1.0) {
-              console.error(
-                `[autoresearch] Metric discrepancy: agent reported ${metric}, API shows ${apiOutcome.pnl} (diff: ${diff.toFixed(2)})`,
-              );
-            }
-          }
-        }).catch(() => { /* Silent */ });
-      }
-    }
+      state.results.push(experiment);
 
-    // Budget warning
-    if (maxExperiments > 0) {
-      const threshold = Math.floor(maxExperiments * 0.8);
-      if (state.results.length === threshold) {
-        text += `\n\n⏳ ${maxExperiments - state.results.length} experiments remaining (limit: ${maxExperiments}).`;
-      }
-    }
-
-    // Pause messages
-    if (state.paused) {
-      const pauseCount = currentResults(state.results, state.currentSegment).length;
-      if (pauseCount === 1) {
-        text += `\n\n🛑 BASELINE CRASHED — autoresearch paused.\nFix the issue, then call init_experiment to start fresh.`;
+      if (status === "crash" || status === "checks_failed") {
+        state.consecutiveCrashes++;
+        const curCount = currentResults(state.results, state.currentSegment).length;
+        if (curCount === 1) state.paused = true;
+        if (state.consecutiveCrashes >= 3) state.paused = true;
       } else {
-        text += `\n\n⚠️ ${state.consecutiveCrashes} CONSECUTIVE CRASHES — autoresearch paused.\nInvestigate, fix, then call init_experiment to resume.`;
+        state.consecutiveCrashes = 0;
       }
-    }
 
-    return { content: [{ type: "text" as const, text }] };
-  },
-);
+      for (const name of Object.keys(secMetrics)) {
+        if (!state.secondaryMetrics.find((m) => m.name === name)) {
+          let unit = "";
+          if (name.includes("pnl") || name.includes("budget")) unit = "$";
+          else if (name.includes("rate") || name.includes("pct")) unit = "%";
+          state.secondaryMetrics.push({ name, unit });
+        }
+      }
 
-// --- backtest_experiment ---
+      state.bestMetric = findBaselineMetric(state.results, state.currentSegment);
+      state.confidence = computeConfidence(state.results, state.currentSegment, state.bestDirection);
+      experiment.confidence = state.confidence;
 
-server.tool(
-  "backtest_experiment",
-  "Replay historical trades against new config params without executing real trades. Returns simulated P&L.",
-  {
-    skill_slug: z.string().describe("Skill to backtest"),
-    config: z.record(z.string(), z.number()).describe("Config overrides to test"),
-    days: z.number().optional().describe("Days of history to replay (default 7, max 30)"),
-    venue: z.string().optional().describe("'sim' or 'polymarket' (default 'sim')"),
-  },
-  async ({ skill_slug, config, days, venue }) => {
-    if (!simmer) {
-      return {
-        content: [{ type: "text" as const, text: "⚠️ No API key configured. Set SIMMER_API_KEY env var." }],
-        isError: true,
-      };
-    }
+      const curCount = currentResults(state.results, state.currentSegment).length;
+      let text = `Logged #${state.results.length}: ${experiment.status} — ${experiment.description}`;
 
-    const result = await simmer.backtest({ skill_slug, config, days, venue });
-    if (!result) {
-      return {
-        content: [{ type: "text" as const, text: "❌ Backtest failed — API unreachable or no trades found." }],
-        isError: true,
-      };
-    }
+      if (state.bestMetric !== null) {
+        text += `\nBaseline ${state.metricName}: ${formatNum(state.bestMetric, state.metricUnit)}`;
+        if (curCount > 1 && status === "keep" && metric !== 0) {
+          const delta = metric - state.bestMetric;
+          const pct = state.bestMetric !== 0
+            ? ((delta / Math.abs(state.bestMetric)) * 100).toFixed(1)
+            : "∞";
+          const sign = delta > 0 ? "+" : "";
+          text += ` | this: ${formatNum(metric, state.metricUnit)} (${sign}${pct}%)`;
+        }
+      }
 
-    const text = [
-      `📊 Backtest: ${result.trades_included}/${result.trades_total} trades pass new config`,
-      `Simulated P&L: ${result.simulated_pnl} (original: ${result.original_pnl})`,
-      result.improvement_pct !== null
-        ? `Improvement: ${result.improvement_pct > 0 ? "+" : ""}${result.improvement_pct}%`
-        : "No baseline P&L for comparison",
-      `Win rate: ${(result.win_rate * 100).toFixed(1)}%`,
-      `Excluded: ${result.trades_excluded} trades filtered out by new config`,
-    ].join("\n");
+      if (Object.keys(secMetrics).length > 0) {
+        const parts: string[] = [];
+        for (const [name, value] of Object.entries(secMetrics)) {
+          const def = state.secondaryMetrics.find((m) => m.name === name);
+          parts.push(`${name}: ${formatNum(value, def?.unit ?? "")}`);
+        }
+        text += `\nSecondary: ${parts.join("  ")}`;
+      }
 
-    return { content: [{ type: "text" as const, text }] };
-  },
-);
+      if (state.confidence !== null) {
+        const confStr = state.confidence.toFixed(1);
+        if (state.confidence >= 2.0) {
+          text += `\n📊 Confidence: ${confStr}× noise floor — improvement is likely real`;
+        } else if (state.confidence >= 1.0) {
+          text += `\n📊 Confidence: ${confStr}× noise floor — marginal`;
+        } else {
+          text += `\n⚠️ Confidence: ${confStr}× noise floor — within noise`;
+        }
+      }
+
+      text += `\n(${state.results.length} experiments total)`;
+
+      if (status === "keep") {
+        const gitResult = await gitAutoCommit(workspaceDir, description, state.metricName, metric, secMetrics);
+        if (gitResult.committed) {
+          text += `\n📝 Git: committed — ${gitResult.message}`;
+          if (gitResult.newSha) experiment.commit = gitResult.newSha;
+        } else {
+          text += `\n📝 Git: ${gitResult.message}`;
+        }
+      } else {
+        await gitRevert(workspaceDir);
+        text += `\n📝 Git: reverted (${status})`;
+      }
+
+      try {
+        appendJsonl(workspaceDir, { run: state.results.length, ...experiment });
+      } catch {
+        // Don't fail if write fails
+      }
+
+      if (simmer) {
+        simmer.postExperiment({
+          skill_slug: state.skillSlug ?? "unknown",
+          experiment_number: state.results.length,
+          segment: state.currentSegment,
+          status,
+          metric_name: state.metricName,
+          metric_value: metric === 0 && status === "crash" ? null : metric,
+          metric_unit: state.metricUnit,
+          best_direction: state.bestDirection,
+          secondary_metrics: secMetrics,
+          description,
+          commit_hash: experiment.commit,
+        }).catch(() => { /* Silent — JSONL is primary */ });
+
+        if (status === "keep" && state.metricName?.toLowerCase().includes("pnl")) {
+          simmer.getOutcomes(state.skillSlug ?? "unknown", "").then((apiOutcome) => {
+            if (apiOutcome && apiOutcome.trades > 0 && metric !== null) {
+              const diff = Math.abs(apiOutcome.pnl - metric);
+              if (diff > 1.0) {
+                console.error(
+                  `[simmer-mcp] Metric discrepancy: agent reported ${metric}, API shows ${apiOutcome.pnl} (diff: ${diff.toFixed(2)})`,
+                );
+              }
+            }
+          }).catch(() => { /* Silent */ });
+        }
+      }
+
+      if (maxExperiments > 0) {
+        const threshold = Math.floor(maxExperiments * 0.8);
+        if (state.results.length === threshold) {
+          text += `\n\n⏳ ${maxExperiments - state.results.length} experiments remaining (limit: ${maxExperiments}).`;
+        }
+      }
+
+      if (state.paused) {
+        const pauseCount = currentResults(state.results, state.currentSegment).length;
+        if (pauseCount === 1) {
+          text += `\n\n🛑 BASELINE CRASHED — autoresearch paused.\nFix the issue, then call init_experiment to start fresh.`;
+        } else {
+          text += `\n\n⚠️ ${state.consecutiveCrashes} CONSECUTIVE CRASHES — autoresearch paused.\nInvestigate, fix, then call init_experiment to resume.`;
+        }
+      }
+
+      return { content: [{ type: "text" as const, text }] };
+    },
+  );
+
+  // --- backtest_experiment (Task 21 — throws BackendError on 4xx/5xx) ---
+
+  server.tool(
+    "backtest_experiment",
+    "Replay historical trades against new config params without executing real trades. Returns simulated P&L. Requires Pro plan.",
+    {
+      skill_slug: z.string().describe("Skill to backtest"),
+      config: z.record(z.string(), z.number()).describe("Config overrides to test"),
+      days: z.number().optional().describe("Days of history to replay (default 7, max 30)"),
+      venue: z.string().optional().describe("'sim' or 'polymarket' (default 'sim')"),
+    },
+    async ({ skill_slug, config, days, venue }) => {
+      let result;
+      try {
+        result = await simmer!.backtest({ skill_slug, config, days, venue });
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: "❌ Backtest failed — API unreachable or unexpected error." }],
+          isError: true,
+        };
+      }
+
+      const text = [
+        `📊 Backtest: ${result.trades_included}/${result.trades_total} trades pass new config`,
+        `Simulated P&L: ${result.simulated_pnl} (original: ${result.original_pnl})`,
+        result.improvement_pct !== null
+          ? `Improvement: ${result.improvement_pct > 0 ? "+" : ""}${result.improvement_pct}%`
+          : "No baseline P&L for comparison",
+        `Win rate: ${(result.win_rate * 100).toFixed(1)}%`,
+        `Excluded: ${result.trades_excluded} trades filtered out by new config`,
+      ].join("\n");
+
+      return { content: [{ type: "text" as const, text }] };
+    },
+  );
+
+  // --- per-skill tools ---
+
+  for (const skill of skills) {
+    const capturedSkill = skill; // closure capture
+    server.tool(
+      capturedSkill.toolName,
+      buildToolDescription(capturedSkill),
+      buildToolSchema(capturedSkill),
+      async (args) => {
+        return invokeSkillTool(capturedSkill, args as Record<string, unknown>);
+      },
+    );
+  }
+
+} // end if (simmer)
 
 // ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------
 
 async function main() {
+  // Runtime probe (startup diagnostic)
+  const probe = await probeRuntime();
+  const probeLines = [
+    `python3: ${probe.python3.detected ? `v${probe.python3.version}` : `not found (${probe.python3.installHint})`}`,
+    `simmer-sdk: ${probe.simmerSdk.detected ? `v${probe.simmerSdk.version}` : `not installed (${probe.simmerSdk.installHint})`}`,
+    `git: ${probe.git.detected ? `v${probe.git.version}` : `not found`}`,
+  ].join(" | ");
+
+  const freeCount = 3;
+  const proCount = simmer ? 4 + skills.length : 0;
+  const totalTools = freeCount + proCount;
+  const tier = simmer ? "free + autoresearch + per-skill" : "free only";
+
+  console.error(
+    `[simmer-mcp] v${BUNDLED_VERSION} | tools: ${totalTools} (${tier}) | skills: ${skills.length} bundled`
+  );
+  console.error(`[simmer-mcp] runtime: ${probeLines}`);
+
+  if (!probe.python3.detected) {
+    console.error("[simmer-mcp] ⚠ python3 not found — per-skill execution will fail. Install python3 to use trading skills.");
+  }
+  if (!probe.simmerSdk.detected && simmer) {
+    console.error("[simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0");
+  }
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("[autoresearch] MCP server started (stdio)");
+  console.error("[simmer-mcp] MCP server started (stdio)");
 }
 
 main().catch((err) => {
-  console.error("[autoresearch] Fatal:", err);
+  console.error("[simmer-mcp] Fatal:", err);
   process.exit(1);
 });

--- a/mcp/src/per-skill-tools.ts
+++ b/mcp/src/per-skill-tools.ts
@@ -30,7 +30,7 @@ function tunableToZod(t: Tunable): ZodType<unknown> {
 // Defense-in-depth: tunables must not shadow gate-relevant schema fields.
 const RESERVED_ARG_NAMES = new Set(["dry_run", "trading_venue", "extra_args", "timeout_s"]);
 
-export function buildToolSchema(skill: Skill): z.ZodObject<z.ZodRawShape> {
+export function buildToolSchema(skill: Skill): z.ZodRawShape {
   const tunableShape: Record<string, ZodType<unknown>> = {};
   for (const t of skill.tunables) {
     const argName = envToArgName(t.env);
@@ -38,7 +38,7 @@ export function buildToolSchema(skill: Skill): z.ZodObject<z.ZodRawShape> {
     tunableShape[argName] = tunableToZod(t).optional();
   }
 
-  return z.object({
+  return {
     dry_run: z.boolean().default(true).describe(
       "If false, may place real orders (requires SIMMER_MCP_ALLOW_LIVE=true env). Default: paper mode."
     ),
@@ -49,7 +49,7 @@ export function buildToolSchema(skill: Skill): z.ZodObject<z.ZodRawShape> {
       "Pass-through CLI flags. Live-trading flags (--live, --no-dry-run, --mode=live, etc.) are filtered."
     ),
     ...tunableShape,
-  });
+  };
 }
 
 export function buildToolDescription(skill: Skill): string {
@@ -75,6 +75,7 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_TIMEOUT_MS = 300_000;
 
 export interface InvokeSkillResponse {
+  [key: string]: unknown;
   content: Array<{ type: "text"; text: string }>;
   isError: boolean;
   _meta?: Record<string, unknown>;

--- a/mcp/src/troubleshoot.ts
+++ b/mcp/src/troubleshoot.ts
@@ -1,0 +1,74 @@
+/**
+ * troubleshoot_error — live /api/sdk/troubleshoot + local pattern fallback.
+ * Ported from Python simmer-mcp v0.3.0 (simmer_mcp/errors.py).
+ */
+
+export interface TroubleshootResult {
+  matched: boolean;
+  fix: string;
+  source?: string;
+}
+
+const LOCAL_FALLBACK: Array<{ patterns: string[]; fix: string }> = [
+  {
+    patterns: ["not enough balance", "insufficient balance", "insufficient funds"],
+    fix: "Check USDC.e balance with GET /api/sdk/portfolio. If balance is less than your order size, either deposit more USDC.e or reduce order size. (Allowance errors are a separate failure class and surface as 'allowance'/'approval' — run client.set_approvals() only for those.)",
+  },
+  {
+    patterns: ["rate limit", "too many requests", "429"],
+    fix: "You're over the request limit. Use GET /api/sdk/briefing (1 call) instead of separate /context + /positions + /portfolio calls.",
+  },
+  {
+    patterns: ["nonce", "already used", "nonce too low"],
+    fix: "Nonce collision from concurrent trades. Serialize your trade calls or add a 2-3 second delay between trades.",
+  },
+  {
+    patterns: ["daily trade limit", "trades/day"],
+    fix: "Daily trade limit counts across all venues (sim + real). Raise via PATCH /api/sdk/user/settings with max_trades_per_day (Free: up to 1,000, Pro: up to 5,000). Sells are exempt.",
+  },
+];
+
+const NO_MATCH_FIX =
+  "No known pattern matched. Check the full docs at docs.simmer.markets or fetch docs.simmer.markets/llms-full.txt for the complete reference.";
+
+/**
+ * Look up a Simmer API error. Calls the live /api/sdk/troubleshoot endpoint
+ * first; falls back to local patterns when the API is unreachable.
+ *
+ * @param errorText  The error message or response body from a failed Simmer API call.
+ * @param apiUrl     Optional API base URL (defaults to production).
+ */
+export async function troubleshootError(
+  errorText: string,
+  apiUrl = "https://api.simmer.markets",
+): Promise<TroubleshootResult> {
+  const url = `${apiUrl}/api/sdk/troubleshoot`;
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5000);
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ error_text: errorText }),
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (resp.ok) {
+      return (await resp.json()) as TroubleshootResult;
+    }
+  } catch {
+    // Network error or timeout — fall through to local patterns.
+  }
+
+  const lower = errorText.toLowerCase();
+  for (const entry of LOCAL_FALLBACK) {
+    if (entry.patterns.some((p) => lower.includes(p))) {
+      return { matched: true, fix: entry.fix, source: "pattern_match" };
+    }
+  }
+  return { matched: false, fix: NO_MATCH_FIX, source: "pattern_match" };
+}

--- a/mcp/tests/api.test.ts
+++ b/mcp/tests/api.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for SimmerApi.checkPro() and SimmerApi.backtest() BackendError behavior.
+ * Task 21 (SIM-2056): api.ts refactor — throw BackendError on 4xx/5xx.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { SimmerApi } from "../dist/api.js";
+import { BackendError } from "../dist/errors.js";
+
+type FetchFn = typeof global.fetch;
+let savedFetch: FetchFn;
+
+function mockFetch(fn: FetchFn) {
+  // @ts-expect-error global override for testing
+  global.fetch = fn;
+}
+
+describe("SimmerApi.checkPro", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("resolves when API returns 200", async () => {
+    mockFetch(async () => new Response(JSON.stringify({ last_experiment_number: 0 }), { status: 200 }));
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    await assert.doesNotReject(() => api.checkPro());
+  });
+
+  it("throws BackendError(403) when API returns 403 — Pro required", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "Autoresearch requires a Pro plan." }), { status: 403 })
+    );
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    await assert.rejects(
+      () => api.checkPro(),
+      (err: unknown) => {
+        assert.ok(err instanceof BackendError, `Expected BackendError, got ${err}`);
+        assert.equal(err.statusCode, 403);
+        assert.match(err.body, /Pro/i);
+        assert.ok(err.upgradeUrl, "upgradeUrl should be set for 403");
+        return true;
+      },
+    );
+  });
+
+  it("does not throw on network error (non-blocking — API unreachable)", async () => {
+    mockFetch(async () => { throw new Error("Network error"); });
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    // Network failure must not block run_experiment — gracefully skips the check
+    await assert.doesNotReject(() => api.checkPro());
+  });
+
+  it("does not throw on non-403 API error (server down, 500)", async () => {
+    mockFetch(async () => new Response("Internal Server Error", { status: 500 }));
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    // Only 403 is meaningful for the Pro gate; other errors are transient
+    await assert.doesNotReject(() => api.checkPro());
+  });
+});
+
+describe("SimmerApi.backtest — throws BackendError on 4xx/5xx", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("returns BacktestResult on success", async () => {
+    const mockResult = {
+      trades_total: 10, trades_included: 8, trades_excluded: 2,
+      simulated_pnl: 42.5, original_pnl: 38.0, win_rate: 0.75, improvement_pct: 11.8,
+    };
+    mockFetch(async () => new Response(JSON.stringify(mockResult), { status: 200 }));
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    const result = await api.backtest({ skill_slug: "test", config: {} });
+    assert.equal(result.trades_total, 10);
+    assert.equal(result.simulated_pnl, 42.5);
+  });
+
+  it("throws BackendError(403) when user is not Pro", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "Autoresearch requires a Pro plan." }), { status: 403 })
+    );
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    await assert.rejects(
+      () => api.backtest({ skill_slug: "test", config: {} }),
+      (err: unknown) => {
+        assert.ok(err instanceof BackendError, `Expected BackendError, got ${err}`);
+        assert.equal(err.statusCode, 403);
+        assert.ok(err.upgradeUrl, "upgradeUrl should be set for 403");
+        return true;
+      },
+    );
+  });
+
+  it("throws BackendError(401) on invalid API key", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "Invalid API key" }), { status: 401 })
+    );
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    await assert.rejects(
+      () => api.backtest({ skill_slug: "test", config: {} }),
+      (err: unknown) => {
+        assert.ok(err instanceof BackendError);
+        assert.equal(err.statusCode, 401);
+        return true;
+      },
+    );
+  });
+
+  it("throws BackendError on 500 server error", async () => {
+    mockFetch(async () => new Response(JSON.stringify({ detail: "Internal server error" }), { status: 500 }));
+    const api = new SimmerApi("sk_test", "https://api.simmer.markets", "2.3.0");
+    await assert.rejects(
+      () => api.backtest({ skill_slug: "test", config: {} }),
+      (err: unknown) => {
+        assert.ok(err instanceof BackendError);
+        assert.equal(err.statusCode, 500);
+        return true;
+      },
+    );
+  });
+});

--- a/mcp/tests/mcp-protocol.test.ts
+++ b/mcp/tests/mcp-protocol.test.ts
@@ -1,0 +1,117 @@
+/**
+ * MCP JSON-RPC protocol integration tests.
+ * Task 25 (tools/list count) + Task 28 (resources/list).
+ * Spawns the compiled dist/mcp-server.js and exercises the wire protocol.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER = path.join(__dirname, "../dist/mcp-server.js");
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: number;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+/**
+ * Run a full MCP session against the server, sending initialize + one method.
+ * Returns the response for the second request (id=2).
+ */
+async function mcpCall(
+  method: string,
+  params: unknown,
+  env: Record<string, string | undefined> = {},
+): Promise<JsonRpcResponse> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [SERVER], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+
+    let stdout = "";
+    child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.on("error", reject);
+    child.on("close", () => {
+      const lines = stdout.trim().split("\n");
+      for (const line of lines) {
+        try {
+          const parsed = JSON.parse(line) as JsonRpcResponse;
+          if (parsed.id === 2) { resolve(parsed); return; }
+        } catch { /* skip non-JSON or incomplete lines */ }
+      }
+      reject(new Error(`No response for id=2 in output:\n${stdout.slice(0, 2000)}`));
+    });
+
+    // MCP handshake: initialize → initialized notification → method call
+    const init: Record<string, unknown> = {
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.1" },
+      },
+    };
+    const notify: Record<string, unknown> = {
+      jsonrpc: "2.0", method: "notifications/initialized", params: {},
+    };
+    const call: Record<string, unknown> = { jsonrpc: "2.0", id: 2, method, params };
+
+    child.stdin.write(JSON.stringify(init) + "\n");
+    child.stdin.write(JSON.stringify(notify) + "\n");
+    child.stdin.write(JSON.stringify(call) + "\n");
+    child.stdin.end();
+
+    setTimeout(() => { child.kill(); reject(new Error(`MCP call timeout: ${method}`)); }, 15_000);
+  });
+}
+
+// --- tools/list ---
+
+test("tools/list without SIMMER_API_KEY returns exactly 3 free tools", async () => {
+  const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "" });
+  assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
+  const tools = (resp.result?.tools ?? []) as Array<{ name: string }>;
+  assert.equal(tools.length, 3, `Expected 3 tools, got ${tools.length}: ${tools.map((t) => t.name).join(", ")}`);
+  const names = tools.map((t) => t.name);
+  assert.ok(names.includes("list_skills"), "list_skills missing");
+  assert.ok(names.includes("get_skill_docs"), "get_skill_docs missing");
+  assert.ok(names.includes("troubleshoot_error"), "troubleshoot_error missing");
+});
+
+test("tools/list with SIMMER_API_KEY returns 19+ tools (free + autoresearch + per-skill)", async () => {
+  const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "sk_test_key" });
+  assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
+  const tools = (resp.result?.tools ?? []) as Array<{ name: string }>;
+  // 3 free + 4 autoresearch + 19 bundled skills = 26
+  assert.ok(tools.length >= 19, `Expected >= 19 tools with API key, got ${tools.length}`);
+  const names = tools.map((t) => t.name);
+  // Free tools always present
+  assert.ok(names.includes("list_skills"), "list_skills missing");
+  assert.ok(names.includes("troubleshoot_error"), "troubleshoot_error missing");
+  // Autoresearch tools
+  assert.ok(names.includes("init_experiment"), "init_experiment missing");
+  assert.ok(names.includes("run_experiment"), "run_experiment missing");
+  assert.ok(names.includes("log_experiment"), "log_experiment missing");
+  assert.ok(names.includes("backtest_experiment"), "backtest_experiment missing");
+  // At least one per-skill tool
+  assert.ok(names.some((n) => n.startsWith("simmer_")), "no simmer_* per-skill tools found");
+});
+
+// --- resources/list ---
+
+test("resources/list returns at least 2 doc resources", async () => {
+  const resp = await mcpCall("resources/list", {}, { SIMMER_API_KEY: "" });
+  assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
+  const resources = (resp.result?.resources ?? []) as Array<{ uri: string; mimeType: string }>;
+  assert.ok(resources.length >= 2, `Expected >= 2 resources, got ${resources.length}`);
+  for (const r of resources) {
+    assert.ok(r.uri.startsWith("simmer://"), `unexpected URI: ${r.uri}`);
+    assert.equal(r.mimeType, "text/markdown");
+  }
+});

--- a/mcp/tests/pro-gate.test.ts
+++ b/mcp/tests/pro-gate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Pro-gating test: mock 403 from checkPro() relays cleanly as BackendError.
+ * Task 26 (SIM-2056).
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { SimmerApi } from "../dist/api.js";
+import { BackendError } from "../dist/errors.js";
+
+type FetchFn = typeof global.fetch;
+let savedFetch: FetchFn;
+
+function mockFetch(fn: FetchFn) {
+  // @ts-expect-error global override for testing
+  global.fetch = fn;
+}
+
+/**
+ * Simulates assertProForRunExperiment — the inline helper in mcp-server.ts.
+ * Extracted here so we can test the exact relay pattern without spawning a server.
+ */
+async function assertProForRunExperiment(api: SimmerApi): Promise<void> {
+  await api.checkPro();
+}
+
+/**
+ * Simulates the run_experiment handler's Pro-gate wrapper in mcp-server.ts.
+ */
+async function runExperimentGate(api: SimmerApi): Promise<{ isError?: boolean; content: Array<{ type: string; text: string }> }> {
+  try {
+    await assertProForRunExperiment(api);
+    return { content: [{ type: "text", text: "✅ Would run experiment" }] };
+  } catch (e) {
+    if (e instanceof BackendError) return e.toMcpResponse();
+    throw e;
+  }
+}
+
+describe("Pro-gate relay", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("returns BackendError MCP response when API returns 403", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "Autoresearch requires a Pro plan." }), { status: 403 })
+    );
+    const api = new SimmerApi("sk_free", "https://api.simmer.markets", "2.3.0");
+    const resp = await runExperimentGate(api);
+    assert.equal(resp.isError, true, "should be isError=true");
+    assert.match(resp.content[0].text, /Pro/i, "should mention Pro");
+    assert.match(resp.content[0].text, /simmer\.markets\/pro/i, "should include upgrade URL");
+  });
+
+  it("passes through (no error) when API returns 200 (Pro user)", async () => {
+    mockFetch(async () => new Response(JSON.stringify({ last_experiment_number: 0 }), { status: 200 }));
+    const api = new SimmerApi("sk_pro", "https://api.simmer.markets", "2.3.0");
+    const resp = await runExperimentGate(api);
+    assert.ok(!resp.isError, "should not be error for Pro user");
+    assert.match(resp.content[0].text, /Would run experiment/);
+  });
+
+  it("passes through when API is unreachable (graceful degradation)", async () => {
+    mockFetch(async () => { throw new Error("ECONNREFUSED"); });
+    const api = new SimmerApi("sk_unknown", "https://api.simmer.markets", "2.3.0");
+    const resp = await runExperimentGate(api);
+    // Network errors must not block — the Pro check is best-effort
+    assert.ok(!resp.isError, "should not error when API unreachable");
+  });
+
+  it("status_code meta is set correctly on 403 response", async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ detail: "Autoresearch requires a Pro plan." }), { status: 403 })
+    );
+    const api = new SimmerApi("sk_free", "https://api.simmer.markets", "2.3.0");
+    const resp = await runExperimentGate(api) as ReturnType<BackendError["toMcpResponse"]>;
+    assert.equal(resp._meta?.status_code, 403, "status_code should be 403");
+    assert.ok(resp._meta?.upgrade_url, "upgrade_url should be set");
+  });
+});

--- a/mcp/tests/troubleshoot.test.ts
+++ b/mcp/tests/troubleshoot.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for troubleshoot_error — live API + local pattern fallback.
+ * Task 23 (SIM-2056): port from Python simmer-mcp v0.3.0.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { troubleshootError } from "../dist/troubleshoot.js";
+
+type FetchFn = typeof global.fetch;
+let savedFetch: FetchFn;
+
+function mockFetch(fn: FetchFn) {
+  // @ts-expect-error global override for testing
+  global.fetch = fn;
+}
+
+describe("troubleshootError — local fallback patterns", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("matches insufficient balance error", async () => {
+    mockFetch(async () => { throw new Error("Network error"); });
+    const r = await troubleshootError("not enough balance");
+    assert.equal(r.matched, true);
+    assert.ok(r.fix.length > 10, "fix should be non-trivial");
+  });
+
+  it("matches rate limit error", async () => {
+    mockFetch(async () => { throw new Error("Network error"); });
+    const r = await troubleshootError("429 too many requests");
+    assert.equal(r.matched, true);
+    assert.match(r.fix, /briefing/i);
+  });
+
+  it("matches nonce error", async () => {
+    mockFetch(async () => { throw new Error("Network error"); });
+    const r = await troubleshootError("nonce too low");
+    assert.equal(r.matched, true);
+  });
+
+  it("returns matched=false for unknown error", async () => {
+    mockFetch(async () => { throw new Error("Network error"); });
+    const r = await troubleshootError("some totally unknown error xyz123");
+    assert.equal(r.matched, false);
+    assert.ok(r.fix.includes("docs.simmer.markets"), "should point to docs");
+  });
+
+  it("is case-insensitive", async () => {
+    mockFetch(async () => { throw new Error("Network error"); });
+    const r = await troubleshootError("INSUFFICIENT BALANCE in your wallet");
+    assert.equal(r.matched, true);
+  });
+});
+
+describe("troubleshootError — live API path", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("returns API response when API succeeds", async () => {
+    const apiResult = { matched: true, fix: "Fix from API", source: "llm" };
+    mockFetch(async () => new Response(JSON.stringify(apiResult), { status: 200 }));
+    const r = await troubleshootError("some error", "https://api.simmer.markets");
+    assert.equal(r.matched, true);
+    assert.equal(r.fix, "Fix from API");
+  });
+
+  it("falls back to local patterns when API returns non-200", async () => {
+    mockFetch(async () => new Response("", { status: 503 }));
+    const r = await troubleshootError("nonce already used");
+    assert.equal(r.matched, true);
+  });
+
+  it("falls back to local patterns on network timeout", async () => {
+    mockFetch(async () => { throw new Error("AbortError"); });
+    const r = await troubleshootError("rate limit exceeded");
+    assert.equal(r.matched, true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the Simmer MCP unification (SIM-2045). Builds on Phase 1 (SIM-2054, autoresearch src) and Phase 2 (SIM-2055, per-skill tools + skill discovery).

- **SimmerApi refactor** — `checkPro()` lightweight Pro probe; `backtest()` throws `BackendError` on 4xx/5xx (previously swallowed errors)
- **Per-call Pro gate** — `assertProForRunExperiment()` called at the top of `run_experiment` (Codex CRITICAL #1 fix)
- **`troubleshoot_error` tool** — ported from Python `simmer-mcp` v0.3.0: calls live `/api/sdk/troubleshoot`, falls back to 4 local patterns (balance, rate limit, nonce, daily limit)
- **Full tool wiring** — 3 free + 4 autoresearch + 19 per-skill = 26 tools total; startup log shows tier + skill count
- **MCP SDK type compat** — `McpErrorResponse`, `ToolResponse`, `InvokeSkillResponse` gain index signatures; `buildToolSchema` returns raw `ZodRawShape` (not `ZodObject`) fixing the overload error
- **`bundled-snapshots/` in npm package** — doc resources (API reference, skill reference) now ship with `npm pack`
- **CONTRIBUTING.md** — manual smoke checklist for Phase 4 publish gate
- **README.md** — install instructions, free/Pro tool tables, bundled skill list

## Changes

| File | What changed |
|---|---|
| `mcp/src/api.ts` | `checkPro()` added; `backtest()` throws `BackendError` on error |
| `mcp/src/errors.ts` | `McpErrorResponse` + index signature |
| `mcp/src/docs-tools.ts` | `ToolResponse` + index signature |
| `mcp/src/per-skill-tools.ts` | `InvokeSkillResponse` + index sig; `buildToolSchema` → `ZodRawShape` |
| `mcp/src/troubleshoot.ts` | new — `troubleshootError()` live + fallback |
| `mcp/src/mcp-server.ts` | `troubleshoot_error` tool + Pro gate wiring |
| `mcp/tests/api.test.ts` | new — `SimmerApi.checkPro()` + `backtest()` error relay |
| `mcp/tests/pro-gate.test.ts` | new — 403 relay shape, graceful degradation |
| `mcp/tests/troubleshoot.test.ts` | new — local fallback patterns + live API path |
| `mcp/tests/mcp-protocol.test.ts` | new — wire protocol: tools/list count, resources/list |
| `mcp/package.json` | `bundled-snapshots/` added to `files` |
| `mcp/CONTRIBUTING.md` | new — dev setup + manual smoke checklist |
| `mcp/README.md` | new — install + tier capabilities + skill list |

## Tests

- 104 tests, 0 failures
- `npm run build` clean (0 TypeScript errors)
- Smoke: `3 tools (no SIMMER_API_KEY)` / `26 tools (with key)` via full JSON-RPC protocol
- `npm pack --dry-run` includes `dist/`, `skills/`, `bundled-skills/`, `bundled-snapshots/`, `README.md`, `LICENSE`

## Risk tier

**B** — touches Pro gating (financial entitlement) and error relay. The `run_experiment` per-call Pro check is security-critical. Recommend `/codex review` with scrutiny on the Pro gate path.

Closes SIM-2056