### PR TITLE
fix(milaircraft): support autonomous pref credentials

### DIFF
--- a/skills/polymarket-mil-aircraft-tracker/SKILL.md
+++ b/skills/polymarket-mil-aircraft-tracker/SKILL.md
@@ -52,7 +52,59 @@ Use this skill when the user wants to:
 Required environment:
 
 - `SIMMER_API_KEY` - get from `simmer.markets/dashboard`
-- `PREF_API_KEY` - register your own agent at [pref.trade](https://pref.trade) via `POST /v1/agents/register` to get a `pref_agent_*` key (50 free calls/day on anonymous tier, 250/day after claiming)
+- `PREF_API_KEY`, `PREFERENCE_API_KEY`, or `~/.config/preference/credentials.json` - a pref.trade `pref_agent_*` key for the aircraft data source
+
+### Autonomous pref.trade key setup
+
+Agents do not need to use the human browser sign-up flow. If no pref key exists, register an agent key directly and save it to the standard credentials file:
+
+```bash
+mkdir -p ~/.config/preference
+python - <<'PY'
+import json
+import os
+import stat
+import urllib.request
+from pathlib import Path
+
+cred = Path.home() / ".config" / "preference" / "credentials.json"
+if cred.exists():
+    raise SystemExit(f"credentials already exist: {cred}")
+
+payload = json.dumps({
+    "name": "Military Aircraft Tracker Agent",
+    "description": "Agent using pref.trade aviation data through the Simmer mil-aircraft tracker skill",
+}).encode()
+req = urllib.request.Request(
+    "https://pref.trade/v1/agents/register",
+    data=payload,
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=30) as resp:
+    data = json.loads(resp.read().decode())
+
+# The api_key is shown once. Save it without printing it.
+cred.write_text(json.dumps({"api_key": data["api_key"]}, indent=2))
+os.chmod(cred, stat.S_IRUSR | stat.S_IWUSR)
+print(f"saved pref credentials to {cred}")
+print("claim_url available:", bool(data.get("claim_url")))
+PY
+```
+
+Then verify the key and quota before any strategy run:
+
+```bash
+python milaircraft_tracker.py --check
+```
+
+The skill reads pref credentials in this order:
+
+1. `PREF_API_KEY`
+2. `PREFERENCE_API_KEY`
+3. `~/.config/preference/credentials.json` with shape `{"api_key":"pref_agent_*"}`
+
+Keep the key out of terminal logs, issues, PRs, and prompts. If `--check` reports an anonymous identity or missing key, stop and fix the credential path before scanning.
 
 Then install the SDK:
 
@@ -123,7 +175,7 @@ All trades are tagged with `source: "sdk:milaircraft"` and `skill_slug: "polymar
 
 ## Troubleshooting
 
-**`PREF_API_KEY not set`** - create or export a pref.trade agent key.
+**`PREF_API_KEY not set`** - create a pref.trade agent key with the autonomous setup command above, export it as `PREF_API_KEY`/`PREFERENCE_API_KEY`, or save it to `~/.config/preference/credentials.json`. Run `python milaircraft_tracker.py --check` before scanning.
 
 **`SIMMER_API_KEY environment variable not set`** - get a key from `simmer.markets/dashboard`.
 

--- a/skills/polymarket-mil-aircraft-tracker/pref_client.py
+++ b/skills/polymarket-mil-aircraft-tracker/pref_client.py
@@ -11,10 +11,12 @@ Pref uses two call conventions:
 
 import json
 import os
+from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 PREF_MCP_ENDPOINT = "https://pref.trade/mcp"
+PREF_CREDENTIALS_PATH = Path.home() / ".config" / "preference" / "credentials.json"
 _request_id = 0
 
 
@@ -24,15 +26,30 @@ def _next_id():
     return _request_id
 
 
+def _load_api_key():
+    """Load pref.trade API key from env or the standard agent credentials file."""
+    for env_name in ("PREF_API_KEY", "PREFERENCE_API_KEY"):
+        api_key = os.environ.get(env_name, "").strip()
+        if api_key:
+            return api_key
+
+    try:
+        data = json.loads(PREF_CREDENTIALS_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+
+    return str(data.get("api_key") or "").strip()
+
+
 def _call_tool(tool_name, arguments=None):
     """Call a pref MCP tool via JSON-RPC 2.0. Returns parsed result or None.
 
     Dotted tool names (containing '.') use the call_tool meta-pattern.
     Direct tool names use the standard MCP tools/call pattern.
     """
-    api_key = os.environ.get("PREF_API_KEY", "")
+    api_key = _load_api_key()
     if not api_key:
-        print("  [pref] PREF_API_KEY not set - skipping pref call")
+        print("  [pref] PREF_API_KEY not set and no ~/.config/preference/credentials.json key found - skipping pref call")
         return None
 
     if "." in tool_name:

--- a/tests/test_milaircraft_pref_client.py
+++ b/tests/test_milaircraft_pref_client.py
@@ -72,3 +72,22 @@ def test_fetch_military_aircraft_handles_error():
         os.environ["PREF_API_KEY"] = "pref_agent_test"
         aircraft = pref_client.get_military_aircraft()
         assert aircraft == []
+
+
+def test_load_api_key_accepts_preference_alias():
+    """PREFERENCE_API_KEY works for agents that follow pref.trade onboarding docs."""
+    import pref_client
+
+    with patch.dict(os.environ, {"PREFERENCE_API_KEY": "pref_agent_alias"}, clear=True):
+        assert pref_client._load_api_key() == "pref_agent_alias"
+
+
+def test_load_api_key_reads_standard_credentials_file(tmp_path):
+    """Agents can store pref credentials outside .env and still run the skill."""
+    import pref_client
+
+    cred = tmp_path / "credentials.json"
+    cred.write_text(json.dumps({"api_key": "pref_agent_file"}))
+
+    with patch.dict(os.environ, {}, clear=True), patch.object(pref_client, "PREF_CREDENTIALS_PATH", cred):
+        assert pref_client._load_api_key() == "pref_agent_file"


### PR DESCRIPTION
## Summary
- let mil-aircraft pref client read PREF_API_KEY, PREFERENCE_API_KEY, or ~/.config/preference/credentials.json
- document autonomous pref.trade agent-key registration without printing the key
- add regression tests for alias/env-file credential loading

## Test Plan
- python3 -m pytest -q tests/test_milaircraft_pref_client.py tests/test_milaircraft_integration.py
- python3 -m py_compile skills/polymarket-mil-aircraft-tracker/pref_client.py skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
- env -u PREF_API_KEY -u PREFERENCE_API_KEY TRADING_VENUE=sim python3 milaircraft_tracker.py --check
- env -u PREF_API_KEY -u PREFERENCE_API_KEY TRADING_VENUE=sim python3 milaircraft_tracker.py --dry-run

## Dogfood receipt
Herman registered a pref_agent key from https://pref.trade/v1/agents/register, stored it in ~/.config/preference/credentials.json with 0600 permissions, verified authenticated pref account status, and ran a SIM dry-run: 230 aircraft fetched, 0 fired clusters, 0 trades.