### PR TITLE
feat(mcp): add raw trade primitives v3.3.0 (SIM-2323)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -39,6 +39,40 @@ export interface PostExperimentResult {
   latest_version?: string;
 }
 
+// Raw primitive API types
+
+export interface TradeParams {
+  market_id: string;
+  side: "yes" | "no";
+  amount?: number;
+  shares?: number;
+  venue?: string;
+  dry_run?: boolean;
+  reasoning?: string;
+  source?: string;
+}
+
+export interface TradeResult {
+  [key: string]: unknown;
+}
+
+export interface BriefingResult {
+  [key: string]: unknown;
+}
+
+export interface MarketsResult {
+  markets: unknown[];
+  [key: string]: unknown;
+}
+
+export interface MarketContextResult {
+  [key: string]: unknown;
+}
+
+export interface CancelOrderResult {
+  [key: string]: unknown;
+}
+
 export class SimmerApi {
   private apiKey: string;
   private apiUrl: string;
@@ -153,6 +187,111 @@ export class SimmerApi {
     } catch {
       return null;
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Raw trading primitives
+  // -------------------------------------------------------------------------
+
+  /**
+   * Execute or dry-run a trade. Throws BackendError on 4xx/5xx.
+   */
+  async trade(params: TradeParams): Promise<TradeResult> {
+    const resp = await this.timedFetch(
+      `${this.apiUrl}/api/sdk/trade`,
+      {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(params),
+      },
+      30_000,
+    );
+    if (!resp.ok) {
+      const detail = await this.extractDetail(resp);
+      const upgradeUrl = resp.status === 403 ? "https://simmer.markets/pro" : undefined;
+      throw new BackendError(resp.status, detail, upgradeUrl);
+    }
+    return (await resp.json()) as TradeResult;
+  }
+
+  /**
+   * Get the agent briefing (portfolio, positions, opportunities, performance).
+   * Throws BackendError on 4xx/5xx.
+   */
+  async getBriefing(since?: string): Promise<BriefingResult> {
+    const url = since
+      ? `${this.apiUrl}/api/sdk/briefing?since=${encodeURIComponent(since)}`
+      : `${this.apiUrl}/api/sdk/briefing`;
+    const resp = await this.timedFetch(url, { headers: this.headers() }, 15_000);
+    if (!resp.ok) {
+      const detail = await this.extractDetail(resp);
+      const upgradeUrl = resp.status === 403 ? "https://simmer.markets/pro" : undefined;
+      throw new BackendError(resp.status, detail, upgradeUrl);
+    }
+    return (await resp.json()) as BriefingResult;
+  }
+
+  /**
+   * List or search markets. Throws BackendError on 4xx/5xx.
+   */
+  async getMarkets(params: {
+    q?: string;
+    limit?: number;
+    venue?: string;
+    status?: string;
+    tags?: string;
+    sort?: string;
+  }): Promise<MarketsResult> {
+    const qs = new URLSearchParams();
+    if (params.q) qs.set("q", params.q);
+    if (params.limit) qs.set("limit", String(params.limit));
+    if (params.venue) qs.set("venue", params.venue);
+    if (params.status) qs.set("status", params.status);
+    if (params.tags) qs.set("tags", params.tags);
+    if (params.sort) qs.set("sort", params.sort);
+    const url = `${this.apiUrl}/api/sdk/markets?${qs.toString()}`;
+    const resp = await this.timedFetch(url, { headers: this.headers() }, 15_000);
+    if (!resp.ok) {
+      const detail = await this.extractDetail(resp);
+      throw new BackendError(resp.status, detail);
+    }
+    return (await resp.json()) as MarketsResult;
+  }
+
+  /**
+   * Get rich context for a market. Throws BackendError on 4xx/5xx.
+   */
+  async getMarketContext(marketId: string, params: {
+    my_probability?: number;
+    venue?: string;
+  } = {}): Promise<MarketContextResult> {
+    const qs = new URLSearchParams();
+    if (params.my_probability !== undefined) qs.set("my_probability", String(params.my_probability));
+    if (params.venue) qs.set("venue", params.venue);
+    const qStr = qs.toString();
+    const url = `${this.apiUrl}/api/sdk/context/${encodeURIComponent(marketId)}${qStr ? `?${qStr}` : ""}`;
+    const resp = await this.timedFetch(url, { headers: this.headers() }, 15_000);
+    if (!resp.ok) {
+      const detail = await this.extractDetail(resp);
+      throw new BackendError(resp.status, detail);
+    }
+    return (await resp.json()) as MarketContextResult;
+  }
+
+  /**
+   * Cancel a single open order by ID. Throws BackendError on 4xx/5xx.
+   */
+  async cancelOrder(orderId: string): Promise<CancelOrderResult> {
+    const resp = await this.timedFetch(
+      `${this.apiUrl}/api/sdk/orders/${encodeURIComponent(orderId)}`,
+      { method: "DELETE", headers: this.headers() },
+      15_000,
+    );
+    if (!resp.ok) {
+      const detail = await this.extractDetail(resp);
+      throw new BackendError(resp.status, detail);
+    }
+    return (await resp.json()) as CancelOrderResult;
   }
 
   /**

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -44,6 +44,7 @@ export interface PostExperimentResult {
 export interface TradeParams {
   market_id: string;
   side: "yes" | "no";
+  action?: "buy" | "sell";
   amount?: number;
   shares?: number;
   venue?: string;

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -661,8 +661,9 @@ if (simmer) {
     {
       market_id: z.string().describe("Simmer market UUID (from simmer_get_markets)"),
       side: z.enum(["yes", "no"]).describe("Which outcome to trade"),
-      amount: z.number().optional().describe("USD to spend (for buys). Mutually exclusive with shares."),
-      shares: z.number().optional().describe("Shares to sell (for sells). Mutually exclusive with amount."),
+      action: z.enum(["buy", "sell"]).default("buy").describe("'buy' to open/add to a position (requires amount); 'sell' to close/reduce (requires shares)."),
+      amount: z.number().optional().describe("USD to spend. Required for action='buy'."),
+      shares: z.number().optional().describe("Shares to sell. Required for action='sell'."),
       venue: z.enum(["sim", "polymarket", "kalshi"]).default("sim").describe("Trading venue. 'sim' = $SIM paper mode."),
       dry_run: z.boolean().default(true).describe("If false (+ SIMMER_MCP_ALLOW_LIVE=true + live venue), places a real order. Default: paper mode."),
       reasoning: z.string().optional().describe("Why you're making this trade (stored for P&L attribution and flip-flop detection)"),

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -111,6 +111,7 @@ import { discoverSkills } from "./skill-discovery.js";
 import { buildToolSchema, buildToolDescription, invokeSkillTool } from "./per-skill-tools.js";
 import { listSkills, getSkillDocs } from "./docs-tools.js";
 import { troubleshootError } from "./troubleshoot.js";
+import { executeTrade } from "./trade-primitives.js";
 import { probeRuntime } from "./runtime-probe.js";
 import { BUNDLED_VERSION } from "./version.js";
 
@@ -640,6 +641,153 @@ if (simmer) {
     },
   );
 
+  // ===========================================================================
+  // RAW TRADE PRIMITIVES — direct REST, no Python subprocess
+  // ===========================================================================
+
+  // --- simmer_trade ---
+
+  server.tool(
+    "simmer_trade",
+    [
+      "Execute or dry-run a trade on a Simmer market.",
+      "",
+      "Safety triple-gate: a live trade on a real venue requires (1) dry_run=false,",
+      "(2) venue='polymarket' or 'kalshi', AND (3) SIMMER_MCP_ALLOW_LIVE=true env.",
+      "Any missing gate coerces to sim with a warning. Default: dry_run=true (paper mode).",
+      "",
+      "Use 'amount' (USD) for buys, 'shares' for sells. Providing both raises an error.",
+    ].join("\n"),
+    {
+      market_id: z.string().describe("Simmer market UUID (from simmer_get_markets)"),
+      side: z.enum(["yes", "no"]).describe("Which outcome to trade"),
+      amount: z.number().optional().describe("USD to spend (for buys). Mutually exclusive with shares."),
+      shares: z.number().optional().describe("Shares to sell (for sells). Mutually exclusive with amount."),
+      venue: z.enum(["sim", "polymarket", "kalshi"]).default("sim").describe("Trading venue. 'sim' = $SIM paper mode."),
+      dry_run: z.boolean().default(true).describe("If false (+ SIMMER_MCP_ALLOW_LIVE=true + live venue), places a real order. Default: paper mode."),
+      reasoning: z.string().optional().describe("Why you're making this trade (stored for P&L attribution and flip-flop detection)"),
+      source: z.string().optional().describe("Source tag for grouping trades (e.g. 'sdk:my-strategy')"),
+    },
+    async (args) => {
+      return executeTrade(simmer!, args);
+    },
+  );
+
+  // --- simmer_get_briefing ---
+
+  server.tool(
+    "simmer_get_briefing",
+    [
+      "Get a single-call agent briefing: portfolio balance, open positions,",
+      "top opportunities, and recent performance. Replaces 5-6 separate API calls.",
+      "Ideal for agent heartbeat check-ins.",
+    ].join("\n"),
+    {
+      since: z.string().optional().describe("ISO timestamp — only show changes since this time. Defaults to 24h ago."),
+    },
+    async ({ since }) => {
+      try {
+        const result = await simmer!.getBriefing(since);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Briefing failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // --- simmer_get_markets ---
+
+  server.tool(
+    "simmer_get_markets",
+    [
+      "List or search markets available for SDK trading.",
+      "Use 'q' for text search. Results include price, volume, and venue.",
+      "Default limit is 50; max is 500.",
+    ].join("\n"),
+    {
+      q: z.string().optional().describe("Text search query (min 2 chars, case-insensitive)"),
+      limit: z.number().optional().describe("Max markets to return (default 50, max 500)"),
+      venue: z.enum(["sim", "polymarket", "kalshi"]).optional().describe("Filter by venue"),
+      status: z.string().optional().describe("Filter by status ('active', 'resolved', etc.)"),
+      tags: z.string().optional().describe("Comma-separated tags to filter by (e.g. 'weather,crypto')"),
+      sort: z.enum(["volume", "created"]).optional().describe("Sort order: 'volume' (24h) or 'created'"),
+    },
+    async (args) => {
+      try {
+        const result = await simmer!.getMarkets(args);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Markets fetch failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // --- simmer_get_market_context ---
+
+  server.tool(
+    "simmer_get_market_context",
+    [
+      "Get rich context for a specific market: price history, your position,",
+      "recent trades, flip-flop detection, slippage estimates, and edge analysis.",
+      "Pass my_probability for a TRADE/HOLD recommendation.",
+    ].join("\n"),
+    {
+      market_id: z.string().describe("Simmer market UUID"),
+      my_probability: z.number().min(0).max(1).optional().describe("Your probability estimate (0-1) for edge calculation and TRADE/HOLD recommendation"),
+      venue: z.enum(["sim", "polymarket", "kalshi", "all"]).optional().describe("Which venue's positions to include (default 'all')"),
+    },
+    async ({ market_id, my_probability, venue }) => {
+      try {
+        const result = await simmer!.getMarketContext(market_id, { my_probability, venue });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Market context failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // --- simmer_cancel_order ---
+
+  server.tool(
+    "simmer_cancel_order",
+    "Cancel a single open order by its order ID (managed wallets only).",
+    {
+      order_id: z.string().describe("Order ID to cancel (from GET /api/sdk/orders/open)"),
+    },
+    async ({ order_id }) => {
+      try {
+        const result = await simmer!.cancelOrder(order_id);
+        return {
+          content: [{ type: "text" as const, text: `✅ Order cancelled:\n${JSON.stringify(result, null, 2)}` }],
+        };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Cancel failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
   // --- per-skill tools ---
 
   for (const skill of skills) {
@@ -670,7 +818,7 @@ async function main() {
   ].join(" | ");
 
   const freeCount = 3;
-  const proCount = simmer ? 4 + skills.length : 0;
+  const proCount = simmer ? 9 + skills.length : 0; // 4 autoresearch + 5 raw primitives
   const totalTools = freeCount + proCount;
   const tier = simmer ? "free + autoresearch + per-skill" : "free only";
 

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -111,7 +111,7 @@ import { discoverSkills } from "./skill-discovery.js";
 import { buildToolSchema, buildToolDescription, invokeSkillTool } from "./per-skill-tools.js";
 import { listSkills, getSkillDocs } from "./docs-tools.js";
 import { troubleshootError } from "./troubleshoot.js";
-import { executeTrade } from "./trade-primitives.js";
+import { executeTrade, executeCancelOrder } from "./trade-primitives.js";
 import { probeRuntime } from "./runtime-probe.js";
 import { BUNDLED_VERSION } from "./version.js";
 
@@ -769,23 +769,17 @@ if (simmer) {
 
   server.tool(
     "simmer_cancel_order",
-    "Cancel a single open order by its order ID (managed wallets only).",
+    [
+      "Cancel a single open order by its order ID (managed wallets only).",
+      "",
+      "Live state-changing action: requires SIMMER_MCP_ALLOW_LIVE=true env.",
+      "Without it, the call returns an error explaining the gate.",
+    ].join("\n"),
     {
       order_id: z.string().describe("Order ID to cancel (from GET /api/sdk/orders/open)"),
     },
     async ({ order_id }) => {
-      try {
-        const result = await simmer!.cancelOrder(order_id);
-        return {
-          content: [{ type: "text" as const, text: `✅ Order cancelled:\n${JSON.stringify(result, null, 2)}` }],
-        };
-      } catch (e) {
-        if (e instanceof BackendError) return e.toMcpResponse();
-        return {
-          content: [{ type: "text" as const, text: `❌ Cancel failed: ${e instanceof Error ? e.message : String(e)}` }],
-          isError: true,
-        };
-      }
+      return executeCancelOrder(simmer!, order_id);
     },
   );
 

--- a/mcp/src/trade-primitives.ts
+++ b/mcp/src/trade-primitives.ts
@@ -16,16 +16,21 @@ export interface TradePrimitiveResult {
   isError?: boolean;
 }
 
+// Allowlist of live venues. Anything outside this list (including "", undefined,
+// malformed strings like "polymarketz") is treated as paper/sim — defense-in-depth
+// against bypass of the MCP Zod schema by programmatic callers.
+const LIVE_VENUES = ["polymarket", "kalshi"] as const;
+
 function resolveVenue(
   dry_run: boolean,
   venue: string,
   processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): { resolvedVenue: string; coercionWarning?: string } {
   const allowLive = processEnv.SIMMER_MCP_ALLOW_LIVE === "true";
-  // Strict === false: defense-in-depth. Undefined/null/falsy values default
-  // to paper mode even if TS signature is bypassed (programmatic callers,
-  // malformed MCP args, tests). Only literal `false` opts into live.
-  const wantsLive = dry_run === false && venue !== "sim";
+  // Strict === false: only literal `false` opts into live. Undefined/null/0/""
+  // all default to paper. Paired with the venue allowlist below.
+  const isLiveVenue = (LIVE_VENUES as readonly string[]).includes(venue);
+  const wantsLive = dry_run === false && isLiveVenue;
 
   if (wantsLive && allowLive) {
     return { resolvedVenue: venue };
@@ -38,7 +43,19 @@ function resolveVenue(
         `To enable live trading on ${venue}, set SIMMER_MCP_ALLOW_LIVE=true in your MCP env.`,
     };
   }
-  return { resolvedVenue: venue };
+  // Paper path: pass venue through only if it's sim or a known live venue (for
+  // paper-trading on real pricing). Unknown/malformed venues coerce to sim
+  // with a warning so the caller knows what happened. This also ensures
+  // effectiveDryRun gets forced to true downstream (coercionWarning truthy).
+  if (venue === "sim" || isLiveVenue) {
+    return { resolvedVenue: venue };
+  }
+  return {
+    resolvedVenue: "sim",
+    coercionWarning:
+      `⚠️ Unknown venue "${venue}" coerced to sim. ` +
+      `Allowed venues: sim, polymarket, kalshi.`,
+  };
 }
 
 export async function executeTrade(
@@ -85,6 +102,42 @@ export async function executeTrade(
     if (e instanceof BackendError) return e.toMcpResponse();
     return {
       content: [{ type: "text" as const, text: `❌ Trade failed: ${e instanceof Error ? e.message : String(e)}` }],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Cancel an open order. Always a live state-changing action (no paper mode
+ * exists for cancellation), so it's gated on SIMMER_MCP_ALLOW_LIVE=true.
+ * Mirrors the live-trading posture: explicit env opt-in required.
+ */
+export async function executeCancelOrder(
+  api: SimmerApi,
+  orderId: string,
+  processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): Promise<TradePrimitiveResult> {
+  const allowLive = processEnv.SIMMER_MCP_ALLOW_LIVE === "true";
+  if (!allowLive) {
+    return {
+      content: [{
+        type: "text" as const,
+        text: `⚠️ Cancellation blocked — order cancellation is a live state-changing action. ` +
+          `Set SIMMER_MCP_ALLOW_LIVE=true in your MCP env to enable.`,
+      }],
+      isError: true,
+    };
+  }
+
+  try {
+    const result = await api.cancelOrder(orderId);
+    return {
+      content: [{ type: "text" as const, text: `✅ Order cancelled:\n${JSON.stringify(result, null, 2)}` }],
+    };
+  } catch (e) {
+    if (e instanceof BackendError) return e.toMcpResponse();
+    return {
+      content: [{ type: "text" as const, text: `❌ Cancel failed: ${e instanceof Error ? e.message : String(e)}` }],
       isError: true,
     };
   }

--- a/mcp/src/trade-primitives.ts
+++ b/mcp/src/trade-primitives.ts
@@ -1,0 +1,83 @@
+/**
+ * Raw trade primitive tools — direct REST calls, no Python subprocess.
+ * Safety gate mirrors the per-skill triple gate in env-translation.ts:
+ *   1. dry_run === false  (explicit opt-out)
+ *   2. venue is a live venue (not "sim")
+ *   3. SIMMER_MCP_ALLOW_LIVE === "true"
+ * If any gate fails, the trade is coerced to sim with a warning in the result.
+ */
+
+import type { SimmerApi, TradeParams } from "./api.js";
+import { BackendError } from "./errors.js";
+
+export interface TradePrimitiveResult {
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+function resolveVenue(
+  dry_run: boolean,
+  venue: string,
+  processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): { resolvedVenue: string; coercionWarning?: string } {
+  const allowLive = processEnv.SIMMER_MCP_ALLOW_LIVE === "true";
+  const wantsLive = !dry_run && venue !== "sim";
+
+  if (wantsLive && allowLive) {
+    return { resolvedVenue: venue };
+  }
+  if (wantsLive && !allowLive) {
+    return {
+      resolvedVenue: "sim",
+      coercionWarning:
+        `⚠️ Trade coerced to dry_run=true on sim venue. ` +
+        `To enable live trading on ${venue}, set SIMMER_MCP_ALLOW_LIVE=true in your MCP env.`,
+    };
+  }
+  return { resolvedVenue: venue };
+}
+
+export async function executeTrade(
+  api: SimmerApi,
+  args: {
+    market_id: string;
+    side: "yes" | "no";
+    amount?: number;
+    shares?: number;
+    venue: string;
+    dry_run: boolean;
+    reasoning?: string;
+    source?: string;
+  },
+  processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): Promise<TradePrimitiveResult> {
+  const { resolvedVenue, coercionWarning } = resolveVenue(args.dry_run, args.venue, processEnv);
+  const effectiveDryRun = coercionWarning ? true : args.dry_run;
+
+  const params: TradeParams = {
+    market_id: args.market_id,
+    side: args.side,
+    venue: resolvedVenue,
+    dry_run: effectiveDryRun,
+  };
+  if (args.amount !== undefined) params.amount = args.amount;
+  if (args.shares !== undefined) params.shares = args.shares;
+  if (args.reasoning) params.reasoning = args.reasoning;
+  if (args.source) params.source = args.source;
+
+  try {
+    const result = await api.trade(params);
+    const parts: string[] = [];
+    if (coercionWarning) parts.push(coercionWarning);
+    const label = effectiveDryRun ? "Dry-run result" : "Trade result";
+    parts.push(`${label}:\n${JSON.stringify(result, null, 2)}`);
+    return { content: [{ type: "text" as const, text: parts.join("\n\n") }] };
+  } catch (e) {
+    if (e instanceof BackendError) return e.toMcpResponse();
+    return {
+      content: [{ type: "text" as const, text: `❌ Trade failed: ${e instanceof Error ? e.message : String(e)}` }],
+      isError: true,
+    };
+  }
+}

--- a/mcp/src/trade-primitives.ts
+++ b/mcp/src/trade-primitives.ts
@@ -43,6 +43,7 @@ export async function executeTrade(
   args: {
     market_id: string;
     side: "yes" | "no";
+    action: "buy" | "sell";
     amount?: number;
     shares?: number;
     venue: string;
@@ -58,6 +59,7 @@ export async function executeTrade(
   const params: TradeParams = {
     market_id: args.market_id,
     side: args.side,
+    action: args.action,
     venue: resolvedVenue,
     dry_run: effectiveDryRun,
   };

--- a/mcp/src/trade-primitives.ts
+++ b/mcp/src/trade-primitives.ts
@@ -22,7 +22,10 @@ function resolveVenue(
   processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): { resolvedVenue: string; coercionWarning?: string } {
   const allowLive = processEnv.SIMMER_MCP_ALLOW_LIVE === "true";
-  const wantsLive = !dry_run && venue !== "sim";
+  // Strict === false: defense-in-depth. Undefined/null/falsy values default
+  // to paper mode even if TS signature is bypassed (programmatic callers,
+  // malformed MCP args, tests). Only literal `false` opts into live.
+  const wantsLive = dry_run === false && venue !== "sim";
 
   if (wantsLive && allowLive) {
     return { resolvedVenue: venue };
@@ -54,7 +57,10 @@ export async function executeTrade(
   processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): Promise<TradePrimitiveResult> {
   const { resolvedVenue, coercionWarning } = resolveVenue(args.dry_run, args.venue, processEnv);
-  const effectiveDryRun = coercionWarning ? true : args.dry_run;
+  // Fail-closed: only literal `false` opts out of dry-run. Undefined/null/any
+  // other falsy value defaults to paper mode. Paired with resolveVenue's
+  // strict === false check above for defense-in-depth.
+  const effectiveDryRun = args.dry_run === false && !coercionWarning ? false : true;
 
   const params: TradeParams = {
     market_id: args.market_id,

--- a/mcp/tests/trade-primitives.test.ts
+++ b/mcp/tests/trade-primitives.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for raw trade primitive tools:
- *   - executeTrade (safety gate, coercion, success/error paths)
+ *   - executeTrade (safety gate, action field, coercion, success/error paths)
  *   - SimmerApi.trade, getBriefing, getMarkets, getMarketContext, cancelOrder
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
@@ -55,7 +55,7 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
 
     const result = await executeTrade(
       api,
-      { market_id: "m1", side: "yes", amount: 10, venue: "polymarket", dry_run: false },
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "polymarket", dry_run: false },
       { /* no SIMMER_MCP_ALLOW_LIVE */ },
     );
 
@@ -75,7 +75,7 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
 
     const result = await executeTrade(
       api,
-      { market_id: "m1", side: "yes", amount: 5, venue: "polymarket", dry_run: true },
+      { market_id: "m1", side: "yes", action: "buy", amount: 5, venue: "polymarket", dry_run: true },
       { SIMMER_MCP_ALLOW_LIVE: "true" },
     );
 
@@ -94,7 +94,7 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
 
     const result = await executeTrade(
       api,
-      { market_id: "m1", side: "yes", amount: 10, venue: "polymarket", dry_run: false },
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "polymarket", dry_run: false },
       { SIMMER_MCP_ALLOW_LIVE: "true" },
     );
 
@@ -109,7 +109,7 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
 
     const result = await executeTrade(
       api,
-      { market_id: "m1", side: "yes", amount: 10, venue: "sim", dry_run: true },
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "sim", dry_run: true },
       {},
     );
 
@@ -122,12 +122,79 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
 
     const result = await executeTrade(
       api,
-      { market_id: "m1", side: "yes", amount: 10, venue: "sim", dry_run: true },
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "sim", dry_run: true },
       {},
     );
 
     assert.ok(result.isError);
     assert.ok(result.content[0].text.includes("Network timeout"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeTrade — action field (buy vs sell)
+// ---------------------------------------------------------------------------
+
+describe("executeTrade — action field threading", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("threads action='buy' into POST body", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok", action: "buy" });
+    });
+
+    await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "sim", dry_run: true },
+      {},
+    );
+
+    assert.equal(captured[0].action, "buy");
+    assert.equal(captured[0].amount, 10);
+  });
+
+  it("threads action='sell' + shares into POST body", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok", action: "sell" });
+    });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", action: "sell", shares: 50, venue: "sim", dry_run: true },
+      {},
+    );
+
+    assert.ok(!result.isError);
+    assert.equal(captured[0].action, "sell");
+    assert.equal(captured[0].shares, 50);
+    assert.equal(captured[0].amount, undefined, "amount should not be sent for sells without amount");
+  });
+
+  it("venue gate still coerces a sell on live venue without SIMMER_MCP_ALLOW_LIVE", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok" });
+    });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", action: "sell", shares: 25, venue: "polymarket", dry_run: false },
+      { /* no SIMMER_MCP_ALLOW_LIVE */ },
+    );
+
+    assert.ok(!result.isError);
+    assert.ok(result.content[0].text.includes("coerced"), "sell coercion warning should appear");
+    assert.equal(captured[0].venue, "sim");
+    assert.equal(captured[0].action, "sell"); // action still threads through correctly
+    assert.equal(captured[0].dry_run, true);
   });
 });
 

