### PR TITLE
fix(mcp): honor safe read-only extra args

### DIFF
--- a/mcp/src/per-skill-tools.ts
+++ b/mcp/src/per-skill-tools.ts
@@ -71,6 +71,11 @@ export function buildToolDescription(skill: Skill): string {
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_TIMEOUT_MS = 300_000;
+const READ_ONLY_EXTRA_ARGS = new Set(["--check", "--config", "--status", "--positions", "--help"]);
+
+function filterDefaultExtraArgs(args: unknown[]): string[] {
+  return filterBlockedFlags(args).filter((arg) => READ_ONLY_EXTRA_ARGS.has(arg));
+}
 
 export interface InvokeSkillResponse {
   [key: string]: unknown;
@@ -98,9 +103,10 @@ export async function invokeSkillTool(
   const skillPath = path.join(skill.skillDir, skill.entrypoint);
   const allowExtraArgs = (options.processEnv ?? process.env).SIMMER_MCP_ALLOW_EXTRA_ARGS === "true";
   const rawExtraArgs = (args.extra_args as unknown[]) ?? [];
-  const argv = allowExtraArgs
-    ? [skillPath, ...filterBlockedFlags(rawExtraArgs)]
-    : [skillPath];
+  const extraArgs = allowExtraArgs
+    ? filterBlockedFlags(rawExtraArgs)
+    : filterDefaultExtraArgs(rawExtraArgs);
+  const argv = [skillPath, ...extraArgs];
 
   const env = buildEnv(skill, args, { processEnv: options.processEnv });
 

--- a/mcp/tests/per-skill-tools.test.ts
+++ b/mcp/tests/per-skill-tools.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { invokeSkillTool } from "../dist/per-skill-tools.js";
+import type { Skill } from "../src/core/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const fixtureSkill: Skill = {
+  slug: "fixture-skill",
+  toolName: "simmer_fixture_skill",
+  name: "Fixture Skill",
+  description: "Echoes argv for MCP tests",
+  version: "0.0.0",
+  tier: "trading",
+  entrypoint: "echo_skill.py",
+  tunables: [],
+  skillDir: path.join(__dirname, "fixtures"),
+  hasDisclaimer: false,
+};
+
+const processEnv: Record<string, string> = {
+  PATH: process.env.PATH ?? "",
+  HOME: process.env.HOME ?? "",
+  SIMMER_MCP_PYTHON: "python3",
+};
+
+function resultArgv(resp: Awaited<ReturnType<typeof invokeSkillTool>>): string[] {
+  const result = resp._meta?.result as { argv?: unknown } | undefined;
+  assert.ok(result, `missing parsed result: ${JSON.stringify(resp)}`);
+  assert.ok(Array.isArray(result.argv), `missing argv: ${JSON.stringify(result)}`);
+  return result.argv as string[];
+}
+
+test("invokeSkillTool passes read-only extra_args without SIMMER_MCP_ALLOW_EXTRA_ARGS", async () => {
+  const resp = await invokeSkillTool(
+    fixtureSkill,
+    { dry_run: true, extra_args: ["--check", "--config"] },
+    { processEnv },
+  );
+
+  assert.equal(resp.isError, false, resp.content[0]?.text);
+  assert.deepEqual(resultArgv(resp), ["--check", "--config"]);
+});
+
+test("invokeSkillTool still drops non-read-only extra_args by default", async () => {
+  const resp = await invokeSkillTool(
+    fixtureSkill,
+    { dry_run: true, extra_args: ["--check", "--positions-only", "--live"] },
+    { processEnv },
+  );
+
+  assert.equal(resp.isError, false, resp.content[0]?.text);
+  assert.deepEqual(resultArgv(resp), ["--check"]);
+});
+
+test("invokeSkillTool passes arbitrary sanitized extra_args when explicitly enabled", async () => {
+  const resp = await invokeSkillTool(
+    fixtureSkill,
+    { dry_run: true, extra_args: ["--positions-only", "--live", "--config"] },
+    { processEnv: { ...processEnv, SIMMER_MCP_ALLOW_EXTRA_ARGS: "true" } },
+  );
+
+  assert.equal(resp.isError, false, resp.content[0]?.text);
+  assert.deepEqual(resultArgv(resp), ["--positions-only", "--config"]);
+});


### PR DESCRIPTION
## Summary
- Allow read-only per-skill MCP extra_args (`--check`, `--config`, `--status`, `--positions`, `--help`) without requiring SIMMER_MCP_ALLOW_EXTRA_ARGS.
- Preserve the existing live-flag sanitizer and keep arbitrary CLI passthrough gated by SIMMER_MCP_ALLOW_EXTRA_ARGS=true.
- Add per-skill invocation tests covering default read-only passthrough, default arbitrary-arg dropping, and explicit passthrough mode.

## Tests
- npm run build && node --test tests/blocked-flags.test.ts tests/per-skill-tools.test.ts

Closes SIM-2459