### PR TITLE
fix: quiet auto_redeem positions timeouts

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1364,6 +1364,30 @@ class SimmerClient:
         response.raise_for_status()
         return response.json()
 
+    def _get_auto_redeem_positions_response(self) -> Optional[Dict[str, Any]]:
+        """Fetch resolved positions for auto_redeem with one timeout-only retry.
+
+        Intermittent positions timeouts are housekeeping noise for auto_redeem:
+        no trade is placed and the next cycle can try again. Keep them out of
+        WARNING/stderr while preserving real failures as warnings at the caller.
+        """
+        params = {"status": "resolved"}
+        for attempt in (1, 2):
+            try:
+                return self._request("GET", "/api/sdk/positions", params=params)
+            except requests.exceptions.Timeout as e:
+                logger.info(
+                    "auto_redeem_warning: positions fetch timed out; "
+                    "endpoint=/api/sdk/positions retryable=true non_fatal=true "
+                    "attempt=%d error=%s",
+                    attempt,
+                    e,
+                )
+                if attempt == 1:
+                    time.sleep(0.5)
+                    continue
+                return None
+
     def get_markets(
         self,
         status: str = "active",
@@ -3491,9 +3515,11 @@ class SimmerClient:
 
         # Fetch positions (raw request to get redeemable fields not on Position dataclass)
         try:
-            data = self._request("GET", "/api/sdk/positions", params={"status": "resolved"})
+            data = self._get_auto_redeem_positions_response()
         except Exception as e:
             logger.warning("auto_redeem: could not fetch positions (%s)", e)
+            return results
+        if data is None:
             return results
 
         positions = data.get("positions", [])

--- a/tests/test_auto_redeem_timeout_noise.py
+++ b/tests/test_auto_redeem_timeout_noise.py
@@ -1,0 +1,48 @@
+"""SIM-2458: auto_redeem positions timeouts should not become alert noise."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_client() -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client._auto_redeem_enabled = True
+    client._refresh_cohort_cache = MagicMock()
+    client._request = MagicMock()
+    return client
+
+
+def test_auto_redeem_positions_timeout_logs_info_not_warning(caplog):
+    client = _make_client()
+    client._request.side_effect = requests.exceptions.ReadTimeout(
+        "HTTPSConnectionPool(host='api.simmer.markets', port=443): Read timed out."
+    )
+
+    with patch("time.sleep"), caplog.at_level(logging.INFO, logger="simmer_sdk.client"):
+        result = client.auto_redeem()
+
+    assert result == []
+    assert client._request.call_count == 2
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == []
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("auto_redeem_warning: positions fetch timed out" in m for m in messages)
+    assert any("retryable=true" in m and "non_fatal=true" in m for m in messages)
+
+
+def test_auto_redeem_positions_non_timeout_still_warns(caplog):
+    client = _make_client()
+    client._request.side_effect = RuntimeError("server returned malformed JSON")
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        result = client.auto_redeem()
+
+    assert result == []
+    assert client._request.call_count == 1
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "auto_redeem: could not fetch positions" in warnings[0]


### PR DESCRIPTION
## Summary
- Retry the auto_redeem resolved-positions fetch once on request timeouts
- Log timeout-only failures as structured non-fatal info (`auto_redeem_warning`) instead of WARNING/stderr
- Keep non-timeout positions fetch failures as warnings

## Tests
- python3 -m pytest -q tests/test_auto_redeem_timeout_noise.py tests/test_failed_trade_logging.py

Closes SIM-2458