### PR TITLE
feat(sdk): activate_polymarket_dw(agent_id=...) per-agent variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Skip sell loop on resolved markets — polymarket-weather-trader v1.21.1, kalshi-weather-trader v1.0.7, polymarket-elon-tweets v1.3.3 (SIM-2046).** All three skills could retry sells indefinitely on resolved markets while waiting for `auto_redeem()` to claim the winning shares. Root cause: the exit loop didn't check `position.status` before attempting a sell; Polymarket/Kalshi reject sells on resolved markets with "Insufficient shares to sell", and the skill retried every cycle. Fix: added `status == "resolved"` guard immediately after the minimum-shares check. `auto_redeem()` at the top of each cycle handles the actual payout. Also changed silent `except: pass` on `auto_redeem()` to log the exception at `force=True` so future failures surface in skill logs.
 
+## [0.17.18] — 2026-05-23
+
+### Added
+
+- **`client.activate_polymarket_dw(agent_id="...")` per-agent variant.** The existing user-primary helper handled OWS signing correctly (line 4768-4772) but was hardcoded to `/api/user/wallet/external/dw-approvals/*`, returning 401 for per-agent SDK API keys. New `agent_id` keyword arg routes to the per-agent endpoint pair `/api/user/agent/{id}/wallet/external/dw-approvals/{prepare,submit}` shipped in SIM-1906, server reading state from `user_agent_wallets` instead of `users` and flipping the per-agent `approvals_set` flag on relayer success. Same idempotent contract — `already_set=True` when on-chain is already complete. Default behavior (no `agent_id`) is unchanged. Unblocks per-agent Elite OWS users from completing missed approvals when Polymarket adds spender contracts post-activation; the dashboard wizard can't sign for these wallets because the OWS vault lives on the agent's host machine, not the user's browser.
+
 ## [0.17.17] — 2026-05-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.17"
+version = "0.17.18"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -4684,21 +4684,43 @@ class SimmerClient:
         print()
         return {"set": set_count, "skipped": skipped, "failed": failed, "details": details}
 
-    def activate_polymarket_dw(self) -> Dict[str, Any]:
+    def activate_polymarket_dw(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
         """Activate Polymarket Deposit Wallet trading headlessly.
 
         Calls /dw-approvals/prepare to get the EIP-712 batch, signs it
-        locally with WALLET_PRIVATE_KEY (key never leaves the process),
-        then submits via /dw-approvals/submit. No browser required.
+        locally with WALLET_PRIVATE_KEY or the configured OWS wallet (key
+        never leaves the process / OWS vault), then submits via
+        /dw-approvals/submit. No browser required.
 
-        NOTE: This method handles user-primary wallets only and will 401 on a
-        per-agent SDK API key. For per-agent wallets (Elite tier dedicated
-        wallets), use ``update_agent_wallet_creds(ows_wallet_name)`` instead.
+        Two scopes (user-primary vs per-agent):
+
+        - **User-primary** (default, ``agent_id=None``): operates on the
+          authenticated user's primary wallet via
+          ``/api/user/wallet/external/dw-approvals/*``. Works with the
+          user's SDK API key OR Dynamic JWT.
+        - **Per-agent** (``agent_id="..."``): operates on the named
+          Elite-tier per-agent OWS wallet via
+          ``/api/user/agent/{agent_id}/wallet/external/dw-approvals/*``.
+          Required when the signing key is the per-agent OWS wallet on
+          the agent's host (the dashboard wizard can't sign for an OWS
+          wallet because the browser has no access to the OWS vault).
+          Works with a per-agent SDK API key OR Dynamic JWT.
+
+        Idempotent: returns ``{already_set: True}`` if all required
+        spenders are already approved on-chain.
 
         Requires:
-        - WALLET_PRIVATE_KEY env var (or private_key constructor arg)
-        - Account upgraded to a Deposit Wallet (wallet_uses_deposit_wallet=True)
-        - eth-account: pip install eth-account
+        - WALLET_PRIVATE_KEY env var, ``private_key`` constructor arg,
+          OR OWS_WALLET env var / ``ows_wallet`` constructor arg
+        - Account upgraded to a Deposit Wallet (wallet_uses_deposit_wallet=True
+          for user-primary; the per-agent equivalent flag in the per-agent
+          variant)
+        - eth-account installed for the raw-key path
+
+        Args:
+            agent_id: When set, routes to the per-agent dw-approvals
+                endpoints. Omit (or pass None) for the user-primary
+                wallet path.
 
         Returns:
             Dict with keys:
@@ -4707,12 +4729,16 @@ class SimmerClient:
             - success (bool): True on completion
 
         Raises:
-            ValueError: if no private key is configured
-            ImportError: if eth-account is not installed
+            ValueError: if no private key / OWS wallet is configured
+            ImportError: if eth-account is not installed and we're on the raw-key path
 
-        Example:
+        Example (user-primary, raw key):
             client = SimmerClient(api_key="sk_live_...")  # WALLET_PRIVATE_KEY in env
             result = client.activate_polymarket_dw()
+
+        Example (per-agent, OWS — Herman's case):
+            client = SimmerClient(api_key="sk_live_per_agent_...", ows_wallet="herman-v3")
+            result = client.activate_polymarket_dw(agent_id="1b279e61-...")
             print(f"Done — already_set={result['already_set']}, calls={result['calls_count']}")
         """
         if not self._private_key and not self._ows_wallet:
@@ -4731,13 +4757,25 @@ class SimmerClient:
                     "Install with: pip install eth-account"
                 )
 
