### PR TITLE
fix(mcp): resolve Python from SIMMER_MCP_PYTHON/PATH instead of literal python3 (SIM-2133)

### DIFF
--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -664,7 +664,7 @@ async function main() {
   // Runtime probe (startup diagnostic)
   const probe = await probeRuntime();
   const probeLines = [
-    `python3: ${probe.python3.detected ? `v${probe.python3.version}` : `not found (${probe.python3.installHint})`}`,
+    `python3: ${probe.python3.detected ? `v${probe.python3.version} (${probe.python3.path})` : `not found at ${probe.python3.path} (${probe.python3.installHint})`}`,
     `simmer-sdk: ${probe.simmerSdk.detected ? `v${probe.simmerSdk.version}` : `not installed (${probe.simmerSdk.installHint})`}`,
     `git: ${probe.git.detected ? `v${probe.git.version}` : `not found`}`,
   ].join(" | ");

--- a/mcp/src/per-skill-tools.ts
+++ b/mcp/src/per-skill-tools.ts
@@ -10,6 +10,7 @@ import { filterBlockedFlags } from "./blocked-flags.js";
 import { buildEnv, envToArgName } from "./env-translation.js";
 import { parseSkillOutput } from "./output-parsing.js";
 import { runSkillProcess } from "./skill-runner.js";
+import { resolvePythonBin } from "./runtime-probe.js";
 
 function tunableToZod(t: Tunable): ZodType<unknown> {
   if (t.type === "number") {
@@ -110,7 +111,7 @@ export async function invokeSkillTool(
   const timeoutMs = Math.min(Math.max(timeoutS * 1000, 1000), MAX_TIMEOUT_MS);
 
   const result = await runSkillProcess({
-    file: "python3",
+    file: await resolvePythonBin(options.processEnv),
     args: argv,
     env,
     timeoutMs,

--- a/mcp/src/runtime-probe.ts
+++ b/mcp/src/runtime-probe.ts
@@ -24,15 +24,50 @@ function runQuick(file: string, args: string[]): Promise<{ exitCode: number; std
   });
 }
 
+/**
+ * Resolve the Python binary to use, in priority order:
+ *   1. SIMMER_MCP_PYTHON env var (explicit override — always checked first)
+ *   2. `python` on the caller's PATH (active venv, pipx, etc.)
+ *   3. `python3` on the caller's PATH
+ *   4. Literal `python3` fallback
+ *
+ * The `which`-based PATH resolution is cached after the first call.
+ * SIMMER_MCP_PYTHON is always evaluated fresh so it can be overridden at runtime.
+ */
+let _whichResolved: string | undefined;
+
+export async function resolvePythonBin(
+  processEnv: Record<string, string | undefined> = process.env,
+): Promise<string> {
+  // 1. Explicit override — always wins, no caching
+  const explicit = processEnv.SIMMER_MCP_PYTHON;
+  if (explicit) return explicit;
+
+  // 2/3/4. PATH resolution — cached after first call
+  if (_whichResolved !== undefined) return _whichResolved;
+
+  for (const name of ["python", "python3"]) {
+    const which = await runQuick("which", [name]);
+    if (which.exitCode === 0 && which.stdout) {
+      _whichResolved = which.stdout;
+      return _whichResolved;
+    }
+  }
+
+  _whichResolved = "python3";
+  return _whichResolved;
+}
+
 export async function probeRuntime(): Promise<RuntimeProbeResult> {
-  const py = await runQuick("python3", ["--version"]);
+  const pythonBin = await resolvePythonBin();
+  const py = await runQuick(pythonBin, ["--version"]);
   const python3: ProbeResult = py.exitCode === 0
-    ? { detected: true, version: py.stdout.replace(/^Python /, "") }
-    : { detected: false, installHint: "Install: brew install python@3.11 (macOS) or apt install python3 (Debian/Ubuntu)" };
+    ? { detected: true, version: py.stdout.replace(/^Python /, ""), path: pythonBin }
+    : { detected: false, path: pythonBin, installHint: "Install: brew install python@3.11 (macOS) or apt install python3 (Debian/Ubuntu)" };
 
   let simmerSdk: ProbeResult = { detected: false, installHint: "Install: pip install simmer-sdk>=0.13.0" };
   if (python3.detected) {
-    const sdk = await runQuick("python3", ["-c", "import simmer_sdk; print(simmer_sdk.__version__)"]);
+    const sdk = await runQuick(pythonBin, ["-c", "import simmer_sdk; print(simmer_sdk.__version__)"]);
     if (sdk.exitCode === 0) {
       simmerSdk = { detected: true, version: sdk.stdout };
     }

--- a/mcp/tests/runtime-probe.test.ts
+++ b/mcp/tests/runtime-probe.test.ts
@@ -1,12 +1,17 @@
-import { test } from "node:test";
+import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { probeRuntime } from "../src/runtime-probe.ts";
+import { probeRuntime, resolvePythonBin } from "../src/runtime-probe.ts";
+
+// Reset module-level cache between resolution tests via the exported function
+// by passing a fresh processEnv each time (cache key is implicit — reset by
+// reimporting; instead we test determinism of each resolution path directly).
 
 test("probeRuntime detects python3 on this machine", async () => {
   const r = await probeRuntime();
   // python3 is required for the SDK — if missing the test environment is broken
-  assert.ok(r.python3.detected, `python3 not found: ${r.python3.installHint}`);
+  assert.ok(r.python3.detected, `python3 not found at ${r.python3.path}: ${r.python3.installHint}`);
   assert.ok(r.python3.version, "python3.version should be set");
+  assert.ok(r.python3.path, "python3.path should be set");
 });
 
 test("probeRuntime returns ProbeResult shape for all three tools", async () => {
@@ -14,4 +19,15 @@ test("probeRuntime returns ProbeResult shape for all three tools", async () => {
   for (const key of ["python3", "simmerSdk", "git"] as const) {
     assert.equal(typeof r[key].detected, "boolean", `${key}.detected should be boolean`);
   }
+});
+
+test("resolvePythonBin honours SIMMER_MCP_PYTHON env override", async () => {
+  // Reset cache by directly testing the env-var path with a fake env object.
+  // We bypass the module cache by calling with an explicit processEnv.
+  const fakeEnv = { SIMMER_MCP_PYTHON: "/custom/venv/bin/python" };
+  // resolvePythonBin caches in module scope, so we test the env branch
+  // by verifying: if SIMMER_MCP_PYTHON is set, it is returned verbatim.
+  // (Integration-level: the function is pure for the env case before any which call.)
+  const result = await resolvePythonBin(fakeEnv as Record<string, string | undefined>);
+  assert.equal(result, "/custom/venv/bin/python", "SIMMER_MCP_PYTHON override not honoured");
 });


### PR DESCRIPTION
simmer-mcp v3.1.0 was hardcoding `python3` in both the runtime probe and skill execution, which caused it to pick up the system Python (3.9.6) instead of the caller's venv (e.g. Herman's 3.11.15 with simmer-sdk 0.17.11).

## Changes

- `mcp/src/runtime-probe.ts`: Added `resolvePythonBin()` that resolves in priority order: `SIMMER_MCP_PYTHON` env var → `which python` (active venv) → `which python3` → literal `python3` fallback. Stores resolved path in `ProbeResult.path`.
- `mcp/src/per-skill-tools.ts`: Uses `resolvePythonBin()` instead of hardcoded `"python3"` for skill execution subprocess.
- `mcp/src/mcp-server.ts`: Startup log now includes the resolved binary path, e.g. `python3: v3.11.15 (/path/to/venv/bin/python)`.
- `mcp/tests/runtime-probe.test.ts`: Added test verifying `SIMMER_MCP_PYTHON` override is honoured.

## Tests

- `npm test` — 104 tests, 0 fail
- Manual: `SIMMER_MCP_PYTHON=/Users/simmer-ops/.hermes/hermes-agent/venv/bin/python simmer-mcp` logs `v3.11.15 (.../venv/bin/python) | simmer-sdk: v0.17.11` ✅
- Manual: without override, logs `v3.9.6 (/usr/bin/python3) | simmer-sdk: v0.9.15` ✅

## Docs impact

No new API surface. Users wanting to pin a venv can set `SIMMER_MCP_PYTHON` in their MCP client config.

Closes SIM-2133