### PR TITLE
docs: per-agent wallet clarifier — README + client.py docstring (SIM-2156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ print(f"Balance: ${summary['balance']:.2f}, P&L: ${summary['total_pnl']:.2f}")
 | `get_settings()` / `update_settings()` | Configure trade limits and notifications |
 | `link_wallet()` | Link external EVM wallet for Polymarket |
 | `set_approvals()` | Set Polymarket token approvals |
+| `activate_polymarket_dw()` | Activate Polymarket Deposit Wallet signing (user-primary only — see note) |
 | `troubleshoot()` | Look up any error and get a fix (no auth required) |
+
+> **Per-agent wallets (Elite tier):** `activate_polymarket_dw()` is user-primary only. For per-agent wallets (Elite tier dedicated wallets), use `update_agent_wallet_creds(ows_wallet_name)` instead. The per-agent path requires OWS-Python (`pip install simmer-sdk[ows] open-wallet-standard`).
 
 **Error handling:** All SDK 4xx responses include a `fix` field with actionable instructions when the error matches a known pattern. You can also call `POST /api/sdk/troubleshoot` with `{"error_text": "..."}` to look up any error.
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -4339,6 +4339,10 @@ class SimmerClient:
         locally with WALLET_PRIVATE_KEY (key never leaves the process),
         then submits via /dw-approvals/submit. No browser required.
 
+        NOTE: This method handles user-primary wallets only and will 401 on a
+        per-agent SDK API key. For per-agent wallets (Elite tier dedicated
+        wallets), use ``update_agent_wallet_creds(ows_wallet_name)`` instead.
+
         Requires:
         - WALLET_PRIVATE_KEY env var (or private_key constructor arg)
         - Account upgraded to a Deposit Wallet (wallet_uses_deposit_wallet=True)


### PR DESCRIPTION
Follow-up to SIM-2117 (PR #956). Adds the Option (b) doc clarifiers that didn't block the wizard fix but should ship for internal consistency.

## Changes
- `README.md`: added `activate_polymarket_dw()` to the Key Methods table with a per-agent wallet note blockquote
- `simmer_sdk/client.py:4335`: updated `activate_polymarket_dw()` docstring with NOTE that this method is user-primary only and will 401 on a per-agent SDK key; directs to `update_agent_wallet_creds()` for per-agent path

## Tests
- `grep activate_polymarket_dw README.md simmer_sdk/client.py` — every public-facing mention now includes the per-agent caveat
- `python -c "import simmer_sdk"` — py_compile clean

Closes SIM-2156