### PR TITLE
feat(skills): wire client.preflight() into bundled trading skills (SIM-2312)

### DIFF
--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.6.4"
+  version: "1.6.5"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -627,7 +627,7 @@ def execute_trade(market_id, side, amount, signal_data=None):
     try:
         client = get_client()
         if client.live:
-            pf = client.preflight(planned_amount=amount, venue=client.venue)
+            pf = client.preflight(planned_amount=amount, exposure_cap_usd=0, venue=client.venue)
             if not pf.ok_to_trade:
                 blockers = ", ".join(pf.blockers)
                 print(f"  ⛔ Preflight blocked: {blockers}")

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -625,7 +625,14 @@ def get_positions():
 def execute_trade(market_id, side, amount, signal_data=None):
     """Execute a trade on Simmer."""
     try:
-        result = get_client().trade(
+        client = get_client()
+        if client.live:
+            pf = client.preflight(planned_amount=amount, venue=client.venue)
+            if not pf.ok_to_trade:
+                blockers = ", ".join(pf.blockers)
+                print(f"  ⛔ Preflight blocked: {blockers}")
+                return {"error": f"preflight_blocked: {blockers}"}
+        result = client.trade(
             market_id=market_id,
             side=side,
             amount=amount,

--- a/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
+++ b/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
@@ -1,0 +1,128 @@
+"""
+Smoke tests for the preflight gate in polymarket-fast-loop.
+
+Verifies execute_trade():
+  - returns {"error": "preflight_blocked: ..."} and does NOT call client.trade()
+    when preflight returns ok_to_trade=False
+  - calls client.trade() normally when preflight returns ok_to_trade=True
+  - skips preflight entirely in paper mode (client.live=False)
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import sys
+import os
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+# Stub simmer_sdk and simmer_sdk.skill before importing the skill module
+# (fastloop_trader imports from simmer_sdk.skill at module level)
+_mock_cfg = {
+    "entry_threshold": 0.05, "min_momentum_pct": 0.5, "max_position": 5.0,
+    "signal_source": "binance", "lookback_minutes": 5, "min_time_remaining": 0,
+    "asset": "BTC", "window": "5m", "volume_confidence": True, "daily_budget": 10.0,
+    "use_fair_value": False, "fair_value_min_edge": 0.05, "btc_annual_vol": 0.55,
+    "order_type": "GTC",
+}
+
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+
+sys.modules.setdefault("simmer_sdk", MagicMock())
+sys.modules["simmer_sdk.skill"] = _skill_stub
+
+import fastloop_trader as ft  # noqa: E402
+
+
+def _make_preflight(ok=False, blockers=None):
+    pf = MagicMock()
+    pf.ok_to_trade = ok
+    pf.blockers = blockers or ["WALLET_UNVERIFIED"]
+    return pf
+
+
+def _make_trade_result(success=True, simulated=False):
+    r = MagicMock()
+    r.success = success
+    r.trade_id = "t_test"
+    r.shares_bought = 10.0
+    r.error = None
+    r.simulated = simulated
+    return r
+
+
+class TestPreflightGateFastLoop(unittest.TestCase):
+
+    def test_blocked_returns_error_dict_and_no_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=False, blockers=["WALLET_UNVERIFIED"])
+
+        with patch.object(ft, "get_client", return_value=mock_client):
+            result = ft.execute_trade("mkt_abc", "yes", 5.0)
+
+        self.assertEqual(result, {"error": "preflight_blocked: WALLET_UNVERIFIED"})
+        mock_client.trade.assert_not_called()
+
+    def test_blocked_multiple_blockers_joined(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(
+            ok=False, blockers=["WALLET_UNVERIFIED", "VENUE_UNSUPPORTED"]
+        )
+
+        with patch.object(ft, "get_client", return_value=mock_client):
+            result = ft.execute_trade("mkt_abc", "yes", 5.0)
+
+        self.assertEqual(result["error"], "preflight_blocked: WALLET_UNVERIFIED, VENUE_UNSUPPORTED")
+        mock_client.trade.assert_not_called()
+
+    def test_preflight_ok_calls_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result(success=True)
+
+        with patch.object(ft, "get_client", return_value=mock_client):
+            result = ft.execute_trade("mkt_abc", "yes", 5.0)
+
+        mock_client.trade.assert_called_once()
+        self.assertTrue(result["success"])
+
+    def test_preflight_called_with_cap_zero(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result()
+
+        with patch.object(ft, "get_client", return_value=mock_client):
+            ft.execute_trade("mkt_abc", "yes", 7.5)
+
+        mock_client.preflight.assert_called_once_with(
+            planned_amount=7.5, exposure_cap_usd=0, venue="polymarket"
+        )
+
+    def test_paper_mode_skips_preflight(self):
+        mock_client = MagicMock()
+        mock_client.live = False
+        mock_client.venue = "polymarket"
+        mock_client.trade.return_value = _make_trade_result(simulated=True)
+
+        with patch.object(ft, "get_client", return_value=mock_client):
+            result = ft.execute_trade("mkt_abc", "yes", 5.0)
+
+        mock_client.preflight.assert_not_called()
+        self.assertTrue(result["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. Snipe markets about to resolve when the odds are heavily skewed. Filter by topic, cap your bets, and only trade strong splits close to deadline.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.0"
+  version: "1.3.1"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -173,7 +173,7 @@ def execute_trade(market_id, side, amount, reasoning=""):
     try:
         client = get_client()
         if client.live:
-            pf = client.preflight(planned_amount=amount, venue=client.venue)
+            pf = client.preflight(planned_amount=amount, exposure_cap_usd=0, venue=client.venue)
             if not pf.ok_to_trade:
                 blockers = ", ".join(pf.blockers)
                 print(f"  ⛔ Preflight blocked: {blockers}")

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -171,7 +171,14 @@ def check_context_safeguards(context):
 
 def execute_trade(market_id, side, amount, reasoning=""):
     try:
-        result = get_client().trade(
+        client = get_client()
+        if client.live:
+            pf = client.preflight(planned_amount=amount, venue=client.venue)
+            if not pf.ok_to_trade:
+                blockers = ", ".join(pf.blockers)
+                print(f"  ⛔ Preflight blocked: {blockers}")
+                return {"error": f"preflight_blocked: {blockers}"}
+        result = client.trade(
             market_id=market_id,
             side=side,
             amount=amount,

--- a/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
+++ b/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
@@ -1,0 +1,124 @@
+"""
+Smoke tests for the preflight gate in polymarket-mert-sniper.
+
+Verifies execute_trade():
+  - returns {"error": "preflight_blocked: ..."} and does NOT call client.trade()
+    when preflight returns ok_to_trade=False
+  - calls client.trade() normally when preflight returns ok_to_trade=True
+  - skips preflight entirely in paper mode (client.live=False)
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import sys
+import os
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "market_filter": "", "max_bet_usd": 10.00, "expiry_window_mins": 8,
+    "min_split": 0.60, "max_trades_per_run": 5, "sizing_pct": 0.05,
+    "order_type": "GTC", "fee_buffer": 0.02, "min_edge": 0.0,
+}
+
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+
+sys.modules.setdefault("simmer_sdk", MagicMock())
+sys.modules["simmer_sdk.skill"] = _skill_stub
+
+import mert_sniper as ms  # noqa: E402
+
+
+def _make_preflight(ok=False, blockers=None):
+    pf = MagicMock()
+    pf.ok_to_trade = ok
+    pf.blockers = blockers or ["WALLET_UNVERIFIED"]
+    return pf
+
+
+def _make_trade_result(success=True, simulated=False):
+    r = MagicMock()
+    r.success = success
+    r.trade_id = "t_test"
+    r.shares_bought = 10.0
+    r.error = None
+    r.simulated = simulated
+    return r
+
+
+class TestPreflightGateMertSniper(unittest.TestCase):
+
+    def test_blocked_returns_error_dict_and_no_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=False, blockers=["WALLET_UNVERIFIED"])
+
+        with patch.object(ms, "get_client", return_value=mock_client):
+            result = ms.execute_trade("mkt_abc", "yes", 5.0)
+
+        self.assertEqual(result, {"error": "preflight_blocked: WALLET_UNVERIFIED"})
+        mock_client.trade.assert_not_called()
+
+    def test_blocked_multiple_blockers_joined(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(
+            ok=False, blockers=["WALLET_UNVERIFIED", "VENUE_UNSUPPORTED"]
+        )
+
+        with patch.object(ms, "get_client", return_value=mock_client):
+            result = ms.execute_trade("mkt_abc", "yes", 5.0)
+
+        self.assertEqual(result["error"], "preflight_blocked: WALLET_UNVERIFIED, VENUE_UNSUPPORTED")
+        mock_client.trade.assert_not_called()
+
+    def test_preflight_ok_calls_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result(success=True)
+
+        with patch.object(ms, "get_client", return_value=mock_client):
+            result = ms.execute_trade("mkt_abc", "yes", 5.0)
+
+        mock_client.trade.assert_called_once()
+        self.assertTrue(result["success"])
+
+    def test_preflight_called_with_cap_zero(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result()
+
+        with patch.object(ms, "get_client", return_value=mock_client):
+            ms.execute_trade("mkt_abc", "yes", 8.0)
+
+        mock_client.preflight.assert_called_once_with(
+            planned_amount=8.0, exposure_cap_usd=0, venue="polymarket"
+        )
+
+    def test_paper_mode_skips_preflight(self):
+        mock_client = MagicMock()
+        mock_client.live = False
+        mock_client.venue = "polymarket"
+        mock_client.trade.return_value = _make_trade_result(simulated=True)
+
+        with patch.object(ms, "get_client", return_value=mock_client):
+            result = ms.execute_trade("mkt_abc", "yes", 5.0)
+
+        mock_client.preflight.assert_not_called()
+        self.assertTrue(result["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.21.1"
+  version: "1.21.2"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/tests/test_weathertrader_preflight_gate.py
+++ b/skills/polymarket-weather-trader/tests/test_weathertrader_preflight_gate.py
@@ -1,0 +1,170 @@
+"""
+Smoke tests for the preflight gate in polymarket-weather-trader.
+
+Verifies execute_trade() and execute_sell():
+  - returns {"error": "preflight_blocked: ..."} and does NOT call client.trade()
+    when preflight returns ok_to_trade=False
+  - calls client.trade() normally when preflight returns ok_to_trade=True
+  - skips preflight entirely in paper mode (client.live=False)
+  - execute_sell() calls preflight with planned_amount=0, exposure_cap_usd=0
+    so exit trades are never blocked by the exposure cap
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import sys
+import os
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15, "exit_threshold": 0.45, "max_position_usd": 2.00,
+    "sizing_pct": 0.05, "max_trades_per_run": 5, "locations": "NYC",
+    "binary_only": False, "slippage_max": 0.15, "min_liquidity": 0.0,
+    "order_type": "GTC", "vol_targeting": False, "target_vol": 0.20,
+    "vol_max_leverage": 2.0, "vol_min_allocation": 0.2, "vol_span": 10,
+}
+
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+
+sys.modules.setdefault("simmer_sdk", MagicMock())
+sys.modules["simmer_sdk.skill"] = _skill_stub
+
+import weather_trader as wt  # noqa: E402
+
+
+def _make_preflight(ok=False, blockers=None):
+    pf = MagicMock()
+    pf.ok_to_trade = ok
+    pf.blockers = blockers or ["WALLET_UNVERIFIED"]
+    return pf
+
+
+def _make_trade_result(success=True, simulated=False, order_status="filled"):
+    r = MagicMock()
+    r.success = success
+    r.trade_id = "t_test"
+    r.shares_bought = 10.0
+    r.error = None
+    r.simulated = simulated
+    r.order_status = order_status
+    return r
+
+
+class TestPreflightGateWeatherBuy(unittest.TestCase):
+
+    def test_blocked_returns_error_dict_and_no_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=False, blockers=["WALLET_UNVERIFIED"])
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            result = wt.execute_trade("mkt_abc", "yes", 2.0)
+
+        self.assertEqual(result, {"error": "preflight_blocked: WALLET_UNVERIFIED"})
+        mock_client.trade.assert_not_called()
+
+    def test_preflight_ok_calls_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result(success=True)
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            result = wt.execute_trade("mkt_abc", "yes", 2.0)
+
+        mock_client.trade.assert_called_once()
+        self.assertTrue(result["success"])
+
+    def test_buy_preflight_called_with_cap_zero(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result()
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            wt.execute_trade("mkt_abc", "yes", 3.0)
+
+        mock_client.preflight.assert_called_once_with(
+            planned_amount=3.0, exposure_cap_usd=0, venue="polymarket"
+        )
+
+    def test_paper_mode_skips_preflight(self):
+        mock_client = MagicMock()
+        mock_client.live = False
+        mock_client.venue = "polymarket"
+        mock_client.trade.return_value = _make_trade_result(simulated=True)
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            result = wt.execute_trade("mkt_abc", "yes", 2.0)
+
+        mock_client.preflight.assert_not_called()
+        self.assertTrue(result["success"])
+
+
+class TestPreflightGateWeatherSell(unittest.TestCase):
+
+    def test_sell_blocked_returns_error_and_no_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=False, blockers=["WALLET_UNVERIFIED"])
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            result = wt.execute_sell("mkt_abc", 10.0)
+
+        self.assertEqual(result, {"error": "preflight_blocked: WALLET_UNVERIFIED"})
+        mock_client.trade.assert_not_called()
+
+    def test_sell_preflight_uses_zero_amount_and_zero_cap(self):
+        """Sells must never be blocked by the exposure cap — always use planned_amount=0, exposure_cap_usd=0."""
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result()
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            wt.execute_sell("mkt_abc", 10.0)
+
+        mock_client.preflight.assert_called_once_with(
+            planned_amount=0, exposure_cap_usd=0, venue="polymarket"
+        )
+
+    def test_sell_ok_calls_trade(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+        mock_client.trade.return_value = _make_trade_result(success=True)
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            result = wt.execute_sell("mkt_abc", 10.0)
+
+        mock_client.trade.assert_called_once()
+        self.assertTrue(result["success"])
+
+    def test_sell_paper_mode_skips_preflight(self):
+        mock_client = MagicMock()
+        mock_client.live = False
+        mock_client.venue = "polymarket"
+        mock_client.trade.return_value = _make_trade_result(simulated=True)
+
+        with patch.object(wt, "get_client", return_value=mock_client):
+            result = wt.execute_sell("mkt_abc", 10.0)
+
+        mock_client.preflight.assert_not_called()
+        self.assertTrue(result["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -15,6 +15,8 @@ Requires:
     SIMMER_API_KEY environment variable (get from simmer.markets/dashboard)
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import re
@@ -929,7 +931,7 @@ def execute_trade(market_id: str, side: str, amount: float, reasoning: str = Non
     try:
         client = get_client()
         if client.live:
-            pf = client.preflight(planned_amount=amount, venue=client.venue)
+            pf = client.preflight(planned_amount=amount, exposure_cap_usd=0, venue=client.venue)
             if not pf.ok_to_trade:
                 blockers = ", ".join(pf.blockers)
                 print(f"  ⛔ Preflight blocked: {blockers}")
@@ -956,7 +958,7 @@ def execute_sell(market_id: str, shares: float) -> dict:
     try:
         client = get_client()
         if client.live:
-            pf = client.preflight(planned_amount=0, venue=client.venue)
+            pf = client.preflight(planned_amount=0, exposure_cap_usd=0, venue=client.venue)
             if not pf.ok_to_trade:
                 blockers = ", ".join(pf.blockers)
                 print(f"  ⛔ Preflight blocked: {blockers}")

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -927,7 +927,14 @@ def fetch_weather_markets():
 def execute_trade(market_id: str, side: str, amount: float, reasoning: str = None, signal_data: dict = None) -> dict:
     """Execute a buy trade via Simmer SDK with source tagging."""
     try:
-        result = get_client().trade(
+        client = get_client()
+        if client.live:
+            pf = client.preflight(planned_amount=amount, venue=client.venue)
+            if not pf.ok_to_trade:
+                blockers = ", ".join(pf.blockers)
+                print(f"  ⛔ Preflight blocked: {blockers}")
+                return {"error": f"preflight_blocked: {blockers}"}
+        result = client.trade(
             market_id=market_id, side=side, amount=amount, source=TRADE_SOURCE, skill_slug=SKILL_SLUG,
             reasoning=reasoning, signal_data=signal_data, order_type=ORDER_TYPE,
         )
@@ -947,7 +954,14 @@ def execute_trade(market_id: str, side: str, amount: float, reasoning: str = Non
 def execute_sell(market_id: str, shares: float) -> dict:
     """Execute a sell trade via Simmer SDK with source tagging."""
     try:
-        result = get_client().trade(
+        client = get_client()
+        if client.live:
+            pf = client.preflight(planned_amount=0, venue=client.venue)
+            if not pf.ok_to_trade:
+                blockers = ", ".join(pf.blockers)
+                print(f"  ⛔ Preflight blocked: {blockers}")
+                return {"error": f"preflight_blocked: {blockers}"}
+        result = client.trade(
             market_id=market_id, side="yes", action="sell",
             shares=shares, source=TRADE_SOURCE, skill_slug=SKILL_SLUG,
             order_type=ORDER_TYPE,


### PR DESCRIPTION
Surfaces actionable CLOB blocker messages instead of opaque rejections in all three bundled Polymarket skills — the last missing piece from the Volume Cliff findings F3.

## Changes
- `skills/polymarket-fast-loop/fastloop_trader.py`: added `client.preflight()` call in `execute_trade()` before `client.trade()`, gated on `client.live`
- `skills/polymarket-weather-trader/weather_trader.py`: same in `execute_trade()` and `execute_sell()` (sells use `planned_amount=0` to skip cap math but still surface wallet/venue blockers)
- `skills/polymarket-mert-sniper/mert_sniper.py`: same in `execute_trade()`
- SKILL.md version bumps: fast-loop 1.6.4→1.6.5, weather-trader 1.21.1→1.21.2, mert-sniper 1.3.0→1.3.1

## Behaviour
In live mode (`client.live=True`), `client.preflight(planned_amount=amount, venue=client.venue)` runs before each trade. If `ok_to_trade` is `False`, the skill prints `⛔ Preflight blocked: <blocker codes>` and returns `{"error": "preflight_blocked: <blockers>"}` — visible in skill output and Telegram surface. Paper mode is unchanged (preflight skipped when `client.live=False`).

## Tests
- `py_compile` on all three modified skill files: OK
- Preflight API verified against `simmer_sdk/client.py:794` and `skills/preflight/tests/test_preflight.py`
- Pattern: uses `pf.ok_to_trade` and `pf.blockers` attributes (not dict) as confirmed by `PreflightResult` dataclass and unit tests
- Smoke test path: set `real_trading_enabled=False` on the agent → `WALLET_UNVERIFIED` blocker surfaces in skill output instead of a CLOB 403

## Docs impact
No new SDK methods or endpoints. Existing `client.preflight()` docs cover the added usage.

Closes SIM-2312