### PR TITLE
fix(weather): source-tier visibility + outcome_name None coalesce (SIM-2427)

### DIFF
--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — polymarket-weather-trader
 
+## [1.22.1] - 2026-05-24
+
+### Fixed
+- `Matching bucket: None` log when a market's `outcome_name` field is explicitly `None` (matcher loop fell back to `question`, but post-selection line used `.get("outcome_name", "")` which returns `None` not the default). Same class-of-bug as SIM-2371. Closes SIM-2427 issue 1.
+- Source-tier classification + log now runs for EVERY bucket-matched candidate, not only those that pass safeguards. Moved the cross-check fetch + `evaluate_source_agreement` call from inside the entry-threshold branch to immediately after bucket-match. Sizing application stays in the entry-threshold branch. Autoresearch + dogfood receipts now see would-have-been tier classification on slippage-blocked candidates too. Closes SIM-2427 issue 2.
+
+### Cost note
+The cross-check now fires on every bucket-matched candidate (vs. only entry-eligible ones in 1.22.0). `secondary_cache[station_id]` deduplicates within a scan run, so worst case = 1 Open-Meteo fetch per unique station per scan, unchanged from 1.22.0 for any candidate that reached entry-threshold evaluation. New cost: candidates above entry threshold now also incur the fetch — bounded by the per-station cache.
+
 ## [1.22.0] - 2026-05-24
 
 ### Added

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.22.0"
+  version: "1.22.1"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -1490,7 +1490,10 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
             log(f"  ⚠️  No bucket found for {forecast_temp}{unit_label}")
             continue
 
-        outcome_name = matching_market.get("outcome_name", "")
+        # SIM-2427: prefer outcome_name, fall back to question. Mirrors the
+        # matcher loop above. `.get("outcome_name", "")` would return None when
+        # the key exists with None value — same class-of-bug as SIM-2371.
+        outcome_name = matching_market.get("outcome_name") or matching_market.get("question", "")
         price = matching_market.get("external_price_yes") or 0.5
         market_id = matching_market.get("id")
 
@@ -1504,6 +1507,29 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
             log(f"  ⏸️  Price ${price:.4f} above max tradeable - skip (market at extreme)")
             skip_reasons.append("price at extreme")
             continue
+
+        # SIM-2427: compute source-tier early so it logs for EVERY bucket-matched
+        # candidate, even ones subsequently blocked by safeguards. Autoresearch +
+        # dogfood receipts need visibility into would-have-been tier classification.
+        # Cost stays bounded — secondary_cache dedupes per station within a scan.
+        secondary_temp = None
+        if not is_international:
+            if cache_key not in secondary_cache:
+                log(f"  Fetching Open-Meteo cross-check for {cache_key}...")
+                secondary_cache[cache_key] = get_openmeteo_forecast_for_us_station(cache_key)
+            sec_forecasts = secondary_cache[cache_key]
+            sec_day = sec_forecasts.get(date_str, {})
+            secondary_temp = sec_day.get(metric)
+
+        agreement_tier, source_spread, sec_bucket_name = evaluate_source_agreement(
+            forecast_temp, secondary_temp, outcome_name, event_markets, unit_label,
+        )
+        if secondary_temp is not None:
+            spread_str = f"{source_spread:.1f}{unit_label}" if source_spread is not None else "n/a"
+            log(f"  Open-Meteo cross-check: {secondary_temp}{unit_label} "
+                f"({sec_bucket_name or 'out-of-range'}) → tier={agreement_tier}, spread={spread_str}")
+        else:
+            log(f"  Source-agreement: tier={agreement_tier} (no secondary source)")
 
         # Check safeguards with edge analysis
         # NOAA forecasts are ~85% accurate for 1-2 day predictions when in-bucket
@@ -1533,29 +1559,6 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                 trend_bonus = f" 📈 (up {trend['change_24h']:.0%} in 24h)"
 
         if price < ENTRY_THRESHOLD:
-            # SIM-2420: cross-check primary forecast against Open-Meteo secondary.
-            # US/NOAA stations get a second source; intl stations (where Open-Meteo
-            # IS primary) have no second source today and fall through to
-            # REQUIRE_SOURCE_AGREEMENT handling.
-            secondary_temp = None
-            if not is_international:
-                if cache_key not in secondary_cache:
-                    log(f"  Fetching Open-Meteo cross-check for {cache_key}...")
-                    secondary_cache[cache_key] = get_openmeteo_forecast_for_us_station(cache_key)
-                sec_forecasts = secondary_cache[cache_key]
-                sec_day = sec_forecasts.get(date_str, {})
-                secondary_temp = sec_day.get(metric)
-
-            agreement_tier, source_spread, sec_bucket_name = evaluate_source_agreement(
-                forecast_temp, secondary_temp, outcome_name, event_markets, unit_label,
-            )
-            if secondary_temp is not None:
-                spread_str = f"{source_spread:.1f}{unit_label}" if source_spread is not None else "n/a"
-                log(f"  Open-Meteo cross-check: {secondary_temp}{unit_label} "
-                    f"({sec_bucket_name or 'out-of-range'}) → tier={agreement_tier}, spread={spread_str}")
-            else:
-                log(f"  Source-agreement: tier={agreement_tier} (no secondary source)")
-
             position_size = calculate_position_size(MAX_POSITION_USD, smart_sizing)
 
             # Apply volatility targeting


### PR DESCRIPTION
## Summary

Two follow-ups Herman surfaced on 1.22.0 dogfood verification (SIM-2427):

### Fix 1 — `Matching bucket: None`

The matcher loop falls back to `question` when `outcome_name` is None:
```python
outcome_name = market.get("outcome_name") or market.get("question", "")
```
But the post-selection line did:
```python
outcome_name = matching_market.get("outcome_name", "")  # ← returns None when key exists with None value
```

`dict.get(key, default)` only applies `default` for *missing* keys — same Python gotcha as SIM-2371's `sources=None` crash. Now coalesces with the same `or .get("question", "")` fallback.

### Fix 2 — Source-tier logs hidden by safeguards

In 1.22.0 the order was:
1. Bucket match
2. Price-extreme skip
3. **Safeguards (slippage) check** ← `continue` on block
4. `if price < ENTRY_THRESHOLD:` → cross-check + tier eval

When slippage blocked at step 3, the tier never logged. Autoresearch + dogfood couldn't see "this would have been wide-tier anyway" signal — every safeguard-blocked candidate looked identical.

Moved cross-check + `evaluate_source_agreement` to immediately after bucket match (before step 3). Sizing application stays in the entry-threshold branch. Tier classification now logs on every bucket-matched candidate.

## Cost

Per-station Open-Meteo cache (`secondary_cache[station_id]`) deduplicates fetches within a scan run — worst case unchanged from 1.22.0 for any entry-eligible candidate. New cost: candidates above entry threshold now also incur the fetch, but bounded by the cache.

## Test plan

- [x] `python3 tests/test_source_agreement.py` — 14/14 pass (pure-unit, source-agreement logic unchanged)
- [x] `python3 tests/test_sources_none.py` — 3/3 pass (SIM-2371 regression)
- [x] Syntax check
- No new tests — both fixes are code-ordering / class-of-bug fixes in `scan()` which lacks an integration-test harness. Risk mitigated by mechanical-diff review.

## Out of scope

- Open-Meteo failure path observability (could add explicit log when fetch returns `{}`; deferred)
- Tier breakdown in scan summary footer (could enhance dogfood receipts further; deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)