### PR TITLE
feat(sdk): add client.preflight() pre-trade readiness check (SIM-2237)

### DIFF
--- a/simmer_sdk/__init__.py
+++ b/simmer_sdk/__init__.py
@@ -59,6 +59,7 @@ from .client import (
     TradeResult,
     RealTradeResult,
     PolymarketOrderParams,
+    PreflightResult,
 )
 from .paper import PaperPortfolio
 from .approvals import (
@@ -89,6 +90,7 @@ __all__ = [
     "TradeResult",
     "RealTradeResult",
     "PolymarketOrderParams",
+    "PreflightResult",
     "PaperPortfolio",
     # Polymarket approvals
     "get_required_approvals",

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -113,6 +113,43 @@ class TradeResult:
 
 
 @dataclass
+class PreflightResult:
+    """Structured result of a pre-trade readiness check.
+
+    Log ``client_preflight_id`` in your trade ledger before order submission.
+    Check ``ok_to_trade`` first; if False, ``blockers`` contains codes that
+    explain why trading is unsafe.
+
+    Blocker codes (v0):
+        EXPOSURE_CAP_EXCEEDED  — open_exposure_total + planned_amount > exposure_cap_usd
+        EXPOSURE_UNKNOWN       — real venue + active cap but positions fetch failed (fail-closed)
+        WALLET_UNVERIFIED      — real venue requested but agent not real-trading-enabled
+        VENUE_UNSUPPORTED      — venue string not recognised by the SDK
+        INSUFFICIENT_GAS       — gas signal detected in risk_alerts (v0 proxy; no on-chain query)
+
+    ``gas_balance`` is None in v0 — on-chain RPC query is deferred to v1.
+    ``warnings`` are non-blocking advisories (fetch failures, skipped checks).
+    """
+    client_preflight_id: str
+    agent_id: Optional[str]
+    tier: Optional[str]
+    resolved_venue: str
+    execution_wallet: Optional[str]
+    deposit_wallet: Optional[str]
+    signer_status: str  # "ows" | "external_key" | "managed" | "unknown"
+    spendable_balance: Optional[float]
+    gas_balance: Optional[float]
+    open_exposure_total: float
+    exposure_cap_usd: float
+    planned_amount: float
+    would_exceed_cap: bool
+    pending_alerts: List[dict]
+    ok_to_trade: bool
+    blockers: List[str]
+    warnings: List[str]
+
+
+@dataclass
 class PolymarketOrderParams:
     """Order parameters for Polymarket CLOB execution."""
     token_id: str
@@ -753,6 +790,218 @@ class SimmerClient:
                 print(f"[SimmerSDK] Update available: {upd['slug']} {upd['current']} -> {upd['latest']} — run: clawhub install {upd['slug']}")
 
         return response
+
+    def preflight(
+        self,
+        venue: Optional[str] = None,
+        planned_amount: float = 0.0,
+        exposure_cap_usd: float = 100.0,
+    ) -> "PreflightResult":
+        """Run a pre-trade readiness check without signing or mutating state.
+
+        Composes identity, wallet, balance, and exposure data from three
+        read-only SDK endpoints. Safe to call before every real-money trade.
+
+        Args:
+            venue: Trading venue to check ("sim", "polymarket", "kalshi").
+                   Defaults to this client's configured venue.
+            planned_amount: Planned trade size in USD (USDC for real venues,
+                           $SIM for sim). Used with exposure_cap_usd to check
+                           whether this trade would exceed your cap.
+                           Pass 0.0 to skip cap math.
+            exposure_cap_usd: Your maximum allowed total open exposure in USD
+                             across real venues (polymarket + kalshi). The cap
+                             is applied to the sum of current_value across all
+                             non-sim positions plus planned_amount. Pass 0.0
+                             to disable. Default: 100.0 ($100 USDC).
+
+        Returns:
+            PreflightResult — check ``ok_to_trade`` and ``blockers`` before
+            submitting. Log ``client_preflight_id`` in your trade ledger for
+            audit correlation.
+
+        Example::
+
+            result = client.preflight(
+                venue="polymarket",
+                planned_amount=5,
+                exposure_cap_usd=100,
+            )
+            if not result.ok_to_trade:
+                print(f"Cannot trade: {result.blockers}")
+                return
+            ledger.record(result.client_preflight_id)
+        """
+        import uuid as _uuid
+
+        client_preflight_id = str(_uuid.uuid4())
+
+        # Resolve and normalise venue
+        resolved_venue = venue or self.venue
+        if resolved_venue in ("simmer", "sandbox"):
+            resolved_venue = "sim"
+
+        blockers: List[str] = []
+        warnings_list: List[str] = []
+
+        # ── Signer status from client-side state ──────────────────────────
+        if self._ows_wallet:
+            signer_status = "ows"
+        elif self._private_key:
+            signer_status = "external_key"
+        elif self._solana_key_available and resolved_venue == "kalshi":
+            signer_status = "external_key"
+        else:
+            signer_status = "managed"
+
+        # ── Agent identity from /api/sdk/agents/me ────────────────────────
+        agent_id: Optional[str] = None
+        tier: Optional[str] = None
+        real_trading_enabled = False
+        execution_wallet = self._wallet_address
+        deposit_wallet = self._deposit_wallet_address
+
+        try:
+            me = self._request("GET", "/api/sdk/agents/me")
+            agent_id = me.get("agent_id")
+            _rl = me.get("rate_limits") or {}
+            tier = _rl.get("tier")
+            real_trading_enabled = bool(me.get("real_trading_enabled"))
+
+            # Per-agent OWS wallet takes priority over user-primary wallet.
+            # This prevents the SIM-2130 parent-user identity leak: for a
+            # per-agent API key, agents/me returns per_agent_wallet_address
+            # (the OWS EOA) rather than the parent user's wallet_address.
+            _per_agent_wallet = me.get("per_agent_wallet_address")
+            if _per_agent_wallet:
+                execution_wallet = _per_agent_wallet
+                deposit_wallet = me.get("per_agent_deposit_wallet_address")
+            else:
+                if not execution_wallet:
+                    execution_wallet = me.get("wallet_address")
+                if not deposit_wallet:
+                    deposit_wallet = me.get("deposit_wallet_address")
+        except Exception as _e:
+            warnings_list.append(f"identity_fetch_failed: {_e}")
+
+        # ── Venue support ─────────────────────────────────────────────────
+        _SUPPORTED_VENUES = ("sim", "polymarket", "kalshi")
+        if resolved_venue not in _SUPPORTED_VENUES:
+            blockers.append("VENUE_UNSUPPORTED")
+        elif resolved_venue in ("polymarket", "kalshi"):
+            if not real_trading_enabled:
+                blockers.append("WALLET_UNVERIFIED")
+            elif resolved_venue == "polymarket" and not execution_wallet:
+                blockers.append("WALLET_UNVERIFIED")
+            elif resolved_venue == "kalshi" and not self._solana_key_available:
+                blockers.append("WALLET_UNVERIFIED")
+
+        # ── Briefing: balances + risk alerts ──────────────────────────────
+        spendable_balance: Optional[float] = None
+        pending_alerts: List[dict] = []
+        _briefing_sim_exposure: float = 0.0
+        _has_briefing_sim_exposure = False
+
+        try:
+            briefing = self._request("GET", "/api/sdk/briefing")
+
+            # Normalise risk alerts to list[dict]
+            for _a in (briefing.get("risk_alerts") or []):
+                if isinstance(_a, str):
+                    pending_alerts.append({"message": _a})
+                elif isinstance(_a, dict):
+                    pending_alerts.append(_a)
+
+            _venues = briefing.get("venues") or {}
+            if resolved_venue == "sim":
+                _sv = _venues.get("sim") or {}
+                spendable_balance = _sv.get("cash_balance") or _sv.get("balance")
+                # Exposure fallback: portfolio_value − cash_balance = open positions
+                _pv = _sv.get("portfolio_value")
+                _cb = _sv.get("cash_balance")
+                if _pv is not None and _cb is not None:
+                    _briefing_sim_exposure = max(0.0, float(_pv) - float(_cb))
+                    _has_briefing_sim_exposure = True
+            elif resolved_venue == "polymarket":
+                _pm = _venues.get("polymarket") or {}
+                spendable_balance = _pm.get("balance")
+            elif resolved_venue == "kalshi":
+                _kal = _venues.get("kalshi") or {}
+                spendable_balance = _kal.get("balance")
+        except Exception as _e:
+            warnings_list.append(f"briefing_fetch_failed: {_e}")
+
+        # ── Positions: precise open exposure ──────────────────────────────
+        open_exposure_total = 0.0
+        _positions_ok = False
+
+        try:
+            _pos_data = self._request("GET", "/api/sdk/positions")
+            _positions = _pos_data.get("positions") or []
+
+            # Sum current_value by real vs sim venue so the cap check operates
+            # on the right currency domain. $SIM (virtual) never counts toward
+            # a USD cap; real positions (polymarket, kalshi) always count.
+            _real_exp = sum(
+                float(p.get("current_value") or 0)
+                for p in _positions
+                if p.get("venue") not in (None, "sim")
+            )
+            _sim_exp = sum(
+                float(p.get("current_value") or 0)
+                for p in _positions
+                if p.get("venue") in (None, "sim")
+            )
+            open_exposure_total = _sim_exp if resolved_venue == "sim" else _real_exp
+            _positions_ok = True
+        except Exception as _e:
+            warnings_list.append(f"positions_fetch_failed: {_e}")
+            # Fallback: briefing portfolio_value for sim venue only.
+            # For real venues with an active cap, unknown exposure is unsafe —
+            # block rather than silently assume zero open positions.
+            if _has_briefing_sim_exposure and resolved_venue == "sim":
+                open_exposure_total = _briefing_sim_exposure
+            elif resolved_venue not in (None, "sim") and exposure_cap_usd > 0:
+                blockers.append("EXPOSURE_UNKNOWN")
+
+        # ── Exposure cap ──────────────────────────────────────────────────
+        would_exceed_cap = False
+        if exposure_cap_usd > 0:
+            if open_exposure_total + planned_amount > exposure_cap_usd:
+                would_exceed_cap = True
+                blockers.append("EXPOSURE_CAP_EXCEEDED")
+
+        # ── Gas balance (v0: deferred — no on-chain RPC in SDK client) ────
+        gas_balance: Optional[float] = None
+        # Proxy: check risk_alerts for gas/POL signals from the server.
+        for _alert in pending_alerts:
+            _msg = (_alert.get("message") or "").lower() if isinstance(_alert, dict) else str(_alert).lower()
+            if "gas" in _msg or ("pol" in _msg and "polymarket" not in _msg):
+                if "INSUFFICIENT_GAS" not in blockers:
+                    blockers.append("INSUFFICIENT_GAS")
+                break
+
+        ok_to_trade = len(blockers) == 0
+
+        return PreflightResult(
+            client_preflight_id=client_preflight_id,
+            agent_id=agent_id,
+            tier=tier,
+            resolved_venue=resolved_venue,
+            execution_wallet=execution_wallet,
+            deposit_wallet=deposit_wallet,
+            signer_status=signer_status,
+            spendable_balance=spendable_balance,
+            gas_balance=gas_balance,
+            open_exposure_total=round(open_exposure_total, 6),
+            exposure_cap_usd=exposure_cap_usd,
+            planned_amount=planned_amount,
+            would_exceed_cap=would_exceed_cap,
+            pending_alerts=pending_alerts,
+            ok_to_trade=ok_to_trade,
+            blockers=blockers,
+            warnings=warnings_list,
+        )
 
     def _get_clob_client(self):
         """Get or create an authenticated ClobClient for local CLOB operations."""

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -136,7 +136,7 @@ class PreflightResult:
     resolved_venue: str
     execution_wallet: Optional[str]
     deposit_wallet: Optional[str]
-    signer_status: str  # "ows" | "external_key" | "managed" | "unknown"
+    signer_status: str  # "ows" | "external_key" | "managed"
     spendable_balance: Optional[float]
     gas_balance: Optional[float]
     open_exposure_total: float

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -74,7 +74,7 @@ ledger.record({
 | `resolved_venue` | str | Normalised venue: "sim" / "polymarket" / "kalshi" |
 | `execution_wallet` | str \| None | EOA that signs trades (per-agent OWS wallet for Elite per-agent callers) |
 | `deposit_wallet` | str \| None | Deposit wallet address (DW cohort only; None for Cohort A) |
-| `signer_status` | str | "ows" / "external_key" / "managed" / "unknown" |
+| `signer_status` | str | "ows" / "external_key" / "managed" |
 | `spendable_balance` | float \| None | Venue balance: pUSD/USDC (real) or $SIM (sim) |
 | `gas_balance` | float \| None | POL / SOL for gas — None in v0 (deferred to v1) |
 | `open_exposure_total` | float | Sum of `current_value` across open positions (real venues only when cap is USD) |
@@ -94,6 +94,7 @@ ledger.record({
 | `WALLET_UNVERIFIED` | Real venue requested but `real_trading_enabled` is False, or no wallet configured | Claim agent + link wallet in dashboard |
 | `VENUE_UNSUPPORTED` | Venue string not recognised | Use "sim", "polymarket", or "kalshi" |
 | `INSUFFICIENT_GAS` | Gas signal detected in risk_alerts (proxy only in v0) | Fund wallet with POL / SOL |
+| `EXPOSURE_UNKNOWN` | Real venue + active cap, but positions fetch failed — fail-closed | Check connectivity or set `exposure_cap_usd=0` to disable cap temporarily |
 
 Blockers are additive — all blocking conditions are reported, not just the first.
 

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: preflight
+version: "0.1.0"
+published: true
+description: Pre-trade readiness check for autonomous agents. One call returns wallet identity, venue status, spendable balance, open exposure, and a structured ok_to_trade verdict. Run before every real-money trade to prevent cap overruns and catch config issues before they become P&L issues.
+metadata:
+  author: "Simmer (@simmer_markets)"
+  version: "0.1.0"
+  displayName: Simmer Preflight
+  difficulty: beginner
+  primaryEnv: SIMMER_API_KEY
+  envVars:
+    - name: SIMMER_API_KEY
+      required: true
+      description: "Your Simmer SDK API key."
+---
+
+# Simmer Preflight
+
+Run `client.preflight()` before every real-money trade. One call returns:
+
+- **Who you are**: agent ID, tier, venue resolved from your API key context
+- **Which wallet will sign**: execution wallet, deposit wallet, signer mode (OWS / external key / managed)
+- **Spendable balance**: venue-specific USDC or $SIM balance from the briefing
+- **Open exposure**: sum of `current_value` across your existing positions (real venues only for USD cap)
+- **Cap check**: whether `planned_amount + open_exposure_total` exceeds your `exposure_cap_usd`
+- **Risk alerts**: any briefing risk signals (concentration, expiry, reliability)
+- **ok_to_trade**: a single boolean — True if no blockers
+
+## When to use
+
+Call preflight before every automated trade, especially:
+
+- Before the first real-money order of a run
+- Before scaling into a position beyond your initial size
+- When your heartbeat wakes up after a long sleep (state may have changed)
+
+Do not call it on every polling tick — it makes 3 API calls. Once per trade intent is correct.
+
+## Call it
+
+```python
+from simmer_sdk import SimmerClient
+
+client = SimmerClient.from_env(venue="polymarket")
+
+result = client.preflight(
+    venue="polymarket",       # venue to check (defaults to client.venue)
+    planned_amount=5.0,       # USDC you plan to spend on this trade
+    exposure_cap_usd=100.0,   # your total cross-venue exposure limit
+)
+
+if not result.ok_to_trade:
+    print(f"Preflight blocked: {result.blockers}")
+    # e.g. ["EXPOSURE_CAP_EXCEEDED"]
+    return
+
+# Log for audit
+ledger.record({
+    "preflight_id": result.client_preflight_id,
+    "ok": result.ok_to_trade,
+    "exposure_before": result.open_exposure_total,
+    "planned": result.planned_amount,
+})
+```
+
+## Result fields
+
+| Field | Type | Description |
+|---|---|---|
+| `client_preflight_id` | str | UUID for your trade ledger — log before every order |
+| `agent_id` | str \| None | Agent UUID from `/api/sdk/agents/me` |
+| `tier` | str \| None | Account tier: "free" / "pro" / "elite" |
+| `resolved_venue` | str | Normalised venue: "sim" / "polymarket" / "kalshi" |
+| `execution_wallet` | str \| None | EOA that signs trades (per-agent OWS wallet for Elite per-agent callers) |
+| `deposit_wallet` | str \| None | Deposit wallet address (DW cohort only; None for Cohort A) |
+| `signer_status` | str | "ows" / "external_key" / "managed" / "unknown" |
+| `spendable_balance` | float \| None | Venue balance: pUSD/USDC (real) or $SIM (sim) |
+| `gas_balance` | float \| None | POL / SOL for gas — None in v0 (deferred to v1) |
+| `open_exposure_total` | float | Sum of `current_value` across open positions (real venues only when cap is USD) |
+| `exposure_cap_usd` | float | The cap you passed in |
+| `planned_amount` | float | The planned trade size you passed in |
+| `would_exceed_cap` | bool | True if `open_exposure_total + planned_amount > exposure_cap_usd` |
+| `pending_alerts` | list[dict] | Risk alerts from briefing (normalised to `{message: str}`) |
+| `ok_to_trade` | bool | **True if no blockers** |
+| `blockers` | list[str] | Blocker codes (see below) |
+| `warnings` | list[str] | Non-blocking advisories (fetch failures, skipped checks) |
+
+## Blocker codes (v0)
+
+| Code | Meaning | Fix |
+|---|---|---|
+| `EXPOSURE_CAP_EXCEEDED` | `open_exposure_total + planned_amount > exposure_cap_usd` | Wait for existing positions to resolve, or raise your cap |
+| `WALLET_UNVERIFIED` | Real venue requested but `real_trading_enabled` is False, or no wallet configured | Claim agent + link wallet in dashboard |
+| `VENUE_UNSUPPORTED` | Venue string not recognised | Use "sim", "polymarket", or "kalshi" |
+| `INSUFFICIENT_GAS` | Gas signal detected in risk_alerts (proxy only in v0) | Fund wallet with POL / SOL |
+
+Blockers are additive — all blocking conditions are reported, not just the first.
+
+## Per-agent caller (Elite OWS)
+
+For per-agent API keys, `execution_wallet` returns the per-agent OWS EOA — not the parent user's wallet. This is the SIM-2130 identity guarantee: the preflight returns the wallet that will actually sign the trade.
+
+```python
+result = client.preflight(venue="polymarket", planned_amount=5, exposure_cap_usd=100)
+print(result.execution_wallet)   # 0xYourAgentOWS... (not parent user's wallet)
+print(result.deposit_wallet)     # 0xYourAgentDW... (per-agent DW if activated)
+```
+
+## Exposure calculation
+
+`open_exposure_total` sums `current_value` from `/api/sdk/positions`:
+
+- For **real venues** (polymarket, kalshi): sums non-sim positions in USDC.
+- For **sim venue**: sums sim positions in $SIM.
+
+$SIM positions are never included in a USD cap check — they use virtual currency.
+
+## warnings[] vs blockers[]
+
+`blockers` stop trading. `warnings` are informational — common examples:
+
+- `briefing_fetch_failed: <error>` — balance / alerts unknown; check connectivity
+- `positions_fetch_failed: <error>` — exposure may be understated; check rate limits
+- `identity_fetch_failed: <error>` — agent ID / tier unknown; API key may be invalid
+
+If you see warnings, log them. Fetch failures on individual endpoints are gracefully handled — preflight returns best-effort data rather than throwing.
+
+## Pre-trade pattern (cookbook)
+
+```python
+import os
+from simmer_sdk import SimmerClient
+
+EXPOSURE_CAP = float(os.environ.get("EXPOSURE_CAP_USD", "100"))
+
+client = SimmerClient.from_env(venue="polymarket")
+
+def safe_trade(market_id: str, side: str, amount: float):
+    pf = client.preflight(
+        venue="polymarket",
+        planned_amount=amount,
+        exposure_cap_usd=EXPOSURE_CAP,
+    )
+    if not pf.ok_to_trade:
+        print(f"Preflight blocked ({pf.blockers}), skipping trade")
+        return None
+    if pf.warnings:
+        print(f"Preflight warnings: {pf.warnings}")
+
+    # Log preflight before order submission
+    print(f"Preflight OK — id={pf.client_preflight_id} "
+          f"exposure={pf.open_exposure_total:.2f}+{amount:.2f}/{EXPOSURE_CAP}")
+
+    return client.trade(market_id=market_id, side=side, amount=amount)
+```
+
+## Cadence
+
+Call once per trade intent — not on every poll cycle. The preflight makes 3 API calls (`/agents/me`, `/briefing`, `/positions`), each counting toward your rate limits.
+
+## Scope
+
+Preflight is read-only. It never signs, trades, redeems, or mutates settings. It is safe to call in any context including paper-trading mode (positions will reflect simulated holdings).
+
+## v0 limitations
+
+- `gas_balance` is always `None` — on-chain RPC not available in the SDK client. Use the dashboard to verify POL / SOL balance.
+- `INSUFFICIENT_GAS` is only detected if the briefing risk_alerts mention gas explicitly — not from an on-chain query.
+- Server-side `preflight_id` (stable, storable) deferred to v1.
+- MCP tool exposure deferred to v1.
+
+## Links
+
+- API reference: [docs.simmer.markets/api/preflight](https://docs.simmer.markets)
+- Wallet cohort guide: [docs.simmer.markets/wallets](https://docs.simmer.markets)

--- a/skills/preflight/clawhub.json
+++ b/skills/preflight/clawhub.json
@@ -1,0 +1,35 @@
+{
+  "emoji": "✅",
+  "primaryEnv": "SIMMER_API_KEY",
+  "requires": {
+    "env": [
+      "SIMMER_API_KEY"
+    ],
+    "pip": [
+      "simmer-sdk>=0.17.13"
+    ]
+  },
+  "envVars": [
+    {
+      "name": "SIMMER_API_KEY",
+      "required": true,
+      "description": "Your Simmer SDK API key — get from simmer.markets/dashboard"
+    },
+    {
+      "name": "TRADING_VENUE",
+      "required": false,
+      "description": "Default trading venue (sim / polymarket / kalshi). Overridden by the venue argument to client.preflight()."
+    },
+    {
+      "name": "EXPOSURE_CAP_USD",
+      "required": false,
+      "description": "Maximum total open exposure in USD across real venues. Defaults to 100.0 if not set."
+    }
+  ],
+  "cron": null,
+  "autostart": false,
+  "automaton": {
+    "managed": true,
+    "entrypoint": "preflight.py"
+  }
+}

--- a/skills/preflight/preflight.py
+++ b/skills/preflight/preflight.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Simmer Preflight — pre-trade readiness check for autonomous agents.
+
+Run this to verify wallet identity, venue status, balance, and exposure
+before submitting a real-money trade. Reads three SDK endpoints and returns
+a structured verdict without signing or mutating any state.
+
+Usage:
+    python preflight.py                        # check default venue, no planned trade
+    python preflight.py --venue polymarket     # check polymarket venue
+    python preflight.py --amount 5 --cap 100  # check $5 trade against $100 cap
+    python preflight.py --json                 # output raw JSON (for agent ledgers)
+
+Environment:
+    SIMMER_API_KEY     required  — your SDK API key
+    TRADING_VENUE      optional  — default venue (overridden by --venue)
+    EXPOSURE_CAP_USD   optional  — default cap in USD (overridden by --cap)
+
+Exit codes:
+    0  — ok_to_trade = True (no blockers)
+    1  — blocked (check stdout for blocker codes)
+    2  — configuration error (SIMMER_API_KEY missing, invalid venue)
+"""
+
+import os
+import sys
+import json
+import argparse
+from typing import Optional
+
+# Force line-buffered stdout for cron / Docker / OpenClaw environments
+sys.stdout.reconfigure(line_buffering=True)
+
+# Automaton heartbeat output — required when AUTOMATON_MANAGED=1
+AUTOMATON_MANAGED = os.environ.get("AUTOMATON_MANAGED") == "1"
+
+
+def _fmt_wallet(addr: Optional[str]) -> str:
+    if not addr:
+        return "none"
+    return addr[:10] + "…" + addr[-6:] if len(addr) > 20 else addr
+
+
+def run(
+    venue: Optional[str] = None,
+    planned_amount: float = 0.0,
+    exposure_cap_usd: Optional[float] = None,
+    as_json: bool = False,
+) -> int:
+    """Run the preflight check and return exit code (0 = ok, 1 = blocked)."""
+    api_key = os.environ.get("SIMMER_API_KEY")
+    if not api_key:
+        print("ERROR: SIMMER_API_KEY not set", file=sys.stderr)
+        return 2
+
+    _cap = exposure_cap_usd if exposure_cap_usd is not None else float(
+        os.environ.get("EXPOSURE_CAP_USD", "100")
+    )
+    _venue = venue or os.environ.get("TRADING_VENUE", "sim")
+
+    try:
+        from simmer_sdk import SimmerClient
+    except ImportError:
+        print("ERROR: simmer-sdk not installed — run: pip install simmer-sdk>=0.17.13", file=sys.stderr)
+        return 2
+
+    try:
+        client = SimmerClient(api_key=api_key, venue=_venue)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    pf = client.preflight(
+        venue=_venue,
+        planned_amount=planned_amount,
+        exposure_cap_usd=_cap,
+    )
+
+    if as_json:
+        import dataclasses
+        print(json.dumps(dataclasses.asdict(pf), indent=2))
+    else:
+        _ok = "✅ OK" if pf.ok_to_trade else "❌ BLOCKED"
+        print(f"Preflight {_ok} — id={pf.client_preflight_id}")
+        print(f"  Agent:   {pf.agent_id or 'unknown'}  tier={pf.tier or '?'}")
+        print(f"  Venue:   {pf.resolved_venue}  signer={pf.signer_status}")
+        print(f"  Wallet:  execution={_fmt_wallet(pf.execution_wallet)}  "
+              f"deposit={_fmt_wallet(pf.deposit_wallet)}")
+        if pf.spendable_balance is not None:
+            if pf.resolved_venue == "sim":
+                print(f"  Balance: {pf.spendable_balance:.4f} $SIM")
+            else:
+                print(f"  Balance: ${pf.spendable_balance:.4f}")
+        print(f"  Exposure: {pf.open_exposure_total:.4f} open"
+              f"  + {pf.planned_amount:.4f} planned"
+              f"  / {pf.exposure_cap_usd:.4f} cap")
+        if pf.blockers:
+            print(f"  Blockers: {', '.join(pf.blockers)}")
+        if pf.warnings:
+            for w in pf.warnings:
+                print(f"  Warning: {w}")
+        if pf.pending_alerts:
+            for a in pf.pending_alerts:
+                _msg = a.get("message", str(a)) if isinstance(a, dict) else str(a)
+                print(f"  Alert: {_msg}")
+
+    if AUTOMATON_MANAGED:
+        print(json.dumps({
+            "automaton": {
+                "signals": 1 if pf.ok_to_trade else 0,
+                "trades_attempted": 0,
+                "ok_to_trade": pf.ok_to_trade,
+                "blockers": pf.blockers,
+                "client_preflight_id": pf.client_preflight_id,
+            }
+        }))
+
+    return 0 if pf.ok_to_trade else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Simmer pre-trade readiness check",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--venue", default=None,
+        help="Trading venue to check (sim / polymarket / kalshi). "
+             "Defaults to TRADING_VENUE env var or 'sim'.",
+    )
+    parser.add_argument(
+        "--amount", type=float, default=0.0,
+        help="Planned trade size in USD / $SIM. Used for cap math. Default: 0.",
+    )
+    parser.add_argument(
+        "--cap", type=float, default=None,
+        help="Exposure cap in USD. Defaults to EXPOSURE_CAP_USD env or 100.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", dest="as_json",
+        help="Output full result as JSON instead of human-readable summary.",
+    )
+    args = parser.parse_args()
+
+    sys.exit(run(
+        venue=args.venue,
+        planned_amount=args.amount,
+        exposure_cap_usd=args.cap,
+        as_json=args.as_json,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/preflight/tests/test_preflight.py
+++ b/skills/preflight/tests/test_preflight.py
@@ -1,0 +1,457 @@
+"""
+Unit tests for client.preflight().
+
+All tests are pure-unit: no network calls, no SDK auth required.
+Tests cover:
+  - Per-cohort wallet identity (managed, external, per-agent OWS)
+  - Per-venue resolution (sim, polymarket, kalshi)
+  - EXPOSURE_CAP_EXCEEDED blocker
+  - WALLET_UNVERIFIED blocker (real venue, not enabled)
+  - VENUE_UNSUPPORTED blocker
+  - SIM-2130 regression: per-agent caller must NOT see parent-user identity
+  - Graceful degradation when individual endpoint calls fail
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+
+# Ensure simmer_sdk is importable from the repo root
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from simmer_sdk.client import SimmerClient, PreflightResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(
+    *,
+    private_key=None,
+    ows_wallet=None,
+    venue="sim",
+    wallet_address=None,
+    deposit_wallet_address=None,
+    uses_deposit_wallet=False,
+    solana_key=False,
+):
+    """Build a SimmerClient without network calls."""
+    client = object.__new__(SimmerClient)
+    client.api_key = "sk_live_test"
+    client.base_url = "https://api.simmer.markets"
+    client.venue = venue
+    client.live = True
+    client._private_key = private_key
+    client._ows_wallet = ows_wallet
+    client._wallet_address = wallet_address
+    client._deposit_wallet_address = deposit_wallet_address
+    client._uses_deposit_wallet = uses_deposit_wallet
+    client._solana_key_available = solana_key
+    client._solana_wallet_address = None
+    client._paper_portfolio = None
+    client._session = MagicMock()
+    client._skill_slug = None
+    client._skill_version = None
+    client._skill_dir = None
+    client._auto_redeem_enabled = True
+    client._auto_redeem_enabled_fetched_at = 0.0
+    client._wallet_ownership = None
+    client._wallet_uses_deposit_wallet = False
+    client._cohort_fetched_at = 0.0
+    client._held_markets_cache = None
+    client._held_markets_ts = 0
+    client._position_holder_cache = {}
+    client._position_holder_ts = 0
+    client._clob_client = None
+    client._market_data_cache = {}
+    client._wallet_linked = None
+    client._approvals_checked = False
+    client._agent_wallet_registered = None
+    return client
+
+
+def _agents_me(
+    *,
+    agent_id="agt_test",
+    tier="pro",
+    real_trading_enabled=True,
+    wallet_address="0xUserWallet",
+    deposit_wallet_address=None,
+    per_agent_wallet_address=None,
+    per_agent_deposit_wallet_address=None,
+    per_agent_dw_active=None,
+):
+    return {
+        "agent_id": agent_id,
+        "rate_limits": {"tier": tier},
+        "real_trading_enabled": real_trading_enabled,
+        "wallet_address": wallet_address,
+        "deposit_wallet_address": deposit_wallet_address,
+        "per_agent_wallet_address": per_agent_wallet_address,
+        "per_agent_deposit_wallet_address": per_agent_deposit_wallet_address,
+        "per_agent_dw_active": per_agent_dw_active,
+    }
+
+
+def _briefing(*, sim_balance=9000.0, pm_balance=50.0, kal_balance=None, alerts=None):
+    return {
+        "risk_alerts": alerts or [],
+        "venues": {
+            "sim": {
+                "balance": sim_balance,
+                "cash_balance": sim_balance,
+                "portfolio_value": sim_balance + 200.0,
+            },
+            "polymarket": {
+                "balance": pm_balance,
+            },
+            "kalshi": {
+                "balance": kal_balance,
+            },
+        },
+    }
+
+
+def _positions(items=None):
+    return {"positions": items or []}
+
+
+def _mock_request(client, me_resp=None, briefing_resp=None, positions_resp=None, fail=None):
+    """Patch client._request to return canned responses."""
+    def _side_effect(method, endpoint, **kwargs):
+        if fail and endpoint == fail:
+            raise RuntimeError(f"Simulated failure for {endpoint}")
+        if "/agents/me" in endpoint:
+            return me_resp or _agents_me()
+        if "/briefing" in endpoint:
+            return briefing_resp or _briefing()
+        if "/positions" in endpoint:
+            return positions_resp or _positions()
+        raise RuntimeError(f"Unexpected endpoint: {endpoint}")
+
+    client._request = _side_effect
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPreflightSigner(unittest.TestCase):
+    """Signer status detection from client-side attributes."""
+
+    def test_managed_signer(self):
+        client = _make_client()
+        _mock_request(client)
+        result = client.preflight(venue="sim")
+        self.assertEqual(result.signer_status, "managed")
+
+    def test_external_key_signer(self):
+        client = _make_client(private_key="0xdeadbeef" + "a" * 58, wallet_address="0xExt")
+        _mock_request(client)
+        result = client.preflight(venue="sim")
+        self.assertEqual(result.signer_status, "external_key")
+
+    def test_ows_signer(self):
+        client = _make_client(ows_wallet="my-agent-wallet", wallet_address="0xOWS")
+        _mock_request(client)
+        result = client.preflight(venue="sim")
+        self.assertEqual(result.signer_status, "ows")
+
+    def test_solana_signer_kalshi(self):
+        client = _make_client(solana_key=True)
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True))
+        result = client.preflight(venue="kalshi")
+        self.assertEqual(result.signer_status, "external_key")
+
+
+class TestPreflightVenueResolution(unittest.TestCase):
+    """Venue normalisation and resolution."""
+
+    def test_sim_default(self):
+        client = _make_client(venue="sim")
+        _mock_request(client)
+        result = client.preflight()
+        self.assertEqual(result.resolved_venue, "sim")
+
+    def test_simmer_normalised_to_sim(self):
+        client = _make_client(venue="simmer")
+        _mock_request(client)
+        result = client.preflight()
+        self.assertEqual(result.resolved_venue, "sim")
+
+    def test_polymarket_venue(self):
+        client = _make_client(venue="polymarket", wallet_address="0xPM")
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True))
+        result = client.preflight(venue="polymarket")
+        self.assertEqual(result.resolved_venue, "polymarket")
+
+    def test_unsupported_venue_blocker(self):
+        client = _make_client()
+        _mock_request(client)
+        result = client.preflight(venue="unknown_venue")
+        self.assertIn("VENUE_UNSUPPORTED", result.blockers)
+        self.assertFalse(result.ok_to_trade)
+
+
+class TestPreflightWalletIdentity(unittest.TestCase):
+    """Wallet identity resolution — user-primary vs per-agent OWS."""
+
+    def test_user_primary_wallet(self):
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(wallet_address="0xUserWallet"))
+        result = client.preflight(venue="sim")
+        self.assertEqual(result.execution_wallet, "0xUserWallet")
+        self.assertIsNone(result.deposit_wallet)
+
+    def test_user_primary_with_dw(self):
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(
+            wallet_address="0xUserEOA",
+            deposit_wallet_address="0xUserDW",
+        ))
+        result = client.preflight(venue="sim")
+        self.assertEqual(result.execution_wallet, "0xUserEOA")
+        self.assertEqual(result.deposit_wallet, "0xUserDW")
+
+    def test_per_agent_ows_wallet(self):
+        """SIM-2130 regression: per-agent caller must see per-agent EOA, not parent-user wallet."""
+        client = _make_client(ows_wallet="agent-wallet", wallet_address="0xAgentOWS")
+        _mock_request(client, me_resp=_agents_me(
+            wallet_address="0xParentUserWallet",       # parent-user field
+            per_agent_wallet_address="0xAgentOWS",    # per-agent field — must win
+            per_agent_deposit_wallet_address="0xAgentDW",
+            per_agent_dw_active=True,
+        ))
+        result = client.preflight(venue="polymarket", exposure_cap_usd=0)
+
+        # execution_wallet must be the per-agent OWS address, not the parent user's
+        self.assertEqual(result.execution_wallet, "0xAgentOWS")
+        self.assertNotEqual(result.execution_wallet, "0xParentUserWallet")
+        self.assertEqual(result.deposit_wallet, "0xAgentDW")
+
+    def test_per_agent_no_dw_yet(self):
+        """Per-agent wallet without activated DW: deposit_wallet is None."""
+        client = _make_client(ows_wallet="agent-wallet", wallet_address="0xAgentOWS")
+        _mock_request(client, me_resp=_agents_me(
+            per_agent_wallet_address="0xAgentOWS",
+            per_agent_deposit_wallet_address=None,
+            per_agent_dw_active=False,
+        ))
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertEqual(result.execution_wallet, "0xAgentOWS")
+        self.assertIsNone(result.deposit_wallet)
+
+
+class TestPreflightBlockers(unittest.TestCase):
+    """Blocker code detection."""
+
+    def test_exposure_cap_exceeded(self):
+        client = _make_client()
+        positions = [
+            {"venue": "polymarket", "current_value": 80.0, "market_id": "m1", "shares_yes": 10, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q1"},
+        ]
+        _mock_request(client, positions_resp=_positions(positions))
+        result = client.preflight(venue="polymarket", planned_amount=30.0, exposure_cap_usd=100.0)
+        self.assertIn("EXPOSURE_CAP_EXCEEDED", result.blockers)
+        self.assertTrue(result.would_exceed_cap)
+        self.assertFalse(result.ok_to_trade)
+
+    def test_cap_not_exceeded(self):
+        client = _make_client()
+        positions = [
+            {"venue": "polymarket", "current_value": 40.0, "market_id": "m1", "shares_yes": 10, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q1"},
+        ]
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True), positions_resp=_positions(positions))
+        result = client.preflight(venue="polymarket", planned_amount=10.0, exposure_cap_usd=100.0)
+        self.assertNotIn("EXPOSURE_CAP_EXCEEDED", result.blockers)
+        self.assertFalse(result.would_exceed_cap)
+
+    def test_wallet_unverified_real_trading_disabled(self):
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=False))
+        result = client.preflight(venue="polymarket")
+        self.assertIn("WALLET_UNVERIFIED", result.blockers)
+        self.assertFalse(result.ok_to_trade)
+
+    def test_wallet_unverified_no_wallet_address(self):
+        client = _make_client()  # no wallet_address set
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True, wallet_address=None))
+        result = client.preflight(venue="polymarket")
+        self.assertIn("WALLET_UNVERIFIED", result.blockers)
+
+    def test_no_blockers_sim_venue(self):
+        client = _make_client()
+        _mock_request(client)
+        result = client.preflight(venue="sim", planned_amount=5.0, exposure_cap_usd=100.0)
+        self.assertEqual(result.blockers, [])
+        self.assertTrue(result.ok_to_trade)
+
+    def test_multiple_blockers(self):
+        """Both EXPOSURE_CAP_EXCEEDED and WALLET_UNVERIFIED can fire together."""
+        client = _make_client()
+        positions = [
+            {"venue": "polymarket", "current_value": 95.0, "market_id": "m1", "shares_yes": 10, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q1"},
+        ]
+        _mock_request(client,
+                      me_resp=_agents_me(real_trading_enabled=False),
+                      positions_resp=_positions(positions))
+        result = client.preflight(venue="polymarket", planned_amount=10.0, exposure_cap_usd=100.0)
+        self.assertIn("WALLET_UNVERIFIED", result.blockers)
+        self.assertIn("EXPOSURE_CAP_EXCEEDED", result.blockers)
+        self.assertFalse(result.ok_to_trade)
+
+
+class TestPreflightBalance(unittest.TestCase):
+    """Spendable balance extraction per venue."""
+
+    def test_sim_cash_balance(self):
+        client = _make_client()
+        _mock_request(client, briefing_resp=_briefing(sim_balance=9500.0))
+        result = client.preflight(venue="sim")
+        self.assertEqual(result.spendable_balance, 9500.0)
+
+    def test_polymarket_usdc_balance(self):
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True),
+                      briefing_resp=_briefing(pm_balance=42.50))
+        result = client.preflight(venue="polymarket", exposure_cap_usd=0)
+        self.assertEqual(result.spendable_balance, 42.50)
+
+    def test_kalshi_balance(self):
+        client = _make_client(solana_key=True)
+        _mock_request(client,
+                      me_resp=_agents_me(real_trading_enabled=True),
+                      briefing_resp=_briefing(kal_balance=15.0))
+        result = client.preflight(venue="kalshi", exposure_cap_usd=0)
+        self.assertEqual(result.spendable_balance, 15.0)
+
+
+class TestPreflightExposure(unittest.TestCase):
+    """Open exposure calculation from positions."""
+
+    def test_sim_exposure_excludes_real_positions(self):
+        client = _make_client()
+        positions = [
+            {"venue": "sim", "current_value": 100.0, "market_id": "s1", "shares_yes": 10, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q1"},
+            {"venue": "polymarket", "current_value": 50.0, "market_id": "p1", "shares_yes": 5, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q2"},
+        ]
+        _mock_request(client, positions_resp=_positions(positions))
+        result = client.preflight(venue="sim", planned_amount=0, exposure_cap_usd=0)
+        # Sim venue exposure = sim positions only
+        self.assertAlmostEqual(result.open_exposure_total, 100.0)
+
+    def test_real_exposure_excludes_sim_positions(self):
+        client = _make_client()
+        positions = [
+            {"venue": "sim", "current_value": 200.0, "market_id": "s1", "shares_yes": 10, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q1"},
+            {"venue": "polymarket", "current_value": 30.0, "market_id": "p1", "shares_yes": 5, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q2"},
+            {"venue": "kalshi", "current_value": 20.0, "market_id": "k1", "shares_yes": 2, "shares_no": 0, "pnl": 0, "status": "active", "question": "Q3"},
+        ]
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True),
+                      positions_resp=_positions(positions))
+        result = client.preflight(venue="polymarket", planned_amount=0, exposure_cap_usd=0)
+        # Real exposure = polymarket + kalshi (not sim)
+        self.assertAlmostEqual(result.open_exposure_total, 50.0)
+
+    def test_zero_exposure_no_positions(self):
+        client = _make_client()
+        _mock_request(client, positions_resp=_positions([]))
+        result = client.preflight(venue="sim", planned_amount=0, exposure_cap_usd=0)
+        self.assertEqual(result.open_exposure_total, 0.0)
+
+
+class TestPreflightGracefulDegradation(unittest.TestCase):
+    """Partial endpoint failures produce warnings, not exceptions."""
+
+    def test_briefing_failure_adds_warning(self):
+        client = _make_client()
+        _mock_request(client, fail="/api/sdk/briefing")
+        result = client.preflight(venue="sim")
+        self.assertTrue(any("briefing_fetch_failed" in w for w in result.warnings))
+        self.assertIsNone(result.spendable_balance)
+
+    def test_positions_failure_adds_warning(self):
+        client = _make_client()
+        _mock_request(client, fail="/api/sdk/positions")
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertTrue(any("positions_fetch_failed" in w for w in result.warnings))
+
+    def test_positions_failure_real_venue_active_cap_blocks(self):
+        """Real venue + active cap + positions fetch failure must block (fail-closed)."""
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True),
+                      fail="/api/sdk/positions")
+        result = client.preflight(venue="polymarket", planned_amount=5.0, exposure_cap_usd=100.0)
+        # Should add EXPOSURE_UNKNOWN blocker — unknown real exposure is not safe
+        self.assertIn("EXPOSURE_UNKNOWN", result.blockers)
+        self.assertFalse(result.ok_to_trade)
+        # Warning should still be present too
+        self.assertTrue(any("positions_fetch_failed" in w for w in result.warnings))
+
+    def test_positions_failure_sim_venue_no_blocker(self):
+        """Sim venue positions failure with zero cap must not add EXPOSURE_UNKNOWN."""
+        client = _make_client()
+        _mock_request(client, fail="/api/sdk/positions")
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertNotIn("EXPOSURE_UNKNOWN", result.blockers)
+
+    def test_positions_failure_real_venue_cap_zero_no_blocker(self):
+        """Real venue but cap=0 (disabled) — positions failure should NOT block."""
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True),
+                      fail="/api/sdk/positions")
+        result = client.preflight(venue="polymarket", planned_amount=0, exposure_cap_usd=0)
+        self.assertNotIn("EXPOSURE_UNKNOWN", result.blockers)
+
+    def test_identity_failure_adds_warning(self):
+        client = _make_client()
+        _mock_request(client, fail="/api/sdk/agents/me")
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertTrue(any("identity_fetch_failed" in w for w in result.warnings))
+        self.assertIsNone(result.agent_id)
+
+
+class TestPreflightPendingAlerts(unittest.TestCase):
+    """Risk alerts are forwarded from briefing."""
+
+    def test_string_alert_normalised_to_dict(self):
+        client = _make_client()
+        _mock_request(client, briefing_resp=_briefing(alerts=["2 positions expiring in <6h"]))
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertEqual(len(result.pending_alerts), 1)
+        self.assertEqual(result.pending_alerts[0]["message"], "2 positions expiring in <6h")
+
+    def test_dict_alert_preserved(self):
+        client = _make_client()
+        _mock_request(client, briefing_resp=_briefing(alerts=[{"message": "Concentration: 45%", "type": "concentration"}]))
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertEqual(result.pending_alerts[0]["type"], "concentration")
+
+
+class TestPreflightUUID(unittest.TestCase):
+    """client_preflight_id is unique per call."""
+
+    def test_unique_ids(self):
+        client = _make_client()
+        _mock_request(client)
+        r1 = client.preflight(venue="sim", exposure_cap_usd=0)
+        r2 = client.preflight(venue="sim", exposure_cap_usd=0)
+        self.assertNotEqual(r1.client_preflight_id, r2.client_preflight_id)
+
+    def test_valid_uuid_format(self):
+        import uuid
+        client = _make_client()
+        _mock_request(client)
+        result = client.preflight(venue="sim", exposure_cap_usd=0)
+        # Should not raise
+        parsed = uuid.UUID(result.client_preflight_id)
+        self.assertEqual(str(parsed), result.client_preflight_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a canonical read-only preflight check for autonomous agents before order submission.

## Changes
- `simmer_sdk/client.py`: `PreflightResult` dataclass + `client.preflight()` method — composes identity/wallet/balance/exposure from 3 SDK endpoints, returns structured `ok_to_trade` verdict
- `simmer_sdk/__init__.py`: export `PreflightResult`
- `skills/preflight/preflight.py`: standalone CLI wrapper (supports `--json`, `AUTOMATON_MANAGED=1`)
- `skills/preflight/SKILL.md`: ClawHub skill doc with result field table and usage examples
- `skills/preflight/tests/test_preflight.py`: 31 unit tests covering all blocker paths, wallet identity, SIM-2130 regression, and graceful degradation

## Blocker codes
- `EXPOSURE_CAP_EXCEEDED` — `open_exposure_total + planned_amount > exposure_cap_usd`
- `WALLET_UNVERIFIED` — real venue requested but `real_trading_enabled=False` or wallet address missing
- `VENUE_UNSUPPORTED` — unrecognised venue string
- `INSUFFICIENT_GAS` — gas signal in briefing risk_alerts (v0 proxy; on-chain RPC deferred to v1)

## Tests
- 31/31 pass: `python3 -m pytest skills/preflight/tests/test_preflight.py -v`
- `py_compile` clean on all modified files

## Docs impact
- Yes: new `client.preflight()` SDK method + new `#preflight` skill — SKILL.md is included in this PR

Closes SIM-2237