### PR TITLE
fix(skills/simmer-x402): add DISCLAIMER.md + bounding language (canary for catalog-reshape Tier 2)

### DIFF
--- a/skills/simmer-x402/DISCLAIMER.md
+++ b/skills/simmer-x402/DISCLAIMER.md
@@ -1,0 +1,49 @@
+# Disclaimer
+
+This skill is a **framework for x402 payment plumbing**, not financial advice.
+Read this in full before connecting it to a wallet with real funds.
+
+## No financial advice
+
+Nothing in this skill constitutes financial, investment, or payment-strategy
+advice. The skill handles the mechanical flow of detecting `402 Payment
+Required` responses and producing valid x402 settlement transactions on Base.
+What endpoints you pay for, at what price, and how often is a policy decision
+left entirely to the operator.
+
+## Real on-chain payments — irreversible
+
+When this skill executes a payment, it broadcasts a real on-chain USDC
+transfer on Base. On-chain transfers cannot be recalled. Confirmed payments
+to a malicious or misconfigured endpoint cannot be clawed back.
+
+Mitigations available in the skill:
+- `--dry-run` shows the payment payload without broadcasting.
+- `--max <USD>` caps the per-call payment amount.
+- The `X402_MAX_PAYMENT_USD` env var sets a default cap for unattended runs.
+
+These mitigations bound per-call exposure; they do not prevent malicious or
+misconfigured endpoints from charging the cap repeatedly. Audit your call
+sites and rate-limit at the agent layer.
+
+## Default parameters are starting points
+
+Default per-call caps and balance thresholds are calibrated for testing
+plumbing, not for production payment volumes. Review every parameter before
+scaling.
+
+## Scope the funded wallet
+
+The wallet you fund for x402 payments has full balance authority — any call
+the agent makes that hits an x402-gated endpoint can spend up to the
+configured cap. Treat the x402 wallet as scoped working capital, not a
+treasury wallet. Fund it with the amount you expect to spend in the next
+session, no more.
+
+## Use of this skill is at your own risk
+
+By installing and running this skill you agree that the authors are not
+liable for any losses, direct or indirect, that arise from its use. This
+applies regardless of skill provenance — official Simmer skills, community
+skills, and skills imported from external repositories all carry this same
+disclaimer.

--- a/skills/simmer-x402/SKILL.md
+++ b/skills/simmer-x402/SKILL.md
@@ -3,13 +3,17 @@ name: simmer-x402
 description: Make x402 payments to access paid APIs and gated content. Use when a skill needs to fetch data from x402-gated endpoints (like Kaito mindshare API, Simmer premium endpoints, or any x402 provider). Handles 402 Payment Required responses automatically using USDC on Base.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.8"
+  version: "1.0.9"
   displayName: x402 Payments
   difficulty: advanced
 ---
 # x402 Payments
 
 Pay for x402-gated APIs using USDC on Base. This skill enables agents to autonomously make crypto payments when accessing paid web resources.
+
+> 🚨 **Framework for x402 payment plumbing, not financial advice.** Read [DISCLAIMER.md](./DISCLAIMER.md) before connecting to a wallet with real funds. Cap per-call payments with `--max <USD>` or the `X402_MAX_PAYMENT_USD` env var; the wallet should be a scoped working-capital wallet, not your treasury.
+
+> **This is a template.** The default `x402_cli.py` handles 402 detection, payment-payload construction, and balance checks. Bring your own policy for which endpoints to pay for, what max payment per call is acceptable, and how to scope the funded wallet.
 
 ## When to Use This Skill
 


### PR DESCRIPTION
## Summary

Canary fix for the catalog-reshape Tier 2 work (LLM-flagged official skill content reframes).

- `simmer-x402` was the only suspicious official skill with no `DISCLAIMER.md` at all and no framework warning in its `SKILL.md` opening
- The v2.4.22+ ClawHub scanner flagged it `suspicious.llm_suspicious` consistently
- Standard trading disclaimer template doesn't fit verbatim (x402 is payment plumbing, not a trading strategy) — adapted to the payments-utility domain
- Bumped `1.0.8` → `1.0.9`

## Pattern applied

From `simmer/_dev/active/_skill-catalog-reshape/findings/2026-05-23-post-pob-fix-baseline.md` (Pattern extraction section):

1. `DISCLAIMER.md` exists in skill dir ✓
2. First 30 lines of `SKILL.md` reference it ✓
3. First 30 lines contain framework/template bounding language ✓
4. Quantitative bounding (per-call payment cap mentioned in opening) ✓

## Test plan

- [ ] Publish to ClawHub (`clawhub publish` or equivalent)
- [ ] Wait 24h
- [ ] Re-run `python scripts/audit_v2_backfill.py` in simmer repo
- [ ] Confirm `simmer-x402` verdict is no longer `suspicious.llm_suspicious`
- [ ] If durable clean, apply same pattern to `polymarket-copytrading` (relocate disclaimer from line 50 to first 30 lines) and `polymarket-mert-sniper` (full content reframe to deemphasize "snipe")

Refs: simmer commit `82a39586`, simmer finding doc `2026-05-23-post-pob-fix-baseline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)