### PR TITLE
fix(weather): add London City station mapping

### DIFF
--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — polymarket-weather-trader
 
+## [Unreleased]
+
+### Fixed
+- Added `EGLC` (London City Airport) to the international station coordinate map so Polymarket London weather markets that cite the official London City station can route to Open-Meteo instead of fail-closing as an unsupported station. This does not change markets whose Simmer/SDK metadata lacks usable `resolution_criteria`; those still fail closed.
+
 ## [1.22.2] - 2026-05-24
 
 ### Fixed

--- a/skills/polymarket-weather-trader/tests/test_station_name_resolve.py
+++ b/skills/polymarket-weather-trader/tests/test_station_name_resolve.py
@@ -113,6 +113,18 @@ class TestResolveStationIdFromName(unittest.TestCase):
             "RJAA",
         )
 
+    def test_resolve_london_city_official_station(self):
+        # Polymarket's published London weather station is EGLC, not Heathrow.
+        self.assertEqual(
+            wt.resolve_station_id_from_name("London City Airport"), "EGLC"
+        )
+
+    def test_london_city_has_openmeteo_coords(self):
+        station = wt.INTERNATIONAL_STATION_COORDS.get("EGLC")
+        self.assertIsNotNone(station)
+        self.assertEqual(station["city"], "London")
+        self.assertEqual(station["tz"], "Europe/London")
+
     def test_unknown_returns_none(self):
         self.assertIsNone(
             wt.resolve_station_id_from_name("Somewhere Nonexistent Airport")

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -252,6 +252,7 @@ INTERNATIONAL_LOCATIONS = {
 INTERNATIONAL_STATION_COORDS = {
     "LLBG": {"lat": 32.0114, "lon": 34.8867, "tz": "Asia/Jerusalem",   "city": "Tel Aviv",   "name": "Ben Gurion Airport"},
     "EDDM": {"lat": 48.3538, "lon": 11.7861, "tz": "Europe/Berlin",    "city": "Munich",     "name": "Munich Airport"},
+    "EGLC": {"lat": 51.5053, "lon": 0.0553, "tz": "Europe/London",     "city": "London",     "name": "London City Airport"},
     "EGLL": {"lat": 51.4700, "lon": -0.4543, "tz": "Europe/London",    "city": "London",     "name": "Heathrow Airport"},
     "RJTT": {"lat": 35.5494, "lon": 139.7798, "tz": "Asia/Tokyo",      "city": "Tokyo",      "name": "Tokyo Haneda Airport"},
     "RJAA": {"lat": 35.7647, "lon": 140.3863, "tz": "Asia/Tokyo",      "city": "Tokyo",      "name": "Narita International Airport"},


### PR DESCRIPTION
## Summary
- add `EGLC` / London City Airport to Weather Trader's international station coordinate map
- add regression coverage for resolving `London City Airport` by name and ensuring station coords exist
- document that this fixes the London unsupported-station path but does not fix markets with missing/generic `resolution_criteria`

## Dogfood receipt
Before this patch, Herman's weather scan hit:

```text
London 2026-05-26 (high temp)
Skipping — station EGLC (London City Airport) not in NOAA/Open-Meteo maps
```

After this patch, the same local SIM/paper scan routes London through station-level Open-Meteo:

```text
Oracle: London City Airport (EGLC) → Open-Meteo @ airport coords (London)
Open-Meteo forecast: 32°C
Matching bucket: 32°C @ $0.15
Entry opportunities: 1
Trades executed: 1 [PAPER]
```

No live trade, signing, approvals, or production config changes were performed.

## Test plan
- [x] `python -m pytest tests/test_station_name_resolve.py -q`
- [x] `python -m pytest tests/test_station_name_resolve.py tests/test_source_agreement.py tests/test_sources_none.py tests/test_weathertrader_preflight_gate.py -q`
- [x] `python -m py_compile weather_trader.py`
- [x] manual local SIM/paper scan for London only

## Scope note
This is a partial fix for SIM-2434. It addresses the concrete Weather Trader station-coverage gap for London (`EGLC`). It does not resolve the separate Simmer/SDK market metadata issue where some weather markets still expose missing/generic `resolution_criteria` and therefore correctly fail closed.
