### PR TITLE
fix(install): detect and warn on corrupted SIMMER_API_KEY (SIM-2118)

### DIFF
--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -127,6 +127,8 @@ const simmer = apiKey ? new SimmerApi(apiKey, apiUrl, BUNDLED_VERSION) : null;
 
 if (!apiKey) {
   console.error("[simmer-mcp] No SIMMER_API_KEY set — only free tools available (list_skills, get_skill_docs, troubleshoot_error).");
+} else if (!apiKey.startsWith("sk_live_")) {
+  console.error("[simmer-mcp] WARNING: SIMMER_API_KEY does not start with sk_live_ — key may be corrupted. Common cause: clipboard contamination during install (pbpaste reading the install command instead of the key). Inspect via: printenv SIMMER_API_KEY | cut -c1-20");
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -177,6 +177,7 @@ The auto risk monitor (stop-loss, take-profit) is configured at simmer.markets/d
 - **"External wallet requires a pre-signed order"** → key not configured. For OWS: `ows wallet list` to verify the wallet exists. For external: confirm `WALLET_PRIVATE_KEY` is set.
 - **"insufficient allowance"** → run `client.set_approvals()` once per wallet.
 - **Balance shows $0 but funds visible elsewhere** → check chain (Polygon vs Solana) and token (pUSD vs USDC.e). See dashboard migration tool for V2 conversion.
+- **API key format wrong / 401 with a key that "looks set"** → inspect the raw value: `printenv SIMMER_API_KEY | cut -c1-20`. Must start with `sk_live_`. A common silent failure: install commands that use `pbpaste` or similar clipboard-read primitives write the *install command text itself* as the key value when the user copies the command after copying the key. Fix: get a fresh key from simmer.markets/dashboard, then `export SIMMER_API_KEY="sk_live_..."` (type/paste the key directly, never pipe from clipboard into the variable assignment).
 
 ## Links
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -50,8 +50,10 @@ curl -X POST https://api.simmer.markets/api/sdk/agents/register \
 Response includes `api_key`, `claim_url`, and 10,000 $SIM starting balance for paper trading.
 
 ```bash
-export SIMMER_API_KEY="sk_live_..."
+export SIMMER_API_KEY="sk_live_..."   # paste your actual key here
 pip install simmer-sdk
+# Verify the key loaded correctly (catches clipboard contamination):
+[[ "$SIMMER_API_KEY" == sk_live_* ]] || echo "WARNING: SIMMER_API_KEY should start with sk_live_ — re-set the key"
 ```
 
 ### 2. Send your human the claim link


### PR DESCRIPTION
## Problem
Silent clipboard contamination corrupts the API key during install. User copies API key → copies install command → clipboard now holds command text. Any install command reading from clipboard (pbpaste) bakes the command text as the key value. SDK accepts it, all API calls 401, no obvious diagnosis.

Confirmed on herman-v3 (2026-05-20): SIMMER_API_KEY was 61 chars starting with `pbpaste ` instead of 72 chars starting with `sk_live_`.

## Changes

**`skills/simmer/SKILL.md`** — `sk_live_` format validation check inline in Quick start

**`skills/simmer-wallet-setup/SKILL.md`** — troubleshooting entry: inspect raw key, explain pbpaste contamination, fix recipe

**`mcp/src/mcp-server.ts`** — startup warning when SIMMER_API_KEY exists but doesn't start with `sk_live_`

## Grep sweep
No `pbpaste|wl-paste|xclip|xsel` in any public-facing install docs. Sweep clean.

Closes SIM-2118