### PR TITLE
fix(sdk): forward not_redeemable from DW redeem precheck

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3130,6 +3130,15 @@ class SimmerClient:
                     "redeem ext+DW: %s", stage
                 ),
             )
+            if result.get("not_redeemable"):
+                reason = result.get("reason", "unknown")
+                print(f"  Auto-redeem skipped: {market_id} ({side}) — {reason}")
+                return {
+                    "success": True,
+                    "tx_hash": None,
+                    "not_redeemable": True,
+                    "reason": reason,
+                }
             tx_hash = result.get("tx_hash")
             print(f"  Auto-redeem OK: {market_id} ({side}) tx={tx_hash}")
             return {
@@ -3472,6 +3481,10 @@ class SimmerClient:
             try:
                 print(f"  Auto-redeem: {market_id} ({side})...")
                 result = self.redeem(market_id, side)
+                if result.get("not_redeemable"):
+                    reason = result.get("reason", "not redeemable")
+                    logger.info("auto_redeem: skipped %s (%s) — %s", market_id, side, reason)
+                    continue
                 success = bool(result.get("success"))
                 tx_hash = result.get("tx_hash")
                 error = result.get("error") if not success else None


### PR DESCRIPTION
## Summary
- Forward `not_redeemable` field from server's DW redeem precheck instead of stripping it
- Skip `not_redeemable` positions in `auto_redeem()` loop instead of logging "OK"

## Context
PR #1043 on simmer adds a server-side precheck to `/api/sdk/dw-redeem/submit` that returns `{success: true, not_redeemable: true}` for zero-balance, already-redeemed, or not-yet-settled positions. The SDK's `_redeem_external_dw` was reshaping the response and dropping `not_redeemable`, causing `auto_redeem()` to treat no-ops as successful redemptions.

Found during code review of simmer PR #1043.

## Test plan
- [x] `python -c "import simmer_sdk.client"` — imports clean
- [ ] End-to-end: SDK auto_redeem with a not-yet-settled position logs "skipped" instead of "OK"

🤖 Generated with [Claude Code](https://claude.com/claude-code)