+        # Endpoint base routes per scope. Both endpoint pairs share the same
+        # request/response shape; only the path differs and the server reads
+        # state from `user_agent_wallets` vs `users` accordingly.
+        if agent_id:
+            _dw_base = (
+                f"/api/user/agent/{agent_id}/wallet/external/dw-approvals"
+            )
+            _scope_label = f"per-agent {agent_id}"
+        else:
+            _dw_base = "/api/user/wallet/external/dw-approvals"
+            _scope_label = "user-primary"
+
         # Step 1 — prepare: server scans on-chain allowances and returns the
         # EIP-712 typed data batch. Idempotent — returns already_set=True if
         # nothing to do.
-        print("[DW-Activate] Preparing approval batch…")
+        print(f"[DW-Activate] Preparing approval batch ({_scope_label})…")
         prepare = self._request(
             "POST",
-            "/api/user/wallet/external/dw-approvals/prepare",
+            f"{_dw_base}/prepare",
         )
 
         if prepare.get("already_set"):
@@ -4773,11 +4811,12 @@ class SimmerClient:
 
         # Step 3 — submit: server re-builds the DepositWalletBatchRequest,
         # posts to Polymarket's relayer with its builder HMAC, polls until
-        # STATE_MINED, then flips polymarket_allowances_set=TRUE.
+        # STATE_MINED, then flips approvals_set=TRUE on the matching row
+        # (`users` for user-primary, `user_agent_wallets` for per-agent).
         print("[DW-Activate] Submitting to relayer…")
         self._request(
             "POST",
-            "/api/user/wallet/external/dw-approvals/submit",
+            f"{_dw_base}/submit",
             json={
                 "signature": signature,
                 "nonce": nonce,

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -4764,15 +4764,20 @@ class SimmerClient:
             _dw_base = (
                 f"/api/user/agent/{agent_id}/wallet/external/dw-approvals"
             )
-            _scope_label = f"per-agent {agent_id}"
         else:
             _dw_base = "/api/user/wallet/external/dw-approvals"
-            _scope_label = "user-primary"
 
         # Step 1 — prepare: server scans on-chain allowances and returns the
         # EIP-712 typed data batch. Idempotent — returns already_set=True if
         # nothing to do.
-        print(f"[DW-Activate] Preparing approval batch ({_scope_label})…")
+        #
+        # Preserve byte-identical stdout for the default (user-primary) path
+        # so existing log scrapers + tests don't drift. Scope label only
+        # printed for per-agent (the new path).
+        if agent_id:
+            print(f"[DW-Activate] Preparing approval batch (per-agent {agent_id})…")
+        else:
+            print("[DW-Activate] Preparing approval batch…")
         prepare = self._request(
             "POST",
             f"{_dw_base}/prepare",


### PR DESCRIPTION
## Summary

- Adds optional `agent_id` keyword arg to `activate_polymarket_dw()`. When set, routes to the per-agent dw-approvals endpoint pair (SIM-1906) instead of the user-primary ones.
- Unblocks per-agent Elite OWS users from completing approvals via the SDK — the dashboard wizard cannot sign for these wallets because the OWS vault lives on the agent's host machine, not the user's browser.
- Default behavior (no `agent_id`) is byte-identical to v0.17.17, including stdout.

## Why

Working through Herman's graduation receipt today, we hit a real product constraint: the dashboard's activation wizard uses browser-side signers (Rabby/MetaMask via Dynamic). Per-agent OWS wallets have their keys in OWS-Python's local vault on the agent's host — there's no path to bring that key into the user's browser. The signing must happen on the agent's machine.

The existing `activate_polymarket_dw()` already handled OWS signing correctly via `ows_sign_typed_data` (`simmer_sdk/client.py:4768-4772`). It was hardcoded to user-primary endpoints — the docstring even said "401s on per-agent SDK API keys." This change parameterizes the URL.

Architectural call (Adrian): OWS-via-SDK + dashboard-via-browser stays the cleaner separation. Don't force OWS into the dashboard.

## Codex review

- Round 1: 1 P2 (default-path stdout drift). Fixed in `3159f5f`.
- Round 2: CLEAN.

## Test plan

After release:
- [ ] Herman runs `client.activate_polymarket_dw(agent_id="1b279e61-...")` on MBP-13 with `OWS_WALLET=herman-v3` configured
- [ ] Expected output: prepare → sign via OWS → submit → `Done — N approval(s) set` (N=3 matching the missing approvals diagnosed earlier today)
- [ ] `client.check_approvals(no_cache=True)` returns `all_set=True`
- [ ] Herman retries the canary trade (SIM-2356)

🤖 Generated with [Claude Code](https://claude.com/claude-code)