### PR TITLE
fix(tests): scope sys.modules simmer_sdk stub with patch.dict (SIM-2382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Preflight-gate test stubs scoped with `patch.dict`.** Three preflight-gate test files previously used `sys.modules.setdefault("simmer_sdk", MagicMock())` which could permanently replace the real SDK module when tests ran in a mixed collection order. Replaced with a `patch.dict` context manager scoped to the skill import.
+
 - **`auto_redeem()` warns when signing key is unavailable.** Previously failed silently for managed-wallet users calling `auto_redeem()` without a local signing key. Now surfaces a visible warning explaining that managed-wallet redemptions are handled server-side.
 
 - **Tunable env-var names aligned between `clawhub.json` and `CONFIG_SCHEMA`.** Skills that declared config tunables in both their ClawHub metadata and their Python CONFIG_SCHEMA could have name mismatches (e.g., `SIMMER_MIN_EDGE` vs `MIN_EDGE`). Aligned across all bundled skills.

--- a/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
+++ b/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
@@ -33,10 +33,8 @@ _skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
 _skill_stub.update_config = lambda updates, file, slug=None: None
 _skill_stub.get_config_path = lambda file: "/tmp/config.json"
 
-sys.modules.setdefault("simmer_sdk", MagicMock())
-sys.modules["simmer_sdk.skill"] = _skill_stub
-
-import fastloop_trader as ft  # noqa: E402
+with patch.dict(sys.modules, {"simmer_sdk": MagicMock(), "simmer_sdk.skill": _skill_stub}):
+    import fastloop_trader as ft  # noqa: E402
 
 
 def _make_preflight(ok=False, blockers=None):

--- a/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
+++ b/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
@@ -29,10 +29,8 @@ _skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
 _skill_stub.update_config = lambda updates, file, slug=None: None
 _skill_stub.get_config_path = lambda file: "/tmp/config.json"
 
-sys.modules.setdefault("simmer_sdk", MagicMock())
-sys.modules["simmer_sdk.skill"] = _skill_stub
-
-import mert_sniper as ms  # noqa: E402
+with patch.dict(sys.modules, {"simmer_sdk": MagicMock(), "simmer_sdk.skill": _skill_stub}):
+    import mert_sniper as ms  # noqa: E402
 
 
 def _make_preflight(ok=False, blockers=None):

--- a/skills/polymarket-weather-trader/tests/test_weathertrader_preflight_gate.py
+++ b/skills/polymarket-weather-trader/tests/test_weathertrader_preflight_gate.py
@@ -33,10 +33,8 @@ _skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
 _skill_stub.update_config = lambda updates, file, slug=None: None
 _skill_stub.get_config_path = lambda file: "/tmp/config.json"
 
-sys.modules.setdefault("simmer_sdk", MagicMock())
-sys.modules["simmer_sdk.skill"] = _skill_stub
-
-import weather_trader as wt  # noqa: E402
+with patch.dict(sys.modules, {"simmer_sdk": MagicMock(), "simmer_sdk.skill": _skill_stub}):
+    import weather_trader as wt  # noqa: E402
 
 
 def _make_preflight(ok=False, blockers=None):


### PR DESCRIPTION
Replaces `sys.modules.setdefault("simmer_sdk", MagicMock())` with a `patch.dict` context manager scoped to the skill import in 3 preflight-gate test files.

## Problem

When pytest collects any of these files before a real SDK test, `setdefault` permanently installs a `MagicMock()` for the top-level `simmer_sdk` package. Later imports like `from simmer_sdk import TradeResult` resolve to the mock instead of the real SDK — silent test failures depending on collection order.

## Changes

- `skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py`: scoped stub with `patch.dict`
- `skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py`: scoped stub with `patch.dict`
- `skills/polymarket-weather-trader/tests/test_weathertrader_preflight_gate.py`: scoped stub with `patch.dict`
- `CHANGELOG.md`: added Fix entry

## Tests

18/18 preflight-gate tests pass. The `patch.dict` restores `sys.modules["simmer_sdk"]` after the skill import, leaving no permanent contamination.

Closes SIM-2382