### PR TITLE
fix(mcp): restore executable bit — simmer-mcp@3.0.1 (SIM-2099)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/mcp-server.js",
     "dev": "tsc --watch",
     "pretest": "npm run bundle-skills",
     "test": "npm run build && node --test 'tests/*.test.ts'",


### PR DESCRIPTION
`simmer-mcp@3.0.0` shipped with `dist/mcp-server.js` at mode 0644, causing PATH-based invocation to fail after `npm install -g`. The Phase 4 rename (SIM-2072) inadvertently dropped the `+x` bit.

## Changes
- `mcp/package.json`: version bump `3.0.0` → `3.0.1`; build script: `tsc` → `tsc && chmod +x dist/mcp-server.js`

## Verification
```
npm pack --dry-run  # prepack runs bundle-skills, then tsc, then chmod
tar -tvf simmer-mcp-3.0.1.tgz | grep mcp-server.js
# → -rwxr-xr-x ... package/dist/mcp-server.js  ✓
```
Confirmed on MBP-13: tarball shows mode 100755.

## Publish
After merge, Adrian publishes locally with OTP:
```bash
cd mcp && npm run build && npm publish --otp <OTP>
```
Then on MBP-13:
```bash
npm install -g simmer-mcp@3.0.1
which simmer-mcp  # should resolve without manual chmod
```

Closes SIM-2099