### PR TITLE
fix(weather): station-name → ICAO fallback for intl markets (SIM-2428)

### DIFF
--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog — polymarket-weather-trader
 
+## [1.22.2] - 2026-05-24
+
+### Fixed
+- Intl markets where Polymarket cites the resolution station by NAME only (no Wunderground URL / no ICAO) are no longer silently skipped (SIM-2428). Added a normalized-name → ICAO fallback index covering all 21 US + 16 intl stations. Normalizer strips diacritics (`ğ→g`), trailing `Intl` / `International` / `Airport` tokens, and lowercases — so `Esenboğa Intl Airport`, `Esenboga International Airport`, and `Esenboga Intl Airport` all resolve to `LTAC`.
+- Added `name` field to all 16 `INTERNATIONAL_STATION_COORDS` entries (US table already had it). The name-index is built from both tables at module load.
+
+### Added
+- `resolve_station_id_from_name(station_name)` — public helper for name-to-ICAO lookup.
+- `_normalize_station_name(name)` — internal normalizer used by the index + resolver.
+
+### Behavior delta
+Routing logic now: (a) if `station_id` is present in maps → as before; (b) if `station_id is None` but `station_name` matches an index entry → resolved and logged; (c) otherwise skip with the same message as before. No behavior change for markets that already resolve via ICAO.
+
 ## [1.22.1] - 2026-05-24
 
 ### Fixed

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.22.1"
+  version: "1.22.2"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/tests/test_station_name_resolve.py
+++ b/skills/polymarket-weather-trader/tests/test_station_name_resolve.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for SIM-2428: station-name → ICAO fallback.
+
+When Polymarket cites a station by name only (no Wunderground URL / ICAO),
+the resolver should map the normalized name to a known ICAO so the market
+isn't silently skipped.
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15, "exit_threshold": 0.45, "max_position_usd": 2.0,
+    "sizing_pct": 0.05, "max_trades_per_run": 5, "locations": "NYC",
+    "binary_only": False, "slippage_max": 0.15, "min_liquidity": 0.0,
+    "order_type": "GTC", "vol_targeting": False, "target_vol": 0.20,
+    "vol_max_leverage": 2.0, "vol_min_allocation": 0.2, "vol_span": 10,
+    "require_source_agreement": False, "canary_on_adjacent": True,
+    "max_canary_usd": 2.0, "max_source_spread_f": 2.0,
+}
+
+_skill_mod = types.ModuleType("simmer_sdk.skill")
+_skill_mod.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_mod.update_config = lambda updates, file, slug=None: None
+_skill_mod.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = MagicMock()
+sys.modules["simmer_sdk.skill"] = _skill_mod
+
+import weather_trader as wt  # noqa: E402
+
+
+class TestNormalizeStationName(unittest.TestCase):
+
+    def test_strip_diacritics(self):
+        # Esenboğa → esenboga (g̃ collapsed)
+        self.assertEqual(wt._normalize_station_name("Esenboğa"), "esenboga")
+        self.assertEqual(wt._normalize_station_name("Adolfo Suárez"), "adolfo suarez")
+
+    def test_strip_intl_airport_suffix(self):
+        self.assertEqual(wt._normalize_station_name("Heathrow Airport"), "heathrow")
+        self.assertEqual(wt._normalize_station_name("Esenboğa Intl Airport"), "esenboga")
+        self.assertEqual(
+            wt._normalize_station_name("JFK International Airport"), "jfk"
+        )
+
+    def test_idempotent_repeated_suffix(self):
+        # If someone writes "International Intl Airport Airport" (silly but defensible),
+        # repeated stripping should still terminate cleanly.
+        self.assertEqual(
+            wt._normalize_station_name("Foo Intl International Airport"), "foo"
+        )
+
+    def test_empty_inputs(self):
+        self.assertEqual(wt._normalize_station_name(""), "")
+        self.assertEqual(wt._normalize_station_name(None), "")
+
+    def test_case_insensitive(self):
+        self.assertEqual(
+            wt._normalize_station_name("HEATHROW AIRPORT"), "heathrow"
+        )
+
+
+class TestResolveStationIdFromName(unittest.TestCase):
+
+    def test_resolve_ankara_with_diacritic(self):
+        # The exact case from SIM-2428 repro
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Esenboğa Intl Airport"), "LTAC"
+        )
+
+    def test_resolve_ankara_ascii_variant(self):
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Esenboga Intl Airport"), "LTAC"
+        )
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Esenboga International Airport"),
+            "LTAC",
+        )
+
+    def test_resolve_us_station_by_full_name(self):
+        # Index includes US stations too — Polymarket might cite "Hartsfield-..."
+        # without an ICAO for a US market.
+        self.assertEqual(
+            wt.resolve_station_id_from_name(
+                "Hartsfield-Jackson Atlanta International Airport"
+            ),
+            "KATL",
+        )
+        self.assertEqual(
+            wt.resolve_station_id_from_name("JFK International Airport"), "KJFK"
+        )
+
+    def test_resolve_intl_multi_airport_city(self):
+        # Multi-airport intl cities (Milan, Tokyo) should distinguish per name
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Milan Malpensa Airport"), "LIMC"
+        )
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Milan Linate Airport"), "LIML"
+        )
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Tokyo Haneda Airport"), "RJTT"
+        )
+        self.assertEqual(
+            wt.resolve_station_id_from_name("Narita International Airport"),
+            "RJAA",
+        )
+
+    def test_unknown_returns_none(self):
+        self.assertIsNone(
+            wt.resolve_station_id_from_name("Somewhere Nonexistent Airport")
+        )
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(wt.resolve_station_id_from_name(""))
+        self.assertIsNone(wt.resolve_station_id_from_name(None))
+
+
+class TestStationNameIndex(unittest.TestCase):
+
+    def test_index_covers_all_stations(self):
+        # Every entry in both coord tables should produce a name-index entry.
+        expected_count = len(wt.STATION_ID_TO_NOAA) + len(
+            wt.INTERNATIONAL_STATION_COORDS
+        )
+        self.assertEqual(len(wt._STATION_NAME_INDEX), expected_count)
+
+    def test_index_values_are_valid_icaos(self):
+        all_icaos = (
+            set(wt.STATION_ID_TO_NOAA) | set(wt.INTERNATIONAL_STATION_COORDS)
+        )
+        for icao in wt._STATION_NAME_INDEX.values():
+            self.assertIn(icao, all_icaos)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -250,23 +250,86 @@ INTERNATIONAL_LOCATIONS = {
 # class of bug the US side fixes by going per-station. Coords are the airport
 # itself; tz is the local timezone.
 INTERNATIONAL_STATION_COORDS = {
-    "LLBG": {"lat": 32.0114, "lon": 34.8867, "tz": "Asia/Jerusalem",   "city": "Tel Aviv"},   # Ben Gurion
-    "EDDM": {"lat": 48.3538, "lon": 11.7861, "tz": "Europe/Berlin",    "city": "Munich"},     # Munich Airport
-    "EGLL": {"lat": 51.4700, "lon": -0.4543, "tz": "Europe/London",    "city": "London"},     # Heathrow
-    "RJTT": {"lat": 35.5494, "lon": 139.7798, "tz": "Asia/Tokyo",      "city": "Tokyo"},      # Haneda
-    "RJAA": {"lat": 35.7647, "lon": 140.3863, "tz": "Asia/Tokyo",      "city": "Tokyo"},      # Narita
-    "RKSI": {"lat": 37.4602, "lon": 126.4407, "tz": "Asia/Seoul",      "city": "Seoul"},      # Incheon
-    "RKSS": {"lat": 37.5586, "lon": 126.7906, "tz": "Asia/Seoul",      "city": "Seoul"},      # Gimpo
-    "LTAC": {"lat": 40.1281, "lon": 32.9951, "tz": "Europe/Istanbul",  "city": "Ankara"},     # Esenboga
-    "VILK": {"lat": 26.7606, "lon": 80.8893, "tz": "Asia/Kolkata",     "city": "Lucknow"},    # Chaudhary Charan Singh
-    "NZWN": {"lat": -41.3272, "lon": 174.8053, "tz": "Pacific/Auckland", "city": "Wellington"},  # Wellington Intl
-    "LEMD": {"lat": 40.4839, "lon": -3.5680, "tz": "Europe/Madrid",    "city": "Madrid"},     # Barajas
-    "LIMC": {"lat": 45.6306, "lon": 8.7281, "tz": "Europe/Rome",       "city": "Milan"},      # Malpensa
-    "LIML": {"lat": 45.4451, "lon": 9.2767, "tz": "Europe/Rome",       "city": "Milan"},      # Linate
-    "EHAM": {"lat": 52.3105, "lon": 4.7683, "tz": "Europe/Amsterdam",  "city": "Amsterdam"},  # Schiphol
-    "RCSS": {"lat": 25.0697, "lon": 121.5519, "tz": "Asia/Taipei",     "city": "Taipei"},     # Songshan
-    "RCTP": {"lat": 25.0777, "lon": 121.2328, "tz": "Asia/Taipei",     "city": "Taipei"},     # Taoyuan
+    "LLBG": {"lat": 32.0114, "lon": 34.8867, "tz": "Asia/Jerusalem",   "city": "Tel Aviv",   "name": "Ben Gurion Airport"},
+    "EDDM": {"lat": 48.3538, "lon": 11.7861, "tz": "Europe/Berlin",    "city": "Munich",     "name": "Munich Airport"},
+    "EGLL": {"lat": 51.4700, "lon": -0.4543, "tz": "Europe/London",    "city": "London",     "name": "Heathrow Airport"},
+    "RJTT": {"lat": 35.5494, "lon": 139.7798, "tz": "Asia/Tokyo",      "city": "Tokyo",      "name": "Tokyo Haneda Airport"},
+    "RJAA": {"lat": 35.7647, "lon": 140.3863, "tz": "Asia/Tokyo",      "city": "Tokyo",      "name": "Narita International Airport"},
+    "RKSI": {"lat": 37.4602, "lon": 126.4407, "tz": "Asia/Seoul",      "city": "Seoul",      "name": "Incheon International Airport"},
+    "RKSS": {"lat": 37.5586, "lon": 126.7906, "tz": "Asia/Seoul",      "city": "Seoul",      "name": "Gimpo International Airport"},
+    "LTAC": {"lat": 40.1281, "lon": 32.9951, "tz": "Europe/Istanbul",  "city": "Ankara",     "name": "Esenboğa International Airport"},
+    "VILK": {"lat": 26.7606, "lon": 80.8893, "tz": "Asia/Kolkata",     "city": "Lucknow",    "name": "Chaudhary Charan Singh International Airport"},
+    "NZWN": {"lat": -41.3272, "lon": 174.8053, "tz": "Pacific/Auckland", "city": "Wellington", "name": "Wellington International Airport"},
+    "LEMD": {"lat": 40.4839, "lon": -3.5680, "tz": "Europe/Madrid",    "city": "Madrid",     "name": "Adolfo Suárez Madrid-Barajas Airport"},
+    "LIMC": {"lat": 45.6306, "lon": 8.7281, "tz": "Europe/Rome",       "city": "Milan",      "name": "Milan Malpensa Airport"},
+    "LIML": {"lat": 45.4451, "lon": 9.2767, "tz": "Europe/Rome",       "city": "Milan",      "name": "Milan Linate Airport"},
+    "EHAM": {"lat": 52.3105, "lon": 4.7683, "tz": "Europe/Amsterdam",  "city": "Amsterdam",  "name": "Amsterdam Schiphol Airport"},
+    "RCSS": {"lat": 25.0697, "lon": 121.5519, "tz": "Asia/Taipei",     "city": "Taipei",     "name": "Taipei Songshan Airport"},
+    "RCTP": {"lat": 25.0777, "lon": 121.2328, "tz": "Asia/Taipei",     "city": "Taipei",     "name": "Taoyuan International Airport"},
 }
+
+
+# =============================================================================
+# Station-name → ICAO fallback (SIM-2428)
+# =============================================================================
+#
+# Some Polymarket markets cite the station by NAME ("Esenboğa Intl Airport")
+# without a Wunderground URL or explicit ICAO. The resolution parser then
+# returns station_id=None, station_name=<airport name>. Before SIM-2428 those
+# markets got skipped even when the skill had coords for the station; this
+# index lets the router fall back to a normalized-name lookup.
+
+import unicodedata as _unicodedata
+
+def _normalize_station_name(name: str) -> str:
+    """Lower-cased, diacritic-stripped, suffix-trimmed station name for
+    fuzzy matching. Strips trailing 'airport', 'intl', 'international',
+    'intl airport', 'international airport' tokens so 'Esenboğa Intl
+    Airport' and 'Esenboga International Airport' both collapse to
+    'esenboğa'-normalized → 'esenboga'."""
+    if not name:
+        return ""
+    # Strip diacritics (ğ → g, ü → u, etc.)
+    decomposed = _unicodedata.normalize("NFKD", name)
+    ascii_only = "".join(c for c in decomposed if not _unicodedata.combining(c))
+    s = ascii_only.lower().strip()
+    # Repeatedly strip trailing airport-class suffixes
+    for _ in range(4):
+        for suffix in (" international airport", " intl airport", " airport",
+                       " international", " intl"):
+            if s.endswith(suffix):
+                s = s[: -len(suffix)].strip()
+                break
+        else:
+            break
+    return s
+
+
+def _build_station_name_index() -> dict:
+    """Build {normalized_name: icao} from BOTH coord tables at module load.
+    Used by the router when Polymarket cites a station by name only."""
+    index = {}
+    for icao, info in STATION_ID_TO_NOAA.items():
+        nm = _normalize_station_name(info.get("name", ""))
+        if nm:
+            index[nm] = icao
+    for icao, info in INTERNATIONAL_STATION_COORDS.items():
+        nm = _normalize_station_name(info.get("name", ""))
+        if nm:
+            index[nm] = icao
+    return index
+
+
+_STATION_NAME_INDEX = _build_station_name_index()
+
+
+def resolve_station_id_from_name(station_name: str) -> str | None:
+    """Map a Polymarket-cited airport name to a known ICAO via the
+    normalized-name index. Returns None if no match — caller should
+    skip the market as before."""
+    if not station_name:
+        return None
+    return _STATION_NAME_INDEX.get(_normalize_station_name(station_name))
 
 # =============================================================================
 # Resolution-source parser
@@ -1431,6 +1494,15 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
 
         station_id = parsed.get("station_id")
         station_name = parsed.get("station_name") or station_id or "?"
+
+        # SIM-2428: when Polymarket cites the station by name only (no
+        # Wunderground URL / no explicit ICAO), parsed["station_id"] is
+        # None. Try the normalized-name index before declaring unknown.
+        if not station_id and station_name and station_name != "?":
+            resolved = resolve_station_id_from_name(station_name)
+            if resolved:
+                log(f"  Resolved '{station_name}' → {resolved} via name index")
+                station_id = resolved
 
         # Route forecast source by station_id. Cache key is the station_id
         # itself (not the city) so multi-airport cities like NYC/Chicago/


### PR DESCRIPTION
## Summary

Polymarket weather markets sometimes cite the resolution station by NAME only ("Esenboğa Intl Airport") without a Wunderground URL or explicit ICAO. The 1.22.x parser returned `station_id=None, station_name=<name>` and the router only checked `station_id in known_maps` — so the market was silently skipped despite the skill having coords for the station.

Herman surfaced this on the Ankara market (SIM-2428): `INTERNATIONAL_STATION_COORDS["LTAC"]` exists with the right coords, but the router never reached it because `station_id` was None.

## Fix

Added a normalized-name → ICAO fallback resolver:

1. **`name` field added to all 16 `INTERNATIONAL_STATION_COORDS` entries** (US table already had it).
2. **`_normalize_station_name()`** strips diacritics (`ğ→g`), trailing `Intl` / `International` / `Airport` tokens, lowercases. So `Esenboğa Intl Airport`, `Esenboga International Airport`, and `Esenboga Intl Airport` all collapse to the same key.
3. **`_STATION_NAME_INDEX`** built once at module load from both coord tables (37 entries — 21 US + 16 intl).
4. **`resolve_station_id_from_name(station_name)`** — public helper.
5. **Routing block:** if `station_id is None` and `station_name` matches the index, resolve + log + continue. Otherwise skip with the same message as before.

**No behavior change** for markets that already resolve via ICAO.

## Smoke-tested

```
✓ 'Esenboğa Intl Airport'                              → 'LTAC'
✓ 'Esenboga Intl Airport'                              → 'LTAC'
✓ 'Esenboga International Airport'                     → 'LTAC'
✓ 'Esenboğa International Airport'                     → 'LTAC'
✓ 'Heathrow Airport'                                   → 'EGLL'
✓ 'Hartsfield-Jackson Atlanta International Airport'   → 'KATL'
✓ 'Milan Malpensa Airport'                             → 'LIMC'
✓ 'Milan Linate Airport'                               → 'LIML'  (multi-airport city disambiguation)
✓ 'Tokyo Haneda Airport'                               → 'RJTT'
✓ 'Narita International Airport'                       → 'RJAA'
✓ 'Unknown Place Airport'                              → None
```

## Tests

- 13 new in `tests/test_station_name_resolve.py` — normalizer cases (diacritics, suffix-stripping, idempotence, case-insensitive), resolver cases (Ankara + variants, US full-name, multi-airport intl cities), index integrity (size + valid ICAOs).
- 14 SIM-2420 source-agreement tests still pass.
- 3 SIM-2371 sources-None regression tests still pass.
- **Total: 30 unit tests, all green.**

## Test plan
- [x] `python3 tests/test_station_name_resolve.py` — 13/13 pass
- [x] `python3 tests/test_source_agreement.py` — 14/14 pass (regression)
- [x] `python3 tests/test_sources_none.py` — 3/3 pass (regression)
- [x] Smoke-test resolver against live `INTERNATIONAL_STATION_COORDS` + `STATION_ID_TO_NOAA`
- [ ] Herman to rerun 1.22.2 against Ankara market — expect `Resolved 'Esenboğa Intl Airport' → LTAC via name index` then normal routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)