### PR TITLE
fix(simmer-briefing): remove unsupported venue= param (SIM-2304)

### DIFF
--- a/skills/simmer-briefing/SKILL.md
+++ b/skills/simmer-briefing/SKILL.md
@@ -111,17 +111,18 @@ Don't dump raw JSON. Summarize.
 
 ```python
 briefing = client.get_briefing(since=last_check)
+venues = briefing.get("venues") or {}
 
-sim = briefing.venues.sim          # None if no $SIM activity
-pm  = briefing.venues.polymarket   # None if no Polymarket activity
-ks  = briefing.venues.kalshi       # None if no Kalshi activity
+sim = venues.get("sim")          # None if no $SIM activity
+pm  = venues.get("polymarket")   # None if no Polymarket activity
+ks  = venues.get("kalshi")       # None if no Kalshi activity
 ```
 
 Each key is `None` when the agent has no activity on that venue, so a `None` check is both the skip-inactive guard and the single-venue filter.
 
 ## Recommended cadence
 
-Call `client.get_briefing(since=last_check)` a few times per day. Address `risk_alerts` first, then walk `briefing.venues` and present each venue's `actions` to your human. Track `last_check` to fetch only deltas next time.
+Call `client.get_briefing(since=last_check)` a few times per day. Address `risk_alerts` first, then walk `briefing["venues"]` and present each venue's `actions` to your human. Track `last_check` to fetch only deltas next time.
 
 ## Scope
 

--- a/skills/simmer-briefing/SKILL.md
+++ b/skills/simmer-briefing/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-briefing
 description: Daily check-in pattern for Simmer agents. One API call returns portfolio, risk alerts, and opportunities across all venues. Use this in your heartbeat to keep your human informed.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.2"
+  version: "0.1.3"
   displayName: Simmer Briefing
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -105,15 +105,19 @@ Example output for a human:
 
 Don't dump raw JSON. Summarize.
 
-## Single-venue mode
+## Filtering to a single venue
 
-For paper-only or strategy-specific skills:
+`get_briefing()` always returns all venues. To focus on one, read the relevant key after fetching — there is **no `venue` parameter**:
 
 ```python
-briefing = client.get_briefing(venue="sim")  # filter to one venue
+briefing = client.get_briefing(since=last_check)
+
+sim = briefing.venues.sim          # None if no $SIM activity
+pm  = briefing.venues.polymarket   # None if no Polymarket activity
+ks  = briefing.venues.kalshi       # None if no Kalshi activity
 ```
 
-Same shape, only that venue populates.
+Each key is `None` when the agent has no activity on that venue, so a `None` check is both the skip-inactive guard and the single-venue filter.
 
 ## Recommended cadence
 


### PR DESCRIPTION
Remove the `venue=` keyword argument from the `get_briefing()` example in the `simmer-briefing` skill. The parameter does not exist in the SDK or the REST endpoint — passing it causes `TypeError: got an unexpected keyword argument 'venue'`.

## Changes

- `skills/simmer-briefing/SKILL.md`: replace "Single-venue mode" section (showing unsupported `client.get_briefing(venue="sim")`) with "Filtering to a single venue" — the correct pattern is to fetch all venues and read the relevant key (`None` check is the filter). Version bumped `0.1.2 → 0.1.3`.

## Tests

- Confirmed actual SDK signature via `inspect.signature(SimmerClient.get_briefing)` on SDK 0.17.14: `(self, since: str = None, process_risk_alerts: bool = True, skill_versions: dict = None)` — no `venue` parameter.
- Confirmed `/api/sdk/briefing` endpoint (line 28382, `local_dev_server.py`) accepts only `since` as a query param.
- bundled-skills copy is gitignored (generated at build time); canonical fix is in `skills/simmer-briefing/SKILL.md`.

## Note

`a146f66` also appears as a foundation commit in `feat/sim-2318-get-markets-include` (it was committed there by mistake during this session). When this PR merges first, the SKILL.md change in SIM-2318's PR will be a trivial no-op and can be cleaned up on rebase.

Closes SIM-2304