### PR TITLE
fix: skip user relink for registered OWS wallets

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1631,19 +1631,29 @@ class SimmerClient:
         if price is not None:
             payload["price"] = price
 
+        registered_agent_wallet = (
+            self._ows_wallet
+            and self._wallet_address
+            and self._is_agent_wallet_registered()
+        )
+
         # Include wallet_address only for users who explicitly opted into per-agent
         # wallet attribution by registering this OWS wallet (Elite feature).
         # Otherwise the server would reject with "Agent wallet not found" because
         # the wallet has no row in user_agent_wallets — but the user-level
         # linked_wallet_address path still works fine. Don't conflate "OWS configured"
         # with "wants per-agent isolation."
-        if self._ows_wallet and self._wallet_address and self._is_agent_wallet_registered():
+        if registered_agent_wallet:
             payload["wallet_address"] = self._wallet_address
 
         # External wallet: ensure linked, check approvals, sign locally
         if (self._private_key or self._ows_wallet) and effective_venue == "polymarket":
-            # Auto-link wallet if not already linked
-            self._ensure_wallet_linked()
+            # Registered per-agent OWS wallets route through user_agent_wallets
+            # via payload["wallet_address"]. They must not hit the user-level
+            # auto-link path, which can try to replace the account's current
+            # external wallet and fail when that wallet has open positions.
+            if not registered_agent_wallet:
+                self._ensure_wallet_linked()
             # Warn about missing approvals (once per session)
             self._warn_approvals_once()
             # SIM-1646: for DW users doing sells, look up the on-chain holder so

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1158,6 +1158,31 @@ class SimmerClient:
             print(f"ERROR: Auto-link failed: {e}. Call client.link_wallet() manually.")
             raise RuntimeError(f"Wallet linking failed: {e}")
 
+    def _load_per_agent_dw_state(self) -> None:
+        """Populate DW routing flags from /api/sdk/agents/me for per-agent wallets.
+
+        Registered per-agent OWS wallets skip _ensure_wallet_linked() (to avoid
+        the user-level re-link path), but _build_signed_order() needs
+        _uses_deposit_wallet and _deposit_wallet_address for sig-type selection.
+        Fetches from the same endpoint preflight() uses. Cached for the session.
+        """
+        if getattr(self, "_per_agent_dw_loaded", False):
+            return
+        self._per_agent_dw_loaded = True
+        try:
+            me = self._request("GET", "/api/sdk/agents/me")
+            per_agent_wallet = me.get("per_agent_wallet_address")
+            if per_agent_wallet:
+                if "per_agent_dw_active" in me and me.get("per_agent_dw_active") is not None:
+                    self._uses_deposit_wallet = bool(me["per_agent_dw_active"])
+                    self._deposit_wallet_address = me.get("per_agent_deposit_wallet_address")
+            else:
+                if "wallet_uses_deposit_wallet" in me and me.get("wallet_uses_deposit_wallet") is not None:
+                    self._uses_deposit_wallet = bool(me["wallet_uses_deposit_wallet"])
+                    self._deposit_wallet_address = me.get("deposit_wallet_address")
+        except Exception as e:
+            logger.debug("Could not load per-agent DW state: %s", e)
+
     def _ensure_clob_credentials(self) -> None:
         """
         Derive and register Polymarket CLOB API credentials if not already done.
@@ -1652,8 +1677,12 @@ class SimmerClient:
             # via payload["wallet_address"]. They must not hit the user-level
             # auto-link path, which can try to replace the account's current
             # external wallet and fail when that wallet has open positions.
+            # But we still need DW routing flags for _build_signed_order's
+            # sig-type selection — fetch from /api/sdk/agents/me instead.
             if not registered_agent_wallet:
                 self._ensure_wallet_linked()
+            else:
+                self._load_per_agent_dw_state()
             # Warn about missing approvals (once per session)
             self._warn_approvals_once()
             # SIM-1646: for DW users doing sells, look up the on-chain holder so

--- a/tests/test_agent_wallets_sdk.py
+++ b/tests/test_agent_wallets_sdk.py
@@ -224,6 +224,7 @@ class TestTradeWalletAddress:
                 "Cannot re-link: your current external wallet has open positions on Polymarket."
             )
         )
+        client._load_per_agent_dw_state = MagicMock()
         client._warn_approvals_once = MagicMock()
         client._build_signed_order = MagicMock(return_value={"signed": "order"})
 
@@ -231,10 +232,74 @@ class TestTradeWalletAddress:
 
         assert result.success is True
         client._ensure_wallet_linked.assert_not_called()
+        client._load_per_agent_dw_state.assert_called_once()
         call_args = client._request.call_args
         payload = call_args.kwargs.get("json") or call_args[1].get("json")
         assert payload["wallet_address"] == "0x1234567890abcdef1234567890abcdef12345678"
         assert payload["signed_order"] == {"signed": "order"}
+
+    def test_registered_ows_populates_dw_state_from_agents_me(self):
+        """_load_per_agent_dw_state must populate _uses_deposit_wallet and
+        _deposit_wallet_address so _build_signed_order picks sig type 3."""
+        client = _make_client(
+            ows_wallet="agent-mybot",
+            wallet_address="0x1234567890abcdef1234567890abcdef12345678",
+        )
+        client._uses_deposit_wallet = False
+        client._deposit_wallet_address = None
+
+        def mock_request(method, endpoint, **kwargs):
+            if endpoint == "/api/sdk/agents/me":
+                return {
+                    "agent_id": "test-agent-uuid",
+                    "per_agent_wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                    "per_agent_dw_active": True,
+                    "per_agent_deposit_wallet_address": "0xDW1234",
+                    "rate_limits": {"tier": "elite"},
+                    "real_trading_enabled": True,
+                }
+            return {}
+        client._request = MagicMock(side_effect=mock_request)
+
+        client._load_per_agent_dw_state()
+
+        assert client._uses_deposit_wallet is True
+        assert client._deposit_wallet_address == "0xDW1234"
+        client._request.assert_called_once_with("GET", "/api/sdk/agents/me")
+
+    def test_load_per_agent_dw_state_cached_after_first_call(self):
+        """Second call is a no-op — no duplicate /api/sdk/agents/me fetch."""
+        client = _make_client(
+            ows_wallet="agent-mybot",
+            wallet_address="0x1234567890abcdef1234567890abcdef12345678",
+        )
+        client._uses_deposit_wallet = False
+        client._deposit_wallet_address = None
+        client._request = MagicMock(return_value={
+            "per_agent_wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+            "per_agent_dw_active": True,
+            "per_agent_deposit_wallet_address": "0xDW1234",
+        })
+
+        client._load_per_agent_dw_state()
+        client._load_per_agent_dw_state()
+
+        assert client._request.call_count == 1
+
+    def test_load_per_agent_dw_state_graceful_on_error(self):
+        """Network failure leaves DW defaults (False/None) — degrades to EOA signing."""
+        client = _make_client(
+            ows_wallet="agent-mybot",
+            wallet_address="0x1234567890abcdef1234567890abcdef12345678",
+        )
+        client._uses_deposit_wallet = False
+        client._deposit_wallet_address = None
+        client._request = MagicMock(side_effect=Exception("timeout"))
+
+        client._load_per_agent_dw_state()
+
+        assert client._uses_deposit_wallet is False
+        assert client._deposit_wallet_address is None
 
     def test_omits_wallet_address_when_ows_wallet_not_registered(self):
         """OWS wallet without per-agent-wallet registration falls through to user-level path.