--- a/mcp/tests/trade-primitives.test.ts
+++ b/mcp/tests/trade-primitives.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { executeTrade } from "../dist/trade-primitives.js";
+import { executeTrade, executeCancelOrder } from "../dist/trade-primitives.js";
 import { SimmerApi } from "../dist/api.js";
 import { BackendError } from "../dist/errors.js";
 
@@ -122,6 +122,45 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
 
     assert.ok(!result.isError);
     // Critical: dry_run MUST be true (not false, not undefined) — no live trade.
+    assert.equal(captured[0].dry_run, true);
+  });
+
+  it("coerces malformed venue to sim even with dry_run=false + ALLOW_LIVE=true", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok" });
+    });
+
+    // Bypass Zod schema — simulate caller passing a malformed venue string.
+    // Only the LIVE_VENUES allowlist (polymarket, kalshi) opens the live gate.
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "polymarketz", dry_run: false },
+      { SIMMER_MCP_ALLOW_LIVE: "true" },
+    );
+
+    assert.ok(!result.isError);
+    // Malformed venue must coerce to sim — never forward "polymarketz" downstream.
+    assert.equal(captured[0].venue, "sim");
+    assert.equal(captured[0].dry_run, true);
+  });
+
+  it("coerces empty venue to sim", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok" });
+    });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "", dry_run: false },
+      { SIMMER_MCP_ALLOW_LIVE: "true" },
+    );
+
+    assert.ok(!result.isError);
+    assert.equal(captured[0].venue, "sim");
     assert.equal(captured[0].dry_run, true);
   });
 
