### PR TITLE
chore(mcp): sync package-lock.json to 3.0.2

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simmer-mcp",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simmer-mcp",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Lockfile drifted from package.json during the 3.0.0 → 3.0.2 hotfix sequence — neither #104 nor #105 regenerated it. Doesn't affect what shipped to npm but in-repo state was inconsistent. 
up to date, audited 61 packages in 14s

10 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities to sync. Two-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)