### PR TITLE
fix(weather-trader): override FAK to GTC at startup (SIM-2502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **`polymarket-weather-trader` forces GTC order type, overrides FAK.** Weather markets are structurally illiquid; FAK orders are rejected immediately with no fill. The skill now detects when `order_type=FAK` is configured (via env var or `config.json`) and overrides it to GTC at startup with a clear warning. Default users are unaffected — the default was already GTC.
+
 - **Preflight-gate test stubs scoped with `patch.dict`.** Three preflight-gate test files previously used `sys.modules.setdefault("simmer_sdk", MagicMock())` which could permanently replace the real SDK module when tests ran in a mixed collection order. Replaced with a `patch.dict` context manager scoped to the skill import.
 
 - **`auto_redeem()` warns when signing key is unavailable.** Previously failed silently for managed-wallet users calling `auto_redeem()` without a local signing key. Now surfaces a visible warning explaining that managed-wallet redemptions are handled server-side.

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -65,7 +65,7 @@ CONFIG_SCHEMA = {
     "slippage_max":      {"env": "SIMMER_WEATHER_SLIPPAGE_MAX",      "default": 0.15,  "type": float},
     "min_liquidity":     {"env": "SIMMER_WEATHER_MIN_LIQUIDITY",     "default": 0.0,   "type": float},
     "order_type":        {"env": "SIMMER_WEATHER_ORDER_TYPE",        "default": "GTC", "type": str,
-                          "help": "Order type: GTC (default, limit order that waits for fill) or FAK (cancel if not filled immediately). GTC recommended for illiquid weather markets."},
+                          "help": "Order type: GTC (default, limit order that waits for fill) or FAK (cancel if not filled immediately). FAK is automatically overridden to GTC because weather markets are structurally illiquid — FAK orders are rejected immediately with no fill."},
     "vol_targeting":     {"env": "SIMMER_WEATHER_VOL_TARGETING",     "default": False, "type": bool,
                           "help": "Enable volatility targeting: scale position sizes by target_vol / realized_vol."},
     "target_vol":        {"env": "SIMMER_WEATHER_TARGET_VOL",        "default": 0.20,  "type": float,
@@ -104,7 +104,20 @@ for _old, _new in _LEGACY_ENV_ALIASES.items():
 _config = load_config(CONFIG_SCHEMA, __file__, slug="polymarket-weather-trader")
 
 NOAA_API_BASE = "https://api.weather.gov"
-ORDER_TYPE = (_config.get("order_type") or "GTC").upper()
+_configured_order_type = (_config.get("order_type") or "GTC").upper()
+if _configured_order_type == "FAK":
+    # FAK (Fill And Kill) fails on weather markets because liquidity is structurally
+    # thin — the order gets cancelled immediately with no fill. Force GTC so limit
+    # orders queue on the book and wait for a counterparty. Users who set
+    # SIMMER_WEATHER_ORDER_TYPE=FAK or order_type=FAK in config.json get this override.
+    print(
+        "[weather-trader] WARNING: order_type=FAK is not suitable for weather markets "
+        "(thin liquidity → immediate cancel). Overriding to GTC. "
+        "Set SIMMER_WEATHER_ORDER_TYPE=GTC to silence this warning."
+    )
+    ORDER_TYPE = "GTC"
+else:
+    ORDER_TYPE = _configured_order_type
 
 # SimmerClient singleton
 _client = None


### PR DESCRIPTION
Weather markets are structurally illiquid — FAK (Fill And Kill) orders are rejected immediately with no fill when there's no counterparty at the requested price. Post-May-7 data showed 79 failures at prices like 0.25, 0.57, 0.60, all FAK no-liquidity rejections.

## Root cause

The skill's config default was already GTC (correct). The failures came from users who explicitly set `SIMMER_WEATHER_ORDER_TYPE=FAK` or `order_type: "FAK"` in their `config.json` — familiar with the SDK's `trade()` default being FAK and not realizing it doesn't work for weather markets.

The execute paths (`execute_trade`, `execute_sell`) both correctly pass `order_type=ORDER_TYPE`, so the only way to get FAK was explicit user configuration.

## Changes

- `skills/polymarket-weather-trader/weather_trader.py`: detect `order_type=FAK` at startup and override to GTC with a clear warning. GTC, GTD, FOK all pass through unchanged.
- Updated config schema help text to document the FAK→GTC override.
- `CHANGELOG.md`: entry under Unreleased > Fixed.

## Acceptance checklist

- [x] weather_trader.py consistently uses GTC for all order submissions (FAK users now get GTC)
- [x] Warning printed at startup when FAK is overridden — users get visibility
- [x] Default users (GTC config) are unaffected — code path branches on `_configured_order_type == "FAK"` only
- [x] py_compile passes

## Follow-up (deferred per ticket)

SIM-2502 also flags: "should the SDK default `order_type` be GTC instead of FAK for all Polymarket trades?" This is a broader SDK change — not in scope for this PR.

Closes SIM-2502