### PR TITLE
fix(mcp): source BUNDLED_VERSION from package.json — eliminates drift (SIM-2104)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -112,12 +112,7 @@ import { buildToolSchema, buildToolDescription, invokeSkillTool } from "./per-sk
 import { listSkills, getSkillDocs, listDocResources, readDocResource } from "./docs-tools.js";
 import { troubleshootError } from "./troubleshoot.js";
 import { probeRuntime } from "./runtime-probe.js";
-
-// ---------------------------------------------------------------------------
-// Bundled version
-// ---------------------------------------------------------------------------
-
-const BUNDLED_VERSION = "3.0.0";
+import { BUNDLED_VERSION } from "./version.js";
 
 // ---------------------------------------------------------------------------
 // Config from environment

--- a/mcp/src/version.ts
+++ b/mcp/src/version.ts
@@ -1,0 +1,24 @@
+/**
+ * Single source of truth for the package version.
+ * Reads from package.json at module load so the runtime value is always
+ * consistent with what npm publishes.
+ *
+ * SIM-2104: previously hardcoded as a literal in mcp-server.ts, which drifted
+ * from package.json during the 3.0.0 → 3.0.1 hotfix and caused the server to
+ * report the wrong version + print spurious "update available" warnings.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface PackageJson {
+  version: string;
+}
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8"),
+) as PackageJson;
+
+export const BUNDLED_VERSION: string = pkg.version;

--- a/mcp/tests/version-consistency.test.ts
+++ b/mcp/tests/version-consistency.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression test for SIM-2104: ensures BUNDLED_VERSION is sourced from
+ * package.json at runtime, not hardcoded as a literal that can drift.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BUNDLED_VERSION } from "../dist/version.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test("BUNDLED_VERSION matches package.json version", () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8"),
+  );
+  assert.equal(BUNDLED_VERSION, pkg.version);
+});
+
+test("BUNDLED_VERSION is a non-empty semver-shaped string", () => {
+  assert.ok(typeof BUNDLED_VERSION === "string", "BUNDLED_VERSION should be a string");
+  assert.ok(BUNDLED_VERSION.length > 0, "BUNDLED_VERSION should be non-empty");
+  assert.match(BUNDLED_VERSION, /^\d+\.\d+\.\d+/, "BUNDLED_VERSION should start with semver MAJOR.MINOR.PATCH");
+});


### PR DESCRIPTION
## Summary

`mcp/src/mcp-server.ts:120` had `const BUNDLED_VERSION = "3.0.0"` hardcoded. `package.json` is at 3.0.1. Two consequences for every 3.0.1 install today:

1. MCP `initialize` handshake reports `serverInfo.version = "3.0.0"` (verified on MBP-13)
2. Boot-time `checkLatestVersion()` prints `⚠ Update available: simmer-mcp 3.0.0 → 3.0.1` because it compares the literal against the npm registry, even though the install IS 3.0.1

This PR removes the drift class entirely by sourcing the version from package.json at module load.

## Changes
- **New `mcp/src/version.ts`** — reads package.json, exports `BUNDLED_VERSION`. Single source of truth.
- **`mcp/src/mcp-server.ts`** — replaces the literal with `import { BUNDLED_VERSION } from "./version.js"`
- **New `mcp/tests/version-consistency.test.ts`** — 2 regression tests: asserts BUNDLED_VERSION matches package.json and is a non-empty semver-prefixed string
- **`mcp/package.json`** — bumps to 3.0.2

## Test plan
- [x] `npm test` — 106 pass (104 prior + 2 new)
- [x] Manual MCP `initialize` handshake on freshly-built binary → server reports `simmer-mcp 3.0.2`
- [ ] After merge, publish 3.0.2 via OTP, install on MBP-13, verify handshake + no spurious update warning

## Followup
Closes SIM-2104. Once 3.0.2 is published, the boot-time update notice will only fire when an actual newer version exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)