### PR TITLE
feat(mcp): rename npm package to simmer-mcp

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,63 @@
+name: Publish MCP to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (pack only, no publish)"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        working-directory: mcp
+        run: npm ci
+
+      - name: Build
+        working-directory: mcp
+        run: npm run build
+
+      - name: Bundle skills
+        working-directory: mcp
+        run: npm run bundle-skills
+
+      - name: Pack simmer-mcp (dry run check)
+        working-directory: mcp
+        run: npm pack --dry-run
+
+      - name: Publish simmer-mcp
+        if: ${{ !inputs.dry_run }}
+        working-directory: mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Pack simmer-autoresearch stub (dry run check)
+        working-directory: mcp/deprecated/simmer-autoresearch
+        run: npm pack --dry-run
+
+      - name: Publish simmer-autoresearch deprecation stub
+        if: ${{ !inputs.dry_run }}
+        working-directory: mcp/deprecated/simmer-autoresearch
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Set npm deprecation notice on simmer-autoresearch
+        if: ${{ !inputs.dry_run }}
+        run: npm deprecate simmer-autoresearch "This package has been renamed to simmer-mcp. Run: npm install -g simmer-mcp"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## simmer-mcp v3.0.0 — 2026-05-19 (SIM-2072)
+
+### Breaking
+
+- **Package renamed `simmer-autoresearch` → `simmer-mcp` on npm.** Update your agent config: replace `"command": "simmer-autoresearch"` with `"command": "simmer-mcp"`, and update any `npx simmer-autoresearch` invocations to `npx simmer-mcp`. All tool names, env vars, and behavior are unchanged. The old package publishes a `simmer-autoresearch@2.99.0` deprecation stub pointing here.
+
+### Changed
+
+- MCP server `name` field updated from `"simmer-autoresearch"` to `"simmer-mcp"`.
+- Version-check fetches from `registry.npmjs.org/simmer-mcp/latest` (was `simmer-autoresearch`).
+
 ## Skills — 2026-05-19
 
 ### Fixed

--- a/mcp/CONTRIBUTING.md
+++ b/mcp/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to simmer-autoresearch (MCP)
+# Contributing to simmer-mcp (MCP)
 
 ## Development setup
 
@@ -89,5 +89,5 @@ src/
 2. Update `BUNDLED_VERSION` constant in `mcp-server.ts`
 3. Run smoke checklist above
 4. `npm pack --dry-run` to verify manifest
-5. `npm publish` (requires npm login with access to the `simmer-autoresearch` package)
+5. `npm publish` (requires npm login with access to the `simmer-mcp` package)
 6. Post announcement to `#releases`

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,13 +1,15 @@
-# simmer-autoresearch
+# simmer-mcp
 
 MCP server that gives your AI agent access to Simmer trading skill management, experiment tracking, and AI-powered market research.
 