@@ -344,5 +383,67 @@ describe("SimmerApi.cancelOrder", () => {
       assert.equal(e.statusCode, 404);
       return true;
     });
+  });
+});
+
+describe("executeCancelOrder — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("blocks cancellation when SIMMER_MCP_ALLOW_LIVE is not set", async () => {
+    let fetchCalled = false;
+    mockFetch(async () => { fetchCalled = true; return okJson({ cancelled: true }); });
+
+    const result = await executeCancelOrder(api, "o1", { /* no SIMMER_MCP_ALLOW_LIVE */ });
+
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes("blocked"), "should mention block");
+    assert.ok(result.content[0].text.includes("SIMMER_MCP_ALLOW_LIVE"), "should name the gate");
+    assert.equal(fetchCalled, false, "must NOT hit the backend");
+  });
+
+  it("blocks cancellation when SIMMER_MCP_ALLOW_LIVE is empty string", async () => {
+    let fetchCalled = false;
+    mockFetch(async () => { fetchCalled = true; return okJson({ cancelled: true }); });
+
+    const result = await executeCancelOrder(api, "o1", { SIMMER_MCP_ALLOW_LIVE: "" });
+
+    assert.equal(result.isError, true);
+    assert.equal(fetchCalled, false);
+  });
+
+  it("blocks cancellation when SIMMER_MCP_ALLOW_LIVE is 'false'", async () => {
+    let fetchCalled = false;
+    mockFetch(async () => { fetchCalled = true; return okJson({ cancelled: true }); });
+
+    const result = await executeCancelOrder(api, "o1", { SIMMER_MCP_ALLOW_LIVE: "false" });
+
+    assert.equal(result.isError, true);
+    assert.equal(fetchCalled, false);
+  });
+
+  it("allows cancellation when SIMMER_MCP_ALLOW_LIVE='true'", async () => {
+    const methods: string[] = [];
+    mockFetch(async (_url, init) => {
+      methods.push(init?.method ?? "GET");
+      return okJson({ cancelled: true, order_id: "o1" });
+    });
+
+    const result = await executeCancelOrder(api, "o1", { SIMMER_MCP_ALLOW_LIVE: "true" });
+
+    assert.ok(!result.isError);
+    assert.equal(methods[0], "DELETE");
+    assert.ok(result.content[0].text.includes("cancelled"));
+  });
+
+  it("surfaces BackendError correctly when backend rejects", async () => {
+    mockFetch(async () => errorJson(404, "Order not found"));
+
+    const result = await executeCancelOrder(api, "bad-order", { SIMMER_MCP_ALLOW_LIVE: "true" });
+
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes("404") || result.content[0].text.includes("not found"));
   });
 });

