### PR TITLE
fix: send detected skill slug on trades

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1660,6 +1660,8 @@ class SimmerClient:
             if effective_venue != "polymarket":
                 raise ValueError(f"price parameter only supported for venue='polymarket' (you specified venue='{effective_venue}')")
 
+        effective_skill_slug = skill_slug or self._skill_slug
+
         payload = {
             "market_id": market_id,
             "side": side,
@@ -1673,8 +1675,8 @@ class SimmerClient:
             payload["reasoning"] = reasoning
         if source:
             payload["source"] = source
-        if skill_slug:
-            payload["skill_slug"] = skill_slug
+        if effective_skill_slug:
+            payload["skill_slug"] = effective_skill_slug
         if signal_data:
             payload["signal_data"] = signal_data
         if price is not None:

--- a/tests/test_failed_trade_logging.py
+++ b/tests/test_failed_trade_logging.py
@@ -7,7 +7,11 @@ using stdlib logging gets a stderr signal on the first failure.
 """
 
 import logging
+import os
+import sys
 from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from simmer_sdk.client import SimmerClient
 
@@ -23,6 +27,7 @@ def _make_client(venue="polymarket"):
     client.live = True
     client.venue = venue
     client._held_markets_cache = None
+    client._skill_slug = None
     client._request = MagicMock()
     client._get_held_markets = MagicMock(return_value={})
     return client
@@ -87,3 +92,47 @@ def test_does_not_log_when_failure_has_no_error(caplog):
     assert result.success is False
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert warnings == []
+
+
+def test_trade_defaults_skill_slug_from_detected_skill():
+    """A client constructed inside a skill sends its detected skill slug."""
+    client = _make_client(venue="polymarket")
+    client._skill_slug = "polymarket-weather-trader"
+    client._request.return_value = {
+        "success": True,
+        "market_id": "test-market",
+        "side": "yes",
+        "shares_bought": 5.0,
+        "cost": 2.5,
+        "fill_status": "filled",
+    }
+
+    result = client.trade("test-market", "yes", amount=10.0)
+
+    assert result.success is True
+    payload = client._request.call_args.kwargs["json"]
+    assert payload["skill_slug"] == "polymarket-weather-trader"
+
+
+def test_explicit_trade_skill_slug_overrides_detected_skill():
+    client = _make_client(venue="polymarket")
+    client._skill_slug = "polymarket-weather-trader"
+    client._request.return_value = {
+        "success": True,
+        "market_id": "test-market",
+        "side": "yes",
+        "shares_bought": 5.0,
+        "cost": 2.5,
+        "fill_status": "filled",
+    }
+
+    result = client.trade(
+        "test-market",
+        "yes",
+        amount=10.0,
+        skill_slug="custom-skill",
+    )
+
+    assert result.success is True
+    payload = client._request.call_args.kwargs["json"]
+    assert payload["skill_slug"] == "custom-skill"


### PR DESCRIPTION
## Summary
- include the auto-detected SKILL.md slug in client.trade() payloads by default
- keep explicit per-trade skill_slug overrides authoritative
- add focused SDK coverage for default and explicit skill_slug payloads

## Root Cause
The SDK already parsed SKILL.md into self._skill_slug for integrity/version logic, but client.trade() only sent skill_slug when the caller passed it manually. First-party and third-party skills that relied on automatic detection therefore generated trades without canonical skill attribution.

## Tests
- pytest -q tests/test_failed_trade_logging.py

Related to SIM-2495