### PR TITLE
ci: auto-publish simmer-sdk to PyPI on v* tag push

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,79 @@
+name: Publish simmer-sdk to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build + smoke test, no upload)"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Resolve expected version
+        id: ver
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$REF_TYPE" = "tag" ] && [ "${REF_NAME#v}" != "$REF_NAME" ]; then
+            EXPECTED="${REF_NAME#v}"
+          else
+            EXPECTED=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          fi
+          echo "expected=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "Expected version: $EXPECTED"
+
+      - name: Assert pyproject.toml version matches tag
+        if: github.ref_type == 'tag'
+        env:
+          EXPECTED: ${{ steps.ver.outputs.expected }}
+        run: |
+          PYPROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$PYPROJECT_VERSION" != "$EXPECTED" ]; then
+            echo "::error::Tag is v$EXPECTED but pyproject.toml says $PYPROJECT_VERSION"
+            exit 1
+          fi
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: twine check
+        run: python -m twine check dist/*
+
+      - name: Smoke test (install wheel in clean venv, import, version assert)
+        env:
+          EXPECTED: ${{ steps.ver.outputs.expected }}
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --quiet dist/simmer_sdk-*.whl
+          INSTALLED=$(/tmp/smoke/bin/python -c "import simmer_sdk; print(simmer_sdk.__version__)")
+          if [ "$INSTALLED" != "$EXPECTED" ]; then
+            echo "::error::Wheel installs as $INSTALLED but expected $EXPECTED"
+            exit 1
+          fi
+          echo "Smoke test OK: simmer_sdk==$INSTALLED"
+
+      - name: Publish to PyPI
+        if: ${{ !inputs.dry_run }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python -m twine upload dist/*


### PR DESCRIPTION
## Summary

- Surfaced by SIM-2334: SIM-2325 was closed claiming "Release: simmer-sdk v0.17.16" but no tag or PyPI upload existed. Code fix + version bump landed on main via #121; tag + twine upload (which an engineering agent without PyPI creds can't execute) silently never ran. Herman blocked on 0.17.14.
- This workflow auto-publishes to PyPI when a `v*` tag is pushed, with a version-mismatch guard + smoke test that catches the exact failure modes we saw this round.

## Workflow shape

| Step | Why |
|---|---|
| Trigger on `v*` tag push | Tag is the explicit release act; manual `git tag && git push --tags` stays the gating gesture |
| Assert `pyproject.toml.version == tag.name` | Catches "tag v0.17.16 / pyproject 0.17.15" misalignment |
| Build sdist + wheel, twine check | Standard |
| Smoke test: install wheel in clean venv, import, assert `__version__` | Catches packaging failures (missing `package_data`, broken module imports) that CI's source-checkout pytest doesn't surface |
| Upload via `secrets.PYPI_TOKEN` | Only step that needs the secret |
| `workflow_dispatch` w/ `dry_run` input | Validate workflow on a branch without uploading |

CI on every push to main already gates code quality. This workflow adds only packaging-specific checks + upload — no pytest re-run.

## Before merging

- [ ] Add `PYPI_TOKEN` repo secret (PyPI → Account → API tokens, scope: project=simmer-sdk).
- [ ] Optional: run `workflow_dispatch` against this branch with `dry_run=true` to verify the build + smoke-test path before live use.

## Validation

- YAML syntax checked locally with `python -c "import yaml; yaml.safe_load(...)"`
- No untrusted input flows into `run:` blocks; step outputs and `github.ref_name` pass through `env:`

## Test plan

- [ ] Add `PYPI_TOKEN` secret in repo settings
- [ ] Trigger `workflow_dispatch` on this branch with `dry_run=true` — expect green, no upload
- [ ] Merge
- [ ] Next release: bump `pyproject.toml`, commit `chore(release): vX.Y.Z`, tag `vX.Y.Z`, push tag — verify PyPI publish lands automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)