### PR TITLE
fix(skills/polymarket-copytrading): relocate disclaimer to first 30 lines

### DIFF
--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,13 +3,17 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.11.0"
+  version: "1.11.1"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---
 # Polymarket Copytrading
 
-Mirror positions from successful Polymarket traders using the Simmer SDK. Two modes share the same skill, use whichever fits your strategy:
+Mirror positions from successful Polymarket traders using the Simmer SDK. Two modes share the same skill, use whichever fits your strategy.
+
+> 🚨 **Framework, not a production trading system.** Read [DISCLAIMER.md](./DISCLAIMER.md) before connecting to a wallet with real funds. Per-position cap defaults to $50; per-run cap defaults to 10 trades. Use `$SIM` paper-mode to validate any new whale selection before scaling to real USDC.
+
+> **This is a template.** The default logic mirrors whale wallets — remix it with your own wallet selection, sizing rules, filters, or cap logic. The skill handles all the plumbing (signal polling, trade execution, dedup, signing). Your agent provides the alpha.
 
 | | **Polling mode** (free) | **Reactor mode** (Pro) |
 |---|---|---|
@@ -19,8 +23,6 @@ Mirror positions from successful Polymarket traders using the Simmer SDK. Two mo
 | Strategy | Size-weighted aggregation across wallets, conviction tiering, rebalance to target allocations, drift/stale filters | Event-by-event mirror with fixed `mirror_fraction` sizing, programmatic filters |
 | Best for | Portfolio-aware, multi-whale, periodic scans | Real-time reaction to specific whales as they trade |
 | Requires | `SIMMER_API_KEY` | `SIMMER_API_KEY` + Simmer Pro plan |
-
-> **This is a template.** The default logic mirrors whale wallets — remix it with your own wallet selection, sizing rules, filters, or cap logic. The skill handles all the plumbing (signal polling, trade execution, dedup, signing). Your agent provides the alpha.
 
 ## Setup Flow
 
@@ -46,8 +48,6 @@ When user asks to install or configure this skill:
    - Max per position: Amount per trade (default $50)
    - Top N positions: How many positions to track (auto-calculated from balance)
    - Max trades per run: Safety cap (default 10)
-
-> 🚨 **Framework, not a production trading system.** Read [DISCLAIMER.md](./DISCLAIMER.md) before connecting to a wallet with real funds.
 
 ## When to Use This Skill
 


### PR DESCRIPTION
## Summary

Second skill in catalog-reshape Tier 2. Same pattern as the just-shipped simmer-x402 canary (PR #131, scanner.aggregate.clean at first scan).

- DISCLAIMER.md reference existed but was buried at line 50 — scanner reads first ~30 lines most weighted, so the warning was invisible
- Moved it to line 14 (right after opening paragraph, before the modes table)
- Added quantitative bounding language ($50 per-position, 10 trades/run, $SIM paper validation)
- Version 1.11.0 → 1.11.1

## Pattern applied (from finding doc)

1. DISCLAIMER.md exists ✓ (no change)
2. Referenced in first 30 lines ✓ (line 14 now, was line 50)
3. Framework/template bounding language in first 30 lines ✓
4. Quantitative bounding in opening prose ✓ (caps + paper-mode mention)

## Test plan

- [ ] Merge + publish via `clawhub publish skills/polymarket-copytrading --slug polymarket-copytrading --owner simmer --version 1.11.1`
- [ ] Verify initial ClawHub scan returns clean (per simmer-x402 precedent at first scan)
- [ ] 24h durability watch
- [ ] Re-run `python scripts/audit_v2_backfill.py` in simmer
- [ ] Confirm `polymarket-copytrading` verdict flips from `suspicious.llm_suspicious` → `clean`

Refs: simmer finding doc `_dev/active/_skill-catalog-reshape/findings/2026-05-23-post-pob-fix-baseline.md`, canary PR #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)