### PR TITLE
fix(skills): guard sources=None in exit scan (SIM-2371)

### DIFF
--- a/skills/kalshi-weather-trader/CHANGELOG.md
+++ b/skills/kalshi-weather-trader/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog — kalshi-weather-trader
+
+## [1.0.8] - 2026-05-23
+
+### Fixed
+- `check_exit_opportunities` no longer crashes with `TypeError: argument of type 'NoneType' is not iterable` when a position's `sources` field is `None` (e.g. paper-mode entries). Changed `pos.get("sources", [])` → `pos.get("sources") or []` so explicit `None` values are coalesced to `[]`. Closes SIM-2371.
+
+## [1.0.7] - prior
+- See git history.

--- a/skills/kalshi-weather-trader/SKILL.md
+++ b/skills/kalshi-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: kalshi-weather-trader
 description: Trade Kalshi weather markets using NOAA forecasts via Simmer SDK and DFlow on Solana. Port of the popular polymarket-weather-trader. Use when user wants to trade temperature markets on Kalshi, automate weather bets, or check NOAA forecasts.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.7"
+  version: "1.0.8"
   displayName: Kalshi Weather Trader
   difficulty: intermediate
   attribution: Strategy inspired by gopfan2, powered by DFlow

--- a/skills/kalshi-weather-trader/tests/test_sources_none.py
+++ b/skills/kalshi-weather-trader/tests/test_sources_none.py
@@ -1,0 +1,95 @@
+"""
+Regression tests for SIM-2371: sources=None crash in check_exit_opportunities.
+
+Verifies that a position dict with sources=None does not raise TypeError and
+that the keyword fallback still matches weather positions correctly.
+
+Pure-unit: no network calls, no SDK required.
+"""
+
+import sys
+import os
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15,
+    "exit_threshold": 0.45,
+    "max_position_usd": 2.00,
+    "sizing_pct": 0.05,
+    "max_trades_per_run": 5,
+    "locations": "NYC",
+    "binary_only": False,
+    "slippage_max": 0.15,
+    "min_liquidity": 0.0,
+}
+
+_skill_mod = types.ModuleType("simmer_sdk.skill")
+_skill_mod.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_mod.update_config = lambda updates, file, slug=None: None
+_skill_mod.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = MagicMock()
+sys.modules["simmer_sdk.skill"] = _skill_mod
+
+import weather_trader as wt  # noqa: E402
+
+
+class TestSourcesNoneExitScan(unittest.TestCase):
+
+    def _pos(self, sources, question, price=0.20, shares=5.0):
+        return {
+            "market_id": "m-test",
+            "sources": sources,
+            "question": question,
+            "current_price": price,
+            "shares_yes": shares,
+            "status": "open",
+        }
+
+    def test_sources_none_does_not_crash(self):
+        """sources=None must not raise TypeError in check_exit_opportunities."""
+        pos = self._pos(sources=None, question="will the highest temperature in nyc exceed 80°f?")
+        with patch.object(wt, "get_positions", return_value=[pos]):
+            # Must not raise — this is the regression guard for SIM-2371
+            result = wt.check_exit_opportunities(dry_run=True, use_safeguards=False)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_keyword_fallback_matches_when_sources_none(self):
+        """Position with sources=None is still matched via question keyword fallback."""
+        # Price above EXIT_THRESHOLD so exits_found increments if the position is matched
+        pos = self._pos(
+            sources=None,
+            question="will the highest temperature in nyc exceed 80°f?",
+            price=0.90,   # > EXIT_THRESHOLD (0.45)
+            shares=5.0,
+        )
+        with patch.object(wt, "get_positions", return_value=[pos]), \
+             patch.object(wt, "execute_sell", return_value={"success": True, "simulated": True}):
+            exits_found, exits_executed = wt.check_exit_opportunities(
+                dry_run=True, use_safeguards=False
+            )
+        # If keyword fallback didn't match, weather_positions would be empty and
+        # check_exit_opportunities would return (0, 0) from the early-exit guard.
+        # exits_found=1 proves the position was matched and processed.
+        self.assertEqual(exits_found, 1)
+        self.assertEqual(exits_executed, 1)
+
+    def test_no_keyword_no_source_skipped(self):
+        """Position with sources=None and no weather keyword is NOT matched."""
+        pos = self._pos(sources=None, question="will the next us president be a democrat?")
+        with patch.object(wt, "get_positions", return_value=[pos]):
+            exits_found, exits_executed = wt.check_exit_opportunities(
+                dry_run=True, use_safeguards=False
+            )
+        # No weather match → returns immediately from empty weather_positions guard
+        self.assertEqual(exits_found, 0)
+        self.assertEqual(exits_executed, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/kalshi-weather-trader/weather_trader.py
+++ b/skills/kalshi-weather-trader/weather_trader.py
@@ -664,7 +664,7 @@ def check_exit_opportunities(dry_run: bool = False, use_safeguards: bool = True)
     weather_positions = []
     for pos in positions:
         question = pos.get("question", "").lower()
-        sources = pos.get("sources", [])
+        sources = pos.get("sources") or []
         # Check if from weather skill OR has weather keywords
         if TRADE_SOURCE in sources or any(kw in question for kw in ["temperature", "°f", "highest temp", "lowest temp"]):
             weather_positions.append(pos)
@@ -807,7 +807,7 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         else:
             for pos in positions:
                 log(f"  • {pos.get('question', 'Unknown')[:50]}...")
-                sources = pos.get('sources', [])
+                sources = pos.get('sources') or []
                 log(f"    YES: {pos.get('shares_yes', 0):.1f} | NO: {pos.get('shares_no', 0):.1f} | P&L: ${pos.get('pnl', 0):.2f} | Sources: {sources}")
         return
 

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -443,7 +443,7 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
         else:
             for pos in positions:
                 question = pos.get("question", "Unknown")[:50]
-                sources = pos.get("sources", [])
+                sources = pos.get("sources") or []
                 print(f"  - {question}...")
                 print(f"    YES: {pos.get('shares_yes', 0):.1f} | NO: {pos.get('shares_no', 0):.1f} | P&L: ${pos.get('pnl', 0):.2f} | Sources: {sources}")
         return

--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog — polymarket-weather-trader
+
+## [1.21.2] - 2026-05-23
+
+### Fixed
+- `check_exit_opportunities` no longer crashes with `TypeError: argument of type 'NoneType' is not iterable` when a position's `sources` field is `None` (e.g. paper-mode entries). Changed `pos.get("sources", [])` → `pos.get("sources") or []` so explicit `None` values are coalesced to `[]`. Closes SIM-2371.
+
+## [1.21.1] - prior
+- See git history.

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.21.1"
+  version: "1.21.2"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/tests/test_sources_none.py
+++ b/skills/polymarket-weather-trader/tests/test_sources_none.py
@@ -1,0 +1,101 @@
+"""
+Regression tests for SIM-2371: sources=None crash in check_exit_opportunities.
+
+Verifies that a position dict with sources=None does not raise TypeError and
+that the keyword fallback still matches weather positions correctly.
+
+Pure-unit: no network calls, no SDK required.
+"""
+
+import sys
+import os
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15,
+    "exit_threshold": 0.45,
+    "max_position_usd": 2.00,
+    "sizing_pct": 0.05,
+    "max_trades_per_run": 5,
+    "locations": "NYC",
+    "binary_only": False,
+    "slippage_max": 0.15,
+    "min_liquidity": 0.0,
+    "order_type": "GTC",
+    "vol_targeting": False,
+    "target_vol": 0.20,
+    "vol_max_leverage": 2.0,
+    "vol_min_allocation": 0.2,
+    "vol_span": 10,
+}
+
+_skill_mod = types.ModuleType("simmer_sdk.skill")
+_skill_mod.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_mod.update_config = lambda updates, file, slug=None: None
+_skill_mod.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = MagicMock()
+sys.modules["simmer_sdk.skill"] = _skill_mod
+
+import weather_trader as wt  # noqa: E402
+
+
+class TestSourcesNoneExitScan(unittest.TestCase):
+
+    def _pos(self, sources, question, price=0.20, shares=10.0):
+        return {
+            "market_id": "m-test",
+            "sources": sources,
+            "question": question,
+            "current_price": price,
+            "shares_yes": shares,
+            "status": "open",
+        }
+
+    def test_sources_none_does_not_crash(self):
+        """sources=None must not raise TypeError in check_exit_opportunities."""
+        pos = self._pos(sources=None, question="will the highest temperature in nyc exceed 80°f?")
+        with patch.object(wt, "get_positions", return_value=[pos]):
+            # Must not raise — this is the regression guard for SIM-2371
+            result = wt.check_exit_opportunities(dry_run=True, use_safeguards=False)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_keyword_fallback_matches_when_sources_none(self):
+        """Position with sources=None is still matched via question keyword fallback."""
+        # Price above EXIT_THRESHOLD so exits_found increments if the position is matched
+        pos = self._pos(
+            sources=None,
+            question="will the highest temperature in nyc exceed 80°f?",
+            price=0.90,   # > EXIT_THRESHOLD (0.45)
+            shares=10.0,
+        )
+        with patch.object(wt, "get_positions", return_value=[pos]), \
+             patch.object(wt, "execute_sell", return_value={"success": True, "simulated": True}):
+            exits_found, exits_executed = wt.check_exit_opportunities(
+                dry_run=True, use_safeguards=False
+            )
+        # If keyword fallback didn't match, weather_positions would be empty and
+        # check_exit_opportunities would return (0, 0) from the early-exit guard.
+        # exits_found=1 proves the position was matched and processed.
+        self.assertEqual(exits_found, 1)
+        self.assertEqual(exits_executed, 1)
+
+    def test_no_keyword_no_source_skipped(self):
+        """Position with sources=None and no weather keyword is NOT matched."""
+        pos = self._pos(sources=None, question="will the next us president be a democrat?")
+        with patch.object(wt, "get_positions", return_value=[pos]):
+            exits_found, exits_executed = wt.check_exit_opportunities(
+                dry_run=True, use_safeguards=False
+            )
+        # No weather match → returns immediately from empty weather_positions guard
+        self.assertEqual(exits_found, 0)
+        self.assertEqual(exits_executed, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -1015,7 +1015,7 @@ def check_exit_opportunities(dry_run: bool = False, use_safeguards: bool = True)
     weather_positions = []
     for pos in positions:
         question = pos.get("question", "").lower()
-        sources = pos.get("sources", [])
+        sources = pos.get("sources") or []
         # Check if from weather skill OR has weather keywords
         if TRADE_SOURCE in sources or any(kw in question for kw in ["temperature", "°f", "highest temp", "lowest temp"]):
             weather_positions.append(pos)
@@ -1192,7 +1192,7 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         else:
             for pos in positions:
                 log(f"  • {pos.get('question', 'Unknown')[:50]}...")
-                sources = pos.get('sources', [])
+                sources = pos.get('sources') or []
                 log(f"    YES: {pos.get('shares_yes', 0):.1f} | NO: {pos.get('shares_no', 0):.1f} | P&L: ${pos.get('pnl', 0):.2f} | Sources: {sources}")
         return
 


### PR DESCRIPTION
`pos.get("sources", [])` returns `None` when the key exists with a `None` value — `dict.get(key, default)` only returns the default when the key is absent, not when the value is `None`. The subsequent `TRADE_SOURCE in sources` then raises `TypeError: argument of type 'NoneType' is not iterable`.

Fix: change to `pos.get("sources") or []` which coalesces `None` to `[]`.

## Changes
- `skills/polymarket-weather-trader/weather_trader.py`: fix both `sources` reads (exit scan filter + position log display)
- `skills/kalshi-weather-trader/weather_trader.py`: same two sites
- `skills/polymarket-mert-sniper/mert_sniper.py`: defensive fix on logging-only site

## Tests
- `py_compile` passes on all three modified files
- Root cause confirmed: paper-mode entry creates a position dict where `sources` key exists but is `None`; `.get("sources", [])` returns `None` (not `[]`); `in None` raises `TypeError`
- Autoresearch dry-run repro matches the reported stack trace exactly

## Docs impact
No SDK surface change; internal skill behaviour only.

Closes SIM-2371