--- a/mcp/tests/trade-primitives.test.ts
+++ b/mcp/tests/trade-primitives.test.ts
@@ -104,6 +104,27 @@ describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
     assert.ok(!result.content[0].text.includes("coerced"), "should not warn about coercion");
   });
 
+  it("fail-closes when dry_run is undefined even with ALLOW_LIVE=true (defense-in-depth)", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok" });
+    });
+
+    // Bypass TS signature — simulate programmatic/malformed caller passing undefined.
+    // Only literal `dry_run === false` should open the live gate; undefined must
+    // coerce dry_run to true (paper). Venue may pass through (paper on real pricing).
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", action: "buy", amount: 10, venue: "polymarket", dry_run: undefined as unknown as boolean },
+      { SIMMER_MCP_ALLOW_LIVE: "true" },
+    );
+
+    assert.ok(!result.isError);
+    // Critical: dry_run MUST be true (not false, not undefined) — no live trade.
+    assert.equal(captured[0].dry_run, true);
+  });
+
   it("returns BackendError response on 4xx", async () => {
     mockFetch(async () => errorJson(401, "Invalid API key"));
 

--- a/mcp/tests/trade-primitives.test.ts
+++ b/mcp/tests/trade-primitives.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for raw trade primitive tools:
+ *   - executeTrade (safety gate, coercion, success/error paths)
+ *   - SimmerApi.trade, getBriefing, getMarkets, getMarketContext, cancelOrder
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { executeTrade } from "../dist/trade-primitives.js";
+import { SimmerApi } from "../dist/api.js";
+import { BackendError } from "../dist/errors.js";
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof global.fetch;
+let savedFetch: FetchFn;
+
+function mockFetch(fn: FetchFn) {
+  // @ts-expect-error global override for testing
+  global.fetch = fn;
+}
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorJson(status: number, detail: string): Response {
+  return new Response(JSON.stringify({ detail }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// executeTrade — safety gate tests
+// ---------------------------------------------------------------------------
+
+describe("executeTrade — safety gate (SIMMER_MCP_ALLOW_LIVE)", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("coerces to sim when SIMMER_MCP_ALLOW_LIVE is not set", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (url, init) => {
+      const body = JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>;
+      captured.push({ url: url.toString(), body });
+      return okJson({ status: "ok", venue: "sim", dry_run: true });
+    });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", amount: 10, venue: "polymarket", dry_run: false },
+      { /* no SIMMER_MCP_ALLOW_LIVE */ },
+    );
+
+    assert.ok(!result.isError, "should not be error");
+    assert.ok(result.content[0].text.includes("coerced"), "should mention coercion");
+    // The POST body should have venue=sim and dry_run=true
+    assert.equal(captured[0].body.venue, "sim");
+    assert.equal(captured[0].body.dry_run, true);
+  });
+
+  it("coerces to sim when dry_run=true even with SIMMER_MCP_ALLOW_LIVE=true", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "ok" });
+    });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", amount: 5, venue: "polymarket", dry_run: true },
+      { SIMMER_MCP_ALLOW_LIVE: "true" },
+    );
+
+    assert.ok(!result.isError);
+    // dry_run stays true — no coercion warning needed (caller already asked for paper)
+    assert.equal(captured[0].dry_run, true);
+    assert.equal(captured[0].venue, "polymarket"); // venue passes through for dry-run context
+  });
+
+  it("allows live trade when all 3 gates pass", async () => {
+    const captured: Record<string, unknown>[] = [];
+    mockFetch(async (_url, init) => {
+      captured.push(JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>);
+      return okJson({ status: "executed", venue: "polymarket" });
+    });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", amount: 10, venue: "polymarket", dry_run: false },
+      { SIMMER_MCP_ALLOW_LIVE: "true" },
+    );
+
+    assert.ok(!result.isError);
+    assert.equal(captured[0].venue, "polymarket");
+    assert.equal(captured[0].dry_run, false);
+    assert.ok(!result.content[0].text.includes("coerced"), "should not warn about coercion");
+  });
+
+  it("returns BackendError response on 4xx", async () => {
+    mockFetch(async () => errorJson(401, "Invalid API key"));
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", amount: 10, venue: "sim", dry_run: true },
+      {},
+    );
+
+    assert.ok(result.isError);
+    assert.ok(result.content[0].text.includes("Invalid API key"));
+  });
+
+  it("returns error text on network failure", async () => {
+    mockFetch(async () => { throw new Error("Network timeout"); });
+
+    const result = await executeTrade(
+      api,
+      { market_id: "m1", side: "yes", amount: 10, venue: "sim", dry_run: true },
+      {},
+    );
+
+    assert.ok(result.isError);
+    assert.ok(result.content[0].text.includes("Network timeout"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SimmerApi raw primitive methods
+// ---------------------------------------------------------------------------
+
+describe("SimmerApi.getBriefing", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("returns parsed briefing on 200", async () => {
+    const fixture = { portfolio: { balance: 100 }, positions: [] };
+    mockFetch(async () => okJson(fixture));
+    const result = await api.getBriefing();
+    assert.deepEqual(result, fixture);
+  });
+
+  it("appends since param when provided", async () => {
+    const urls: string[] = [];
+    mockFetch(async (url) => { urls.push(url.toString()); return okJson({}); });
+    await api.getBriefing("2026-01-01T00:00:00Z");
+    assert.ok(urls[0].includes("since="), "URL should include since param");
+  });
+
+  it("throws BackendError on 403", async () => {
+    mockFetch(async () => errorJson(403, "Pro required"));
+    await assert.rejects(() => api.getBriefing(), (e) => {
+      assert.ok(e instanceof BackendError);
+      assert.equal(e.statusCode, 403);
+      return true;
+    });
+  });
+});
+
+describe("SimmerApi.getMarkets", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("returns markets list on 200", async () => {
+    const fixture = { markets: [{ id: "m1", question: "Will it rain?" }] };
+    mockFetch(async () => okJson(fixture));
+    const result = await api.getMarkets({ q: "rain" });
+    assert.deepEqual(result, fixture);
+  });
+
+  it("builds query string from params", async () => {
+    const urls: string[] = [];
+    mockFetch(async (url) => { urls.push(url.toString()); return okJson({ markets: [] }); });
+    await api.getMarkets({ q: "bitcoin", limit: 10, venue: "polymarket", status: "active" });
+    const u = new URL(urls[0]);
+    assert.equal(u.searchParams.get("q"), "bitcoin");
+    assert.equal(u.searchParams.get("limit"), "10");
+    assert.equal(u.searchParams.get("venue"), "polymarket");
+    assert.equal(u.searchParams.get("status"), "active");
+  });
+
+  it("throws BackendError on non-200", async () => {
+    mockFetch(async () => errorJson(500, "Internal server error"));
+    await assert.rejects(() => api.getMarkets({}), (e) => {
+      assert.ok(e instanceof BackendError);
+      assert.equal(e.statusCode, 500);
+      return true;
+    });
+  });
+});
+
+describe("SimmerApi.getMarketContext", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("returns context on 200", async () => {
+    const fixture = { market: { id: "m1" }, edge: { recommendation: "TRADE" } };
+    mockFetch(async () => okJson(fixture));
+    const result = await api.getMarketContext("m1", { my_probability: 0.8 });
+    assert.deepEqual(result, fixture);
+  });
+
+  it("URL-encodes market ID", async () => {
+    const urls: string[] = [];
+    mockFetch(async (url) => { urls.push(url.toString()); return okJson({}); });
+    await api.getMarketContext("market/with/slashes");
+    assert.ok(urls[0].includes("market%2Fwith%2Fslashes"), "market ID should be URL-encoded");
+  });
+
+  it("throws BackendError on 404", async () => {
+    mockFetch(async () => errorJson(404, "Market not found"));
+    await assert.rejects(() => api.getMarketContext("bad-id"), (e) => {
+      assert.ok(e instanceof BackendError);
+      assert.equal(e.statusCode, 404);
+      return true;
+    });
+  });
+});
+
+describe("SimmerApi.cancelOrder", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  const api = new SimmerApi("sk_live_test", "https://api.simmer.markets", "3.3.0");
+
+  it("sends DELETE request and returns result", async () => {
+    const methods: string[] = [];
+    const urls: string[] = [];
+    mockFetch(async (url, init) => {
+      methods.push(init?.method ?? "GET");
+      urls.push(url.toString());
+      return okJson({ cancelled: true, order_id: "o1" });
+    });
+    const result = await api.cancelOrder("o1");
+    assert.equal(methods[0], "DELETE");
+    assert.ok(urls[0].endsWith("/api/sdk/orders/o1"));
+    assert.deepEqual(result, { cancelled: true, order_id: "o1" });
+  });
+
+  it("throws BackendError on 404", async () => {
+    mockFetch(async () => errorJson(404, "Order not found"));
+    await assert.rejects(() => api.cancelOrder("bad-order"), (e) => {
+      assert.ok(e instanceof BackendError);
+      assert.equal(e.statusCode, 404);
+      return true;
+    });
+  });
+});