-[![npm version](https://badge.fury.io/js/simmer-autoresearch.svg)](https://www.npmjs.com/package/simmer-autoresearch)
+[![npm version](https://badge.fury.io/js/simmer-mcp.svg)](https://www.npmjs.com/package/simmer-mcp)
+
+> **Migrating from `simmer-autoresearch`?** Run `npm install -g simmer-mcp` and update your agent config to use `simmer-mcp` as the command. Everything else is the same.
 
 ## Install
 
 ```bash
-npx simmer-autoresearch install-skill
+npx simmer-mcp install-skill
 ```
 
 This installs the `SKILL.md` for your agent runtime (OpenClaw / Hermes). For Claude Code, paste the content into your project's `CLAUDE.md`.
@@ -19,7 +21,7 @@ This installs the `SKILL.md` for your agent runtime (OpenClaw / Hermes). For Cla
   "mcpServers": {
     "simmer": {
       "command": "npx",
-      "args": ["-y", "simmer-autoresearch"],
+      "args": ["-y", "simmer-mcp"],
       "env": {
         "SIMMER_API_KEY": "sk_live_..."
       }

--- a/mcp/bundled-snapshots/docs.md
+++ b/mcp/bundled-snapshots/docs.md
@@ -2133,7 +2133,7 @@ Plugins are OpenClaw extensions that add persistent services, new commands, and 
 | **How they run**  | On a schedule (cron) or on-demand                                    | Persistent background services                                                |
 | **Published to**  | [ClawHub](https://clawhub.ai)                                        | npm                                                                           |
 | **Installed via** | `clawhub install <slug>`                                             | `openclaw plugins install <name>`                                             |
-| **Example**       | `polymarket-weather-trader` — runs every 15 min, checks NOAA, trades | `simmer-autoresearch` — continuously optimizes skill config in the background |
+| **Example**       | `polymarket-weather-trader` — runs every 15 min, checks NOAA, trades | `simmer-mcp` — continuously optimizes skill config in the background |
 
 Skills are stateless — they run, trade, exit. Plugins are stateful — they maintain connections, track state across cycles, and can inject context into your agent's decision-making.
 
@@ -2141,13 +2141,13 @@ Skills are stateless — they run, trade, exit. Plugins are stateful — they ma
 
 | Plugin                                     | Description                                                                        | Status |
 | ------------------------------------------ | ---------------------------------------------------------------------------------- | ------ |
-| [`simmer-autoresearch`](/pro/autoresearch) | Autonomous skill optimization — mutates config, measures results, keeps what works | Pro    |
+| [`simmer-mcp`](/pro/autoresearch) | Autonomous skill optimization — mutates config, measures results, keeps what works | Pro    |
 | [`simmer-reactor`](/pro/reactor)           | Real-time on-chain signal infrastructure — whale copytrading, more streams coming  | Pro    |
 
 ## Install a plugin
 
 ```bash theme={null}
-openclaw plugins install simmer-autoresearch
+openclaw plugins install simmer-mcp
 ```
 
 ## Configure a plugin
@@ -2156,7 +2156,7 @@ Plugin config lives in your OpenClaw `plugins.json`. Each plugin defines its own
 
 ```json theme={null}
 {
-  "simmer-autoresearch": {
+  "simmer-mcp": {
     "maxExperiments": 50
   }
 }
@@ -2199,7 +2199,7 @@ Your agent drives the loop — autoresearch provides the tools, your agent provi
 ## Install
 
 ```bash theme={null}
-npm install -g simmer-autoresearch
+npm install -g simmer-mcp
 ```
 
 Then add the MCP server to your agent's config:
@@ -2208,8 +2208,8 @@ Then add the MCP server to your agent's config:
   ```json OpenClaw theme={null}
   {
     "mcpServers": {
-      "simmer-autoresearch": {
-        "command": "simmer-autoresearch",
+      "simmer-mcp": {
+        "command": "simmer-mcp",
         "env": {
           "SIMMER_API_KEY": "your-api-key"
         }
@@ -2221,8 +2221,8 @@ Then add the MCP server to your agent's config:
   ```json Hermes theme={null}
   {
     "mcpServers": {
-      "simmer-autoresearch": {
-        "command": "simmer-autoresearch",
+      "simmer-mcp": {
+        "command": "simmer-mcp",
         "env": {
           "SIMMER_API_KEY": "your-api-key"
         }
@@ -2234,8 +2234,8 @@ Then add the MCP server to your agent's config:
   ```json Claude Code theme={null}
   {
     "mcpServers": {
-      "simmer-autoresearch": {
-        "command": "simmer-autoresearch",
+      "simmer-mcp": {
+        "command": "simmer-mcp",
         "env": {
           "SIMMER_API_KEY": "your-api-key"
         }
@@ -2417,7 +2417,7 @@ These endpoints power the server's sync. You don't call them directly — the MC
   | `/autoresearch status`  | Current skill, experiment count, keep rate, budget remaining, pause state |
   | `/autoresearch reset`   | Clear state and start fresh (clears pause if paused)                      |
 
-  **Upgrade to v2** — Install `simmer-autoresearch` via npm and switch to the MCP config above. v2 works with OpenClaw, Hermes, and Claude Code.
+  **Upgrade to v2** — Install `simmer-mcp` via npm and switch to the MCP config above. v2 works with OpenClaw, Hermes, and Claude Code.
 </Accordion>
 
 

--- a/mcp/deprecated/simmer-autoresearch/bin/stub.js
+++ b/mcp/deprecated/simmer-autoresearch/bin/stub.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// @ts-check
+console.error(
+  "\n⚠️  simmer-autoresearch has been renamed to simmer-mcp.\n\n" +
+  "Update your installation:\n" +
+  "  npm install -g simmer-mcp\n\n" +
+  "Update your agent config — replace:\n" +
+  '  "command": "simmer-autoresearch"\n' +
+  "with:\n" +
+  '  "command": "simmer-mcp"\n\n' +
+  "All tools, env vars, and behavior are unchanged.\n"
+);
+process.exit(1);

--- a/mcp/deprecated/simmer-autoresearch/package.json
+++ b/mcp/deprecated/simmer-autoresearch/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "simmer-autoresearch",
+  "version": "2.99.0",
+  "description": "DEPRECATED — moved to simmer-mcp. Run: npm install -g simmer-mcp",
+  "deprecated": "This package has been renamed to simmer-mcp. Run: npm install -g simmer-mcp",
+  "type": "module",
+  "bin": {
+    "simmer-autoresearch": "./bin/stub.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,23 +1,26 @@
 {
-  "name": "simmer-autoresearch",
-  "version": "2.3.0",
+  "name": "simmer-mcp",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "simmer-autoresearch",
-      "version": "2.3.0",
+      "name": "simmer-mcp",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.3"
       },
       "bin": {
-        "simmer-autoresearch": "dist/mcp-server.js"
+        "simmer-mcp": "dist/mcp-server.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
         "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=22.6.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "simmer-autoresearch",
-  "version": "2.3.0",
-  "description": "Autonomous skill optimization for Simmer — MCP server for cross-runtime experiment loops",
+  "name": "simmer-mcp",
+  "version": "3.0.0",
+  "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {
-    "simmer-autoresearch": "./dist/mcp-server.js"
+    "simmer-mcp": "./dist/mcp-server.js"
   },
   "files": [
     "dist/",
@@ -27,7 +27,8 @@
     "autoresearch",
     "prediction-markets",
     "trading",
-    "experiment-loop"
+    "experiment-loop",
+    "simmer-mcp"
   ],
   "license": "MIT",
   "engines": {

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -117,7 +117,7 @@ import { probeRuntime } from "./runtime-probe.js";
 // Bundled version
 // ---------------------------------------------------------------------------
 
-const BUNDLED_VERSION = "2.3.0";
+const BUNDLED_VERSION = "3.0.0";
 
 // ---------------------------------------------------------------------------
 // Config from environment
@@ -159,7 +159,7 @@ async function checkLatestVersion(): Promise<void> {
   try {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 3000);
-    const resp = await fetch("https://registry.npmjs.org/simmer-autoresearch/latest", {
+    const resp = await fetch("https://registry.npmjs.org/simmer-mcp/latest", {
       signal: ctrl.signal,
     });
     clearTimeout(timer);
@@ -169,7 +169,7 @@ async function checkLatestVersion(): Promise<void> {
     if (!latest) return;
     if (compareSemver(BUNDLED_VERSION, latest) >= 0) return;
     console.error(
-      `[simmer-mcp] ⚠ Update available: simmer-autoresearch ${BUNDLED_VERSION} → ${latest}. ` +
+      `[simmer-mcp] ⚠ Update available: simmer-mcp ${BUNDLED_VERSION} → ${latest}. ` +
       `Restart your agent session to pick up the latest.`,
     );
   } catch {
@@ -207,7 +207,7 @@ async function assertProForRunExperiment(api: SimmerApi): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const server = new McpServer({
-  name: "simmer-autoresearch",
+  name: "simmer-mcp",
   version: BUNDLED_VERSION,
 });
 


### PR DESCRIPTION
## Summary\n- Rename MCP npm package from `simmer-autoresearch` to `simmer-mcp` at v3.0.0\n- Update MCP server name/logging/version check and user-facing docs/changelog references\n- Add `simmer-autoresearch@2.99.0` deprecation stub package under `mcp/deprecated/simmer-autoresearch`\n\n## Tests\n- `cd mcp && npm test` — 104 pass\n- `cd mcp && npm pack --dry-run`\n- `cd mcp/deprecated/simmer-autoresearch && npm pack --dry-run`\n- `node mcp/deprecated/simmer-autoresearch/bin/stub.js` exits 1 with migration message\n- `node mcp/dist/mcp-server.js` starts and reports `simmer-mcp v3.0.0`\n\n## Notes\n- Publishing/deprecation remains manual/confirmation-gated because npm/PyPI publish and config cutover are irreversible.\n- Follow-up needed: docs repo update + MBP-13 OpenClaw config swap after package is published.\n\nRefs SIM-2072 / SIM-2076