### PR TITLE
fix(preflight): block ok_to_trade for OWS+DW+Polymarket incompatibility (SIM-2325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Skip sell loop on resolved markets — polymarket-weather-trader v1.21.1, kalshi-weather-trader v1.0.7, polymarket-elon-tweets v1.3.3 (SIM-2046).** All three skills could retry sells indefinitely on resolved markets while waiting for `auto_redeem()` to claim the winning shares. Root cause: the exit loop didn't check `position.status` before attempting a sell; Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell", and the skill retried every cycle. Fix: added `status == "resolved"` guard immediately after the minimum-shares check. `auto_redeem()` at the top of each cycle handles the actual payout. Also changed silent `except: pass` on `auto_redeem()` to log the exception at `force=True` so future failures surface in skill logs.
 
-## [0.17.15] — 2026-05-22
+## [0.17.16] — 2026-05-22
 
 ### Fixed
 
-- **`client.preflight()` now returns `ok_to_trade=False` when OWS signing + active deposit wallet + Polymarket venue are combined (SIM-2325).** This combo raises a `ValueError` in the trade path (`_execute_polymarket_byow_trade`) because the OWS signing path uses sig-type-0 (EOA) only and Polymarket V2 CLOB requires sig-type-3 for DW-funded orders. V1 was retired 2026-04-28. Preflight now mirrors the hard-fail guard and adds the `POLYMARKET_SIGNER_UNSUPPORTED` blocker so agents catch the incompatibility before the trade call.
+- **`client.preflight()` correctly blocks `ok_to_trade` for OWS+DW+Polymarket when preflight is the first SDK call (SIM-2325).** The 0.17.15 fix read `self._uses_deposit_wallet`, which defaults `False` at `__init__` and is only populated by `_ensure_wallet_linked()` in the trade path. In Herman's production sequence (`from_env()` → `preflight()` → `trade()`), `_ensure_wallet_linked()` had not run, so the blocker silently didn't fire and `ok_to_trade` remained `True`. Fixed to use the local `deposit_wallet` variable already fetched from `/api/sdk/agents/me` within `preflight()`, which is populated on every preflight call regardless of prior trade history.
 - **`client.preflight()` adds `POLYMARKET_APPROVALS_MISSING` warning** when CLOB token approvals are missing for external-wallet (OWS without DW, private-key) Polymarket traders. Previously only surfaced as a log warning immediately before the first trade attempt; now visible in the preflight envelope for pre-flight gating.
 
 ## [0.17.14] — 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Skip sell loop on resolved markets — polymarket-weather-trader v1.21.1, kalshi-weather-trader v1.0.7, polymarket-elon-tweets v1.3.3 (SIM-2046).** All three skills could retry sells indefinitely on resolved markets while waiting for `auto_redeem()` to claim the winning shares. Root cause: the exit loop didn't check `position.status` before attempting a sell; Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell", and the skill retried every cycle. Fix: added `status == "resolved"` guard immediately after the minimum-shares check. `auto_redeem()` at the top of each cycle handles the actual payout. Also changed silent `except: pass` on `auto_redeem()` to log the exception at `force=True` so future failures surface in skill logs.
 
+## [0.17.15] — 2026-05-22
+
+### Fixed
+
+- **`client.preflight()` now returns `ok_to_trade=False` when OWS signing + active deposit wallet + Polymarket venue are combined (SIM-2325).** This combo raises a `ValueError` in the trade path (`_execute_polymarket_byow_trade`) because the OWS signing path uses sig-type-0 (EOA) only and Polymarket V2 CLOB requires sig-type-3 for DW-funded orders. V1 was retired 2026-04-28. Preflight now mirrors the hard-fail guard and adds the `POLYMARKET_SIGNER_UNSUPPORTED` blocker so agents catch the incompatibility before the trade call.
+- **`client.preflight()` adds `POLYMARKET_APPROVALS_MISSING` warning** when CLOB token approvals are missing for external-wallet (OWS without DW, private-key) Polymarket traders. Previously only surfaced as a log warning immediately before the first trade attempt; now visible in the preflight envelope for pre-flight gating.
+
 ## [0.17.14] — 2026-05-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.14"
+version = "0.17.15"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.15"
+version = "0.17.16"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -905,7 +905,7 @@ class SimmerClient:
         if (
             resolved_venue == "polymarket"
             and signer_status == "ows"
-            and self._uses_deposit_wallet
+            and deposit_wallet
         ):
             blockers.append("POLYMARKET_SIGNER_UNSUPPORTED")
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -896,6 +896,36 @@ class SimmerClient:
             elif resolved_venue == "kalshi" and not self._solana_key_available:
                 blockers.append("WALLET_UNVERIFIED")
 
+        # ── OWS + deposit-wallet incompatibility (Polymarket V2) ─────────
+        # The OWS signing path uses sig-type-0 (EOA) only; Polymarket V2
+        # CLOB requires sig-type-3 for DW-funded orders. V1 was retired
+        # 2026-04-28. Fail closed here so ok_to_trade reflects actual
+        # execution viability, not only balance/exposure readiness.
+        # Mirror of the hard-fail in _execute_polymarket_byow_trade.
+        if (
+            resolved_venue == "polymarket"
+            and signer_status == "ows"
+            and self._uses_deposit_wallet
+        ):
+            blockers.append("POLYMARKET_SIGNER_UNSUPPORTED")
+
+        # ── Polymarket approvals (external wallets without DW block) ─────
+        # Warn if CLOB token approvals are missing. Missing approvals fail
+        # the trade path. Skipped when POLYMARKET_SIGNER_UNSUPPORTED is
+        # already blocking (approvals are moot in that case).
+        if (
+            resolved_venue == "polymarket"
+            and signer_status in ("ows", "external_key")
+            and "POLYMARKET_SIGNER_UNSUPPORTED" not in blockers
+            and execution_wallet
+        ):
+            try:
+                _appr = self.check_approvals(address=execution_wallet)
+                if not _appr.get("all_set", True):
+                    warnings_list.append("POLYMARKET_APPROVALS_MISSING")
+            except Exception:
+                pass  # fail-quiet — approvals check is best-effort
+
         # ── Briefing: balances + risk alerts ──────────────────────────────
         spendable_balance: Optional[float] = None
         pending_alerts: List[dict] = []

--- a/skills/preflight/tests/test_preflight.py
+++ b/skills/preflight/tests/test_preflight.py
@@ -120,7 +120,8 @@ def _positions(items=None):
     return {"positions": items or []}
 
 
-def _mock_request(client, me_resp=None, briefing_resp=None, positions_resp=None, fail=None):
+def _mock_request(client, me_resp=None, briefing_resp=None, positions_resp=None, fail=None,
+                  approvals_all_set=True):
     """Patch client._request to return canned responses."""
     def _side_effect(method, endpoint, **kwargs):
         if fail and endpoint == fail:
@@ -131,6 +132,8 @@ def _mock_request(client, me_resp=None, briefing_resp=None, positions_resp=None,
             return briefing_resp or _briefing()
         if "/positions" in endpoint:
             return positions_resp or _positions()
+        if "/allowances/" in endpoint:
+            return {"all_set": approvals_all_set}
         raise RuntimeError(f"Unexpected endpoint: {endpoint}")
 
     client._request = _side_effect
@@ -451,6 +454,122 @@ class TestPreflightUUID(unittest.TestCase):
         # Should not raise
         parsed = uuid.UUID(result.client_preflight_id)
         self.assertEqual(str(parsed), result.client_preflight_id)
+
+
+class TestPreflightOWSDWIncompatibility(unittest.TestCase):
+    """SIM-2325: OWS + deposit-wallet + Polymarket → POLYMARKET_SIGNER_UNSUPPORTED blocker."""
+
+    def test_ows_dw_polymarket_blocked(self):
+        """Herman's exact repro: OWS signer + active DW + polymarket = POLYMARKET_SIGNER_UNSUPPORTED."""
+        client = _make_client(
+            ows_wallet="herman-v3",
+            wallet_address="0x3dfe3c60aaa",
+            deposit_wallet_address="0xDW123",
+            uses_deposit_wallet=True,
+        )
+        _mock_request(client, me_resp=_agents_me(
+            real_trading_enabled=True,
+            per_agent_wallet_address="0x3dfe3c60aaa",
+            per_agent_deposit_wallet_address="0xDW123",
+        ))
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
+        self.assertFalse(result.ok_to_trade)
+
+    def test_ows_no_dw_polymarket_allowed(self):
+        """OWS without a deposit wallet (EOA-only path) should not get the DW blocker."""
+        client = _make_client(
+            ows_wallet="my-agent",
+            wallet_address="0xOWSEOA",
+            deposit_wallet_address=None,
+            uses_deposit_wallet=False,
+        )
+        _mock_request(client, me_resp=_agents_me(
+            real_trading_enabled=True,
+            wallet_address="0xOWSEOA",
+        ))
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertNotIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
+
+    def test_external_key_dw_polymarket_not_blocked(self):
+        """Private-key external wallet with DW is valid — should NOT get POLYMARKET_SIGNER_UNSUPPORTED."""
+        client = _make_client(
+            private_key="0x" + "a" * 64,
+            wallet_address="0xExtEOA",
+            deposit_wallet_address="0xExtDW",
+            uses_deposit_wallet=True,
+        )
+        _mock_request(client, me_resp=_agents_me(
+            real_trading_enabled=True,
+            wallet_address="0xExtEOA",
+            deposit_wallet_address="0xExtDW",
+        ))
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertNotIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
+
+    def test_ows_dw_sim_venue_not_blocked(self):
+        """OWS + DW on the sim venue is fine — the DW incompatibility is polymarket-only."""
+        client = _make_client(
+            ows_wallet="my-agent",
+            wallet_address="0xOWSEOA",
+            uses_deposit_wallet=True,
+        )
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True))
+        result = client.preflight(venue="sim", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertNotIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
+
+
+class TestPreflightApprovalsWarning(unittest.TestCase):
+    """POLYMARKET_APPROVALS_MISSING warning for external wallets with missing CLOB approvals."""
+
+    def test_missing_approvals_adds_warning(self):
+        """External-key wallet with missing approvals → POLYMARKET_APPROVALS_MISSING warning."""
+        client = _make_client(
+            private_key="0x" + "a" * 64,
+            wallet_address="0xExtEOA",
+            uses_deposit_wallet=False,
+        )
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True),
+                      approvals_all_set=False)
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertIn("POLYMARKET_APPROVALS_MISSING", result.warnings)
+
+    def test_approvals_ok_no_warning(self):
+        """External-key wallet with all approvals set → no approvals warning."""
+        client = _make_client(
+            private_key="0x" + "a" * 64,
+            wallet_address="0xExtEOA",
+            uses_deposit_wallet=False,
+        )
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True),
+                      approvals_all_set=True)
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertNotIn("POLYMARKET_APPROVALS_MISSING", result.warnings)
+
+    def test_ows_dw_blocked_approvals_not_checked(self):
+        """When POLYMARKET_SIGNER_UNSUPPORTED is blocking, approvals check is skipped."""
+        client = _make_client(
+            ows_wallet="herman-v3",
+            wallet_address="0x3dfe3c60aaa",
+            deposit_wallet_address="0xDW123",
+            uses_deposit_wallet=True,
+        )
+        _mock_request(client, me_resp=_agents_me(
+            real_trading_enabled=True,
+            per_agent_wallet_address="0x3dfe3c60aaa",
+            per_agent_deposit_wallet_address="0xDW123",
+        ), approvals_all_set=False)
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        # DW blocker is present; approvals warning should NOT be added (moot)
+        self.assertIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
+        self.assertNotIn("POLYMARKET_APPROVALS_MISSING", result.warnings)
+
+    def test_managed_wallet_no_approvals_check(self):
+        """Managed-wallet signer doesn't need CLOB approvals from the client side."""
+        client = _make_client()
+        _mock_request(client, me_resp=_agents_me(real_trading_enabled=True))
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertNotIn("POLYMARKET_APPROVALS_MISSING", result.warnings)
 
 
 if __name__ == "__main__":