### PR DESCRIPTION
Add 5 raw trade primitive MCP tools as direct REST wrappers. No Python subprocess — same model as the existing `troubleshoot_error` tool.

## New tools

| Tool | Wraps | Notes |
|---|---|---|
| `simmer_trade` | `POST /api/sdk/trade` | Safety triple-gate: dry_run=false + live venue + SIMMER_MCP_ALLOW_LIVE=true; coerces to sim with warning on any missing gate |
| `simmer_get_briefing` | `GET /api/sdk/briefing` | Single-call heartbeat: portfolio, positions, opportunities, performance |
| `simmer_get_markets` | `GET /api/sdk/markets` | Search/filter with q, limit, venue, status, tags, sort |
| `simmer_get_market_context` | `GET /api/sdk/context/{id}` | Rich context: price history, positions, slippage, TRADE/HOLD recommendation |
| `simmer_cancel_order` | `DELETE /api/sdk/orders/{id}` | Cancel a single open order |

## Changes

- `mcp/package.json`: version bump 3.2.0 → 3.3.0
- `mcp/src/api.ts`: 5 new methods on `SimmerApi` (`trade`, `getBriefing`, `getMarkets`, `getMarketContext`, `cancelOrder`) with typed params/returns and `BackendError` on 4xx/5xx
- `mcp/src/trade-primitives.ts`: new file — `executeTrade` with fail-closed venue gate (mirrors env-translation.ts triple gate for per-skill tools)
- `mcp/src/mcp-server.ts`: 5 new tool registrations in the `if (simmer)` block; tool count updated (4 autoresearch + 5 primitives + N per-skill)
- `mcp/tests/trade-primitives.test.ts`: 16 tests — all 5 safety gate paths, all 5 API methods (success, error, URL encoding, DELETE routing)

## Tests

`node --test 'tests/*.test.ts'` → 120 pass, 0 fail (16 new tests in trade-primitives, 104 existing passing)

## Safety

- `simmer_trade` defaults `dry_run: true` — paper mode by default
- Live trading requires all three: `dry_run=false` + `venue=polymarket|kalshi` + `SIMMER_MCP_ALLOW_LIVE=true` env
- Any missing gate coerces to sim with a clear coercion warning in the response
- Backend rails still apply: per-trade $100 cap, daily $500 cap

## Docs impact

Yes — adds 5 new MCP tools to simmer-mcp. Mintlify update needed in simmer-docs once merged.

Closes SIM-2323