--- a/tests/test_agent_wallets_sdk.py
+++ b/tests/test_agent_wallets_sdk.py
@@ -197,6 +197,45 @@ class TestTradeWalletAddress:
         payload = call_args.kwargs.get("json") or call_args[1].get("json")
         assert payload.get("wallet_address") == "0x1234567890abcdef1234567890abcdef12345678"
 
+    def test_registered_ows_polymarket_trade_skips_user_level_auto_link(self):
+        """Registered per-agent OWS trades must not relink the user wallet.
+
+        DW users can legitimately have open positions on the current user-level
+        external wallet. The backend rejects replacing that wallet; per-agent
+        OWS trades should route via user_agent_wallets instead.
+        """
+        client = _make_client(
+            ows_wallet="agent-mybot",
+            wallet_address="0x1234567890abcdef1234567890abcdef12345678",
+        )
+        client._agent_wallet_registered = True
+        client._request.return_value = {
+            "success": True,
+            "market_id": "test-market",
+            "side": "yes",
+            "shares_bought": 10.0,
+            "cost": 5.0,
+            "new_price": 0.5,
+            "fill_status": "filled",
+        }
+        client._get_held_markets = MagicMock(return_value={})
+        client._ensure_wallet_linked = MagicMock(
+            side_effect=RuntimeError(
+                "Cannot re-link: your current external wallet has open positions on Polymarket."
+            )
+        )
+        client._warn_approvals_once = MagicMock()
+        client._build_signed_order = MagicMock(return_value={"signed": "order"})
+
+        result = client.trade("test-market", "yes", amount=10.0, venue="polymarket")
+
+        assert result.success is True
+        client._ensure_wallet_linked.assert_not_called()
+        call_args = client._request.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert payload["wallet_address"] == "0x1234567890abcdef1234567890abcdef12345678"
+        assert payload["signed_order"] == {"signed": "order"}
+
     def test_omits_wallet_address_when_ows_wallet_not_registered(self):
         """OWS wallet without per-agent-wallet registration falls through to user-level path.
 


### PR DESCRIPTION
## Summary
- route registered per-agent OWS Polymarket trades through the existing user_agent_wallets path without invoking user-level wallet auto-linking
- keep unregistered OWS/private-key wallet behavior unchanged
- add a regression test for the DW/open-position relink failure Herman hit

## Tests
- PYTHONPATH=. pytest tests/test_agent_wallets_sdk.py skills/preflight/tests/test_preflight.py

Closes SIM-2456