--- a/skills/preflight/tests/test_preflight.py
+++ b/skills/preflight/tests/test_preflight.py
@@ -518,6 +518,26 @@ class TestPreflightOWSDWIncompatibility(unittest.TestCase):
         result = client.preflight(venue="sim", planned_amount=1.0, exposure_cap_usd=100.0)
         self.assertNotIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
 
+    def test_ows_dw_polymarket_blocked_via_agents_me(self):
+        """Herman's repro path: preflight is the FIRST SDK call, _ensure_wallet_linked
+        has not run, so the blocker must derive DW state from agents/me, not self."""
+        client = _make_client(
+            ows_wallet="herman-v3",
+            wallet_address="0x3dfe3c60aaa",
+            # Intentionally NOT setting deposit_wallet_address or uses_deposit_wallet.
+            # Production init does not populate these before preflight.
+        )
+        # Confirm init-time default — the blocker must NOT rely on this field.
+        self.assertFalse(client._uses_deposit_wallet)
+        _mock_request(client, me_resp=_agents_me(
+            real_trading_enabled=True,
+            per_agent_wallet_address="0x3dfe3c60aaa",
+            per_agent_deposit_wallet_address="0xDW123",
+        ))
+        result = client.preflight(venue="polymarket", planned_amount=1.0, exposure_cap_usd=100.0)
+        self.assertIn("POLYMARKET_SIGNER_UNSUPPORTED", result.blockers)
+        self.assertFalse(result.ok_to_trade)
+
 
 class TestPreflightApprovalsWarning(unittest.TestCase):
     """POLYMARKET_APPROVALS_MISSING warning for external wallets with missing CLOB approvals."""


### PR DESCRIPTION
`client.preflight()` returned `ok_to_trade=True` for Herman's per-agent OWS wallet + active deposit wallet + Polymarket venue, but the subsequent `client.trade()` call failed with `ValueError: OWS BYOW trading does not support Polymarket deposit wallets`. This made the new preflight receipt a false positive for the exact readiness question it is meant to answer.

## Root cause

The trade path (`_execute_polymarket_byow_trade`, line 3716) hard-fails when `self._ows_wallet` is set AND `uses_dw` is True, because the OWS signing path uses sig-type-0 (EOA) only — Polymarket V2 CLOB requires sig-type-3 for DW-funded orders, and V1 was retired 2026-04-28. The preflight checked `signer_status == "ows"` but never checked `self._uses_deposit_wallet`, so it missed the incompatible combo.

## Changes

- `simmer_sdk/client.py`: In `preflight()`, added two checks after the venue-support block:
  1. **`POLYMARKET_SIGNER_UNSUPPORTED` blocker** — when OWS signer + `self._uses_deposit_wallet` + polymarket venue. Mirrors the hard-fail in `_execute_polymarket_byow_trade` so `ok_to_trade` reflects actual execution viability, not only balance/exposure readiness.
  2. **`POLYMARKET_APPROVALS_MISSING` warning** — for external-wallet (OWS without DW, private-key) Polymarket traders with missing CLOB token approvals. Previously only surfaced as a `logger.warning()` immediately before the first trade attempt; now visible in the preflight envelope.

- `skills/preflight/tests/test_preflight.py`: 8 new unit tests covering OWS+DW blocker (Herman repro), OWS-no-DW pass-through, external-key+DW pass-through, sim-venue pass-through, approvals warning, approvals-ok no-warning, blocker-present skips-approvals-check, managed-wallet no-approvals-check.

- `pyproject.toml` + `CHANGELOG.md`: bumped to v0.17.15.

## Tests

42 preflight tests pass (`python3 -m pytest skills/preflight/tests/ -v`).

Closes SIM-2325