### PR TITLE
fix: TradeResult populates shares_sold for sells (SIM-2238)

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -87,10 +87,11 @@ class TradeResult:
     market_id: str = ""
     side: str = ""
     venue: str = "sim"  # "sim", "polymarket", or "kalshi"
-    shares_bought: float = 0  # Actual shares filled (for Polymarket, assumes full fill if matched)
+    shares_bought: float = 0  # Filled shares for a BUY (0 for sells)
+    shares_sold: float = 0  # Filled shares for a SELL (0 for buys). SIM-2238.
     shares_requested: float = 0  # Shares requested (for partial fill detection)
     order_status: Optional[str] = None  # Polymarket order status: "matched", "live", "delayed"
-    cost: float = 0  # Cost in $SIM (simmer) or USDC (polymarket/kalshi)
+    cost: float = 0  # Cost for buys, proceeds for sells (always positive). $SIM (sim) or USDC (real).
     new_price: float = 0
     balance: Optional[float] = None  # Remaining $SIM balance (simmer only, None for real venues)
     error: Optional[str] = None
@@ -99,11 +100,16 @@ class TradeResult:
     fill_status: str = "unknown"  # Server fill status: "filled", "submitted", "unconfirmed", "failed"
 
     @property
+    def shares_filled(self) -> float:
+        """Filled shares regardless of buy/sell direction. SIM-2238."""
+        return self.shares_bought if self.shares_bought else self.shares_sold
+
+    @property
     def fully_filled(self) -> bool:
-        """Check if order was fully filled (shares_bought >= shares_requested)."""
+        """Check if order was fully filled (shares_filled >= shares_requested)."""
         if self.shares_requested <= 0:
             return self.success
-        return self.shares_bought >= self.shares_requested
+        return self.shares_filled >= self.shares_requested
 
 
 @dataclass
@@ -1371,6 +1377,7 @@ class SimmerClient:
                 side=d.get("side", side),
                 venue=effective_venue,
                 shares_bought=d.get("shares_bought", 0),
+                shares_sold=d.get("shares_sold", 0),  # SIM-2238
                 shares_requested=d.get("shares_requested", 0),
                 order_status=d.get("order_status"),
                 cost=d.get("cost", 0),
@@ -1511,13 +1518,16 @@ class SimmerClient:
 
         self._paper_portfolio.log_trade(market_id, side, action, shares_filled, cost, fill_price, venue=venue)
 
+        # SIM-2238: route filled shares to shares_sold for paper sells; otherwise shares_bought
+        is_sell_action = action == "sell"
         return TradeResult(
             success=True,
             trade_id=f"paper_{int(_time.time())}",
             market_id=market_id,
             side=side,
             venue=venue,
-            shares_bought=round(shares_filled, 6),
+            shares_bought=0 if is_sell_action else round(shares_filled, 6),
+            shares_sold=round(shares_filled, 6) if is_sell_action else 0,
             shares_requested=round(shares_filled, 6),
             order_status="simulated",
             cost=round(cost, 4),
@@ -3651,6 +3661,7 @@ class SimmerClient:
             side=data.get("side", side),
             venue="kalshi",
             shares_bought=data.get("shares_bought", 0) if not is_sell else 0,
+            shares_sold=data.get("shares_sold", 0) if is_sell else 0,  # SIM-2238
             shares_requested=data.get("shares_requested", 0),
             order_status=data.get("order_status"),
             cost=data.get("cost", 0),

--- a/tests/test_sim_2238_trade_result_shares_sold.py
+++ b/tests/test_sim_2238_trade_result_shares_sold.py
@@ -1,0 +1,118 @@
+"""SIM-2238 regression: TradeResult must expose shares_sold for sells.
+
+Before SIM-2238 the dataclass only carried `shares_bought`, so a SIM sell
+that filled 18.16 shares came back as `shares_bought=0, shares_sold=0,
+shares_requested=0` — leaving agents no clean field to read filled shares
+from. The server already returned `shares_sold` correctly; the SDK parser
+just ignored it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from simmer_sdk.client import SimmerClient, TradeResult
+
+
+def _make_client(venue: str = "sim") -> SimmerClient:
+    """Live-mode client with network calls stubbed out."""
+    client = SimmerClient.__new__(SimmerClient)
+    client.live = True
+    client.venue = venue
+    client._private_key = None
+    client._ows_wallet = None
+    client._solana_private_key = None
+    client._held_markets_cache = None
+    client._approvals_warned = False
+    client.ORDER_TYPES = {"FAK", "FOK", "GTC", "GTD"}
+    client.VENUES = {"sim", "polymarket", "kalshi", "simmer"}
+    return client
+
+
+def test_trade_result_dataclass_has_shares_sold():
+    """Defensive: the field must exist on the dataclass with default 0."""
+    result = TradeResult(success=True)
+    assert hasattr(result, "shares_sold")
+    assert result.shares_sold == 0
+
+
+def test_sim_sell_response_populates_shares_sold():
+    """Repro the Herman ticket fixture: SDK trade(action='sell') on sim must
+    return TradeResult.shares_sold > 0 when the server returns shares_sold."""
+    client = _make_client(venue="sim")
+
+    def fake_request(method, path, **kwargs):
+        # Mirror the actual server response shape from local_dev_server.py
+        # for a successful SIM sell (line ~23999 onwards).
+        return {
+            "success": True,
+            "trade_id": "fa8ecd64-7996-4f88-a8de-0e734cfb3cc7",
+            "market_id": "58ed726b-a2ec-4223-872c-f6093bc62f35",
+            "side": "no",
+            "shares_sold": 18.163220084084266,  # server emits positive
+            "shares_requested": 18.14477,
+            "cost": 10.020337752821433,  # proceeds for a sell
+            "new_price": 0.448878689513781,
+            "position": {"sim_balance": 9990.02},
+            "fill_status": "filled",
+        }
+
+    client._request = fake_request
+    result = client.trade(
+        market_id="58ed726b-a2ec-4223-872c-f6093bc62f35",
+        side="no",
+        action="sell",
+        shares=18.14477,
+    )
+    assert result.success
+    assert result.shares_sold == pytest.approx(18.163220084084266)
+    assert result.shares_bought == 0
+    assert result.cost == pytest.approx(10.020337752821433)
+
+
+def test_shares_filled_property_works_for_sells():
+    """The shares_filled property returns the relevant filled count regardless
+    of direction — agents can use it without branching on action."""
+    sell = TradeResult(success=True, shares_sold=18.16)
+    assert sell.shares_filled == 18.16
+
+    buy = TradeResult(success=True, shares_bought=12.34)
+    assert buy.shares_filled == 12.34
+
+
+def test_fully_filled_property_handles_sells():
+    """fully_filled was previously buy-only — verify sells now evaluate correctly."""
+    partial_sell = TradeResult(
+        success=True, shares_sold=5.0, shares_requested=10.0
+    )
+    assert partial_sell.fully_filled is False
+
+    full_sell = TradeResult(
+        success=True, shares_sold=10.0, shares_requested=10.0
+    )
+    assert full_sell.fully_filled is True
+
+
+def test_sim_buy_response_still_populates_shares_bought():
+    """Backward compat: SIM buys must keep working unchanged."""
+    client = _make_client(venue="sim")
+
+    def fake_request(method, path, **kwargs):
+        return {
+            "success": True,
+            "trade_id": "buy_trade",
+            "market_id": "m1",
+            "side": "yes",
+            "shares_bought": 20.0,
+            "shares_requested": 20.0,
+            "cost": 10.0,
+            "new_price": 0.55,
+            "position": {"sim_balance": 9980.0},
+            "fill_status": "filled",
+        }
+
+    client._request = fake_request
+    result = client.trade(market_id="m1", side="yes", action="buy", amount=10.0)
+    assert result.success
+    assert result.shares_bought == 20.0
+    assert result.shares_sold == 0


### PR DESCRIPTION
## Summary

Mintlify already documented `result.shares_sold`, but the dataclass didn't have the field and the server-response parser ignored the server's `shares_sold` value. Symptom from Herman dogfood 2026-05-21: a SIM sell that filled 18.16 shares returned `shares_bought=0, shares_sold=0, shares_requested=0` — no clean field to read filled shares from.

Companion to backend PR https://github.com/SupaFund/simmer/pull/996.

## Changes

- Add `shares_sold: float = 0` to `TradeResult` dataclass (was already documented in `simmer-docs/sdk/overview.mdx:79`).
- Read `shares_sold` from server response in:
  - The primary trade() response parser (`_build_result` closure at `client.py:1373`).
  - The paper-trading happy path (`client.py:1521` — was setting `shares_bought` for sells too).
  - The Kalshi BYOW happy path (`client.py:3654` — `shares_bought` was correctly 0 for sells but `shares_sold` was never populated).
- Add `shares_filled` property — direction-agnostic count for agents that don't want to branch on action.
- Fix `fully_filled` to compare against `shares_filled` instead of `shares_bought`, so sells evaluate correctly.

## Test plan

- [x] `pytest tests/test_sim_2238_trade_result_shares_sold.py` — 5/5 pass:
  - Dataclass has the field with default 0.
  - SIM sell response (Herman fixture: 18.16 shares filled, $10.02 proceeds) populates `shares_sold` correctly.
  - `shares_filled` resolves to the right field for both buys and sells.
  - `fully_filled` works for partial + full sells.
  - SIM buy backward-compat: `shares_bought` still populated, `shares_sold` stays 0.
- [x] Full SDK suite: 304 pass / 4 pre-existing OWS-config failures unrelated to this change.

## Compatibility

Additive only. `shares_bought` semantics unchanged. No SDK version bump required, but should ship to PyPI alongside the backend deploy so Herman picks up the fix end-to-end.

Refs SIM-2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)