### PR TITLE
fix(skill): correct simmer-mcp-setup description framing (0.1.1)

### DIFF
--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.1.0"
+version: "0.1.1"
 published: true
-description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets if you want MCP tools instead of (or alongside) the Python SDK.
+description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.0"
+  version: "0.1.1"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY


### PR DESCRIPTION
## Summary

- Updates frontmatter `description:` on `simmer-mcp-setup` skill to align with the body framing from #119
- Bumps version `0.1.0` → `0.1.1` in both `version:` and `metadata.version:` so the new description gets published to ClawHub

## Why

When #119 dogfood surfaced that "MCP tools instead of (or alongside) the Python SDK" was misleading (implies MCP is a primitive-API swap-in for SDK, which it isn't — MCP runs pre-built strategies), the body intro paragraph was fixed but the frontmatter `description:` field was missed. The catalog listing on ClawHub + vector search both index from this field, so first-touch users browsing the catalog still saw the misleading wording.

## Diff

```diff
 name: simmer-mcp-setup
-version: "0.1.0"
+version: "0.1.1"
 published: true
-description: ...Use after registering an agent on simmer.markets if you want MCP tools instead of (or alongside) the Python SDK.
+description: ...Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.0"
+  version: "0.1.1"
```

## Test plan

- [ ] After merge — `clawhub publish skills/simmer-mcp-setup --version 0.1.1`
- [ ] `clawhub inspect simmer-mcp-setup` shows Latest: 0.1.1 with updated description

Refs #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)