### PR TITLE
fix(skill): handle nullable mil-aircraft market fields

### DIFF
--- a/skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
+++ b/skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
@@ -252,12 +252,15 @@ def market_question(market):
 
 
 def is_strike_action_market(market, keywords):
-    text = " ".join([
-        market_question(market),
-        market.get("event_name", ""),
-        market.get("resolution_criteria", ""),
-        market.get("description", ""),
-    ]).lower()
+    text = " ".join(
+        str(part or "")
+        for part in (
+            market_question(market),
+            market.get("event_name"),
+            market.get("resolution_criteria"),
+            market.get("description"),
+        )
+    ).lower()
     if not any(str(keyword).lower() in text for keyword in keywords):
         return False
     action_terms = (

--- a/tests/test_milaircraft_regions.py
+++ b/tests/test_milaircraft_regions.py
@@ -72,3 +72,17 @@ def test_load_regions_from_yaml():
     assert len(regions) == 5
     assert regions[0]["name"] == "persian-gulf"
     assert regions[0]["cluster_threshold"] == 3
+
+
+def test_market_classifier_handles_nullable_text_fields():
+    """Market search responses can include nullable text fields."""
+    from milaircraft_tracker import is_strike_action_market
+
+    market = {
+        "question": "Will there be a military strike on the Korean peninsula?",
+        "event_name": None,
+        "resolution_criteria": None,
+        "description": None,
+    }
+
+    assert is_strike_action_market(market, ["Korea"]) is True


### PR DESCRIPTION
## Summary
- handle nullable market text fields in the mil-aircraft market classifier
- add a regression test for Simmer market-search responses with null event/criteria/description fields

## Dogfood receipt
Cron `Herman mil-aircraft dry-run shadow` errored in paper mode when the Korean-peninsula cluster fired and market search returned a row with `None` text fields:
`TypeError: sequence item 1: expected str instance, NoneType found` at `is_strike_action_market()`.

## Verification
- RED: `pytest tests/test_milaircraft_regions.py::test_market_classifier_handles_nullable_text_fields -q` failed with the reported TypeError before the fix
- GREEN: `pytest tests/test_milaircraft_regions.py tests/test_milaircraft_pref_client.py -q` → 8 passed
- `python -m py_compile skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py`
- Safe paper verification only: `python skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py --dry-run` completed, trades attempted/executed 0

No live trades, signing, approvals, or funds moved.