### PR TITLE
fix(skills): correct bucket_spread type + mert-sniper expiry doc (SIM-2407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Tunable env-var names aligned between `clawhub.json` and `CONFIG_SCHEMA`.** Skills that declared config tunables in both their ClawHub metadata and their Python CONFIG_SCHEMA could have name mismatches (e.g., `SIMMER_MIN_EDGE` vs `MIN_EDGE`). Aligned across all bundled skills.
 
+- **`bucket_spread` tunable type corrected for `polymarket-elon-tweets`.** The ClawHub slider was configured as a float in `[0.01, 0.2]`, but the code interprets `bucket_spread` as an integer count of neighboring buckets. Any ClawHub-configured value like `0.05` would `int()`-truncate to `0`, leaving only the center bucket and defeating the spread strategy. The slider is now an integer in `[0, 5]` with step 1 and a clarified label, matching the code's semantics.
+
+- **Mert-sniper documentation corrected: expiry window default is 8 minutes.** `SKILL.md` showed a 2-minute default for `SIMMER_MERT_EXPIRY_MINUTES` in multiple places; the actual code default is 8 minutes. Updated across all references in the skill documentation.
+
 - **Briefing skill fixes:** Removed unsupported `venue=` parameter. Converted remaining attribute access to dict access for compatibility with briefing response shape changes.
 
 - **Exit scan `sources=None` guard.** Skills with no configured signal sources no longer crash on the exit scan. (#130)

--- a/skills/polymarket-elon-tweets/clawhub.json
+++ b/skills/polymarket-elon-tweets/clawhub.json
@@ -42,13 +42,13 @@
     {
       "env": "SIMMER_ELON_BUCKET_SPREAD",
       "type": "number",
-      "default": 0.05,
+      "default": 1,
       "range": [
-        0.01,
-        0.2
+        0,
+        5
       ],
-      "step": 0.01,
-      "label": "Bucket spread"
+      "step": 1,
+      "label": "Bucket spread (neighbors each side)"
     },
     {
       "env": "SIMMER_ELON_SIZING_PCT",

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polymarket-mert-sniper
-description: Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes, filters for strongly-skewed splits (60/40+), and places bounded trades against the under-priced side. Defaults — $10 max per trade, 5 trades/run, dry-run unless `--live`.
+description: Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes, filters for strongly-skewed splits (60/40+), and places bounded trades against the under-priced side. Defaults — $10 max per trade, 5 trades/run, 8-minute expiry window, dry-run unless `--live`.
 metadata:
   author: Simmer (@simmer_markets)
   version: "1.3.2"
@@ -12,7 +12,7 @@ metadata:
 
 Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes of pricing, filters for strongly-skewed splits, and places bounded trades against the under-priced side.
 
-> 🚨 **Framework, not a production trading system.** Read [DISCLAIMER.md](./DISCLAIMER.md) before connecting to a wallet with real funds. Dry-run is the default; `--live` is required for any real-USDC trade. Defaults: $10 max per trade, 60/40 split minimum, 2-minute expiry window, 5 trades per scan cycle — adjust deliberately before scaling.
+> 🚨 **Framework, not a production trading system.** Read [DISCLAIMER.md](./DISCLAIMER.md) before connecting to a wallet with real funds. Dry-run is the default; `--live` is required for any real-USDC trade. Defaults: $10 max per trade, 60/40 split minimum, 8-minute expiry window, 5 trades per scan cycle — adjust deliberately before scaling.
 
 > **This is a template.** The default logic (expiry + split filter) is a starting point — remix it with your own filters, timing rules, or market selection criteria. The skill handles all the plumbing (market discovery, trade execution, safeguards). Your agent provides the alpha.
 
@@ -46,7 +46,7 @@ Use this skill when the user wants to:
 4. **Ask about settings** (or confirm defaults)
    - Market filter: Which markets to scan (default: all)
    - Max bet: Maximum per trade (default $10)
-   - Expiry window: How close to resolution (default 2 minutes)
+   - Expiry window: How close to resolution (default 8 minutes)
    - Min split: Minimum odds skew (default 60/40)
 
 5. **Save settings to config.json or environment variables**
@@ -57,7 +57,7 @@ Use this skill when the user wants to:
 |---------|---------------------|---------|-------------|
 | Market filter | `SIMMER_MERT_FILTER` | (all) | Tag or keyword filter (e.g. `solana`, `crypto`) |
 | Max bet | `SIMMER_MERT_MAX_BET_USD` | 10.00 | Maximum USD per trade |
-| Expiry window | `SIMMER_MERT_EXPIRY_MINUTES` | 2 | Only trade markets resolving within N minutes |
+| Expiry window | `SIMMER_MERT_EXPIRY_MINUTES` | 8 | Only trade markets resolving within N minutes |
 | Min split | `SIMMER_MERT_MIN_SPLIT` | 0.60 | Only trade when YES or NO >= this (e.g. 0.60 = 60/40) |
 | Max trades/run | `SIMMER_MERT_MAX_TRADES_PER_RUN` | 5 | Maximum trades per scan cycle |
 | Smart sizing % | `SIMMER_MERT_SIZING_PCT` | 0.05 | % of balance per trade |
@@ -112,7 +112,7 @@ python mert_sniper.py --no-safeguards
 
 Each cycle the script:
 1. Fetches active markets from Simmer API (optionally filtered by tag/keyword)
-2. Filters to markets resolving within the expiry window (default 2 minutes)
+2. Filters to markets resolving within the expiry window (default 8 minutes)
 3. Checks the price split -- only trades when one side >= min_split (default 60%)
 4. Determines direction: backs the favored side (higher probability)
 5. **Fee logging**: prints entry-fee cost per market (`POLY_FEE_RATE_CRYPTO × p × (1-p)`, entry only — redemption is free). If `SIMMER_MERT_MIN_EDGE > 0`, gates out markets where declared edge < entry fee + buffer
@@ -131,7 +131,7 @@ Each cycle the script:
   Configuration:
   Filter:        solana
   Max bet:       $10.00
-  Expiry window: 2 minutes
+  Expiry window: 8 minutes
   Min split:     60/40
   Max trades:    5
   Smart sizing:  Disabled
@@ -140,7 +140,7 @@ Each cycle the script:
   Fetching markets (filter: solana)...
   Found 12 active markets
 
-  Markets expiring within 2 minutes: 2
+  Markets expiring within 8 minutes: 2
 
   SOL highest price on Feb 10?
      Resolves in: 1m 34s


### PR DESCRIPTION
Fixes two residual divergences between `clawhub.json` and `CONFIG_SCHEMA` surfaced during the SIM-2374 AI Code Review.

## Changes

### Bug fix: `bucket_spread` type mismatch (polymarket-elon-tweets)
- `skills/polymarket-elon-tweets/clawhub.json`: changed `bucket_spread` tunable from float slider `[0.01, 0.2]` step `0.01` to integer slider `[0, 5]` step `1`.
- **Why:** The code interprets `bucket_spread` as `int` — the count of neighboring buckets on each side of the projection (e.g. `1` = 3 buckets total). The old clawhub float range (e.g. default `0.05`) would `int()`-truncate to `0`, leaving only the center bucket and defeating the spread strategy. This was a silent safety inversion: users who set any value in `[0.01, 0.2]` via the UI got 0 neighbors instead of the intended spread.
- Default aligned to code default (`1`). Label updated to "Bucket spread (neighbors each side)" to clarify semantics.

### Doc nit: mert-sniper expiry window default (polymarket-mert-sniper)
- `skills/polymarket-mert-sniper/SKILL.md`: corrected expiry window default from `2` minutes to `8` minutes in all prose, configuration table, example output, and setup flow.
- **Why:** Code default (`SIMMER_MERT_EXPIRY_MINUTES`) is `8`; SKILL.md showed `2` in 5 places — stale from an earlier version of the skill.

## Tests
- `py_compile` passes on unchanged `.py` files (no Python changes)
- JSON validated via edit (no syntax errors)

## Docs impact
- SKILL.md updated (mert-sniper expiry)
- CHANGELOG.md updated

Closes SIM-2407