### PR TITLE
fix(kalshi-weather-trader): add preflight and ensure_can_trade balance gates (SIM-2501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Briefing skill fixes:** Removed unsupported `venue=` parameter. Converted remaining attribute access to dict access for compatibility with briefing response shape changes.
 
+- **`kalshi-weather-trader` now gates every trade with `preflight()` and skips the run on empty wallets.** Matches the balance-check behaviour already present in `polymarket-weather-trader`: `client.preflight()` blocks each individual trade when the wallet is insufficient, and `client.ensure_can_trade(min_usd=1.0)` exits the run cleanly before the market scan when there is less than $1 available.
+
 - **Exit scan `sources=None` guard.** Skills with no configured signal sources no longer crash on the exit scan. (#130)
 
 ## simmer-mcp v3.3.0 — 2026-05-24

--- a/skills/kalshi-weather-trader/weather_trader.py
+++ b/skills/kalshi-weather-trader/weather_trader.py
@@ -755,6 +755,9 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                          use_safeguards: bool = True, use_trends: bool = True,
                          quiet: bool = False):
     """Run the weather trading strategy."""
+    # Globals declared up-front: balance pre-flight (below) may cap MAX_POSITION_USD.
+    global MAX_POSITION_USD
+
     def log(msg, force=False):
         """Print unless quiet mode is on. force=True always prints."""
         if not quiet or force:

--- a/skills/kalshi-weather-trader/weather_trader.py
+++ b/skills/kalshi-weather-trader/weather_trader.py
@@ -586,7 +586,14 @@ def fetch_weather_markets():
 def execute_trade(market_id: str, side: str, amount: float, reasoning: str = "", signal_data: dict = None) -> dict:
     """Execute a buy trade via Simmer SDK with source tagging."""
     try:
-        result = get_client().trade(
+        client = get_client()
+        if client.live:
+            pf = client.preflight(planned_amount=amount, exposure_cap_usd=0, venue=client.venue)
+            if not pf.ok_to_trade:
+                blockers = ", ".join(pf.blockers)
+                print(f"  ⛔ Preflight blocked: {blockers}")
+                return {"error": f"preflight_blocked: {blockers}"}
+        result = client.trade(
             market_id=market_id, side=side, amount=amount, source=TRADE_SOURCE, skill_slug=SKILL_SLUG,
             reasoning=reasoning, signal_data=signal_data,
         )
@@ -602,7 +609,14 @@ def execute_trade(market_id: str, side: str, amount: float, reasoning: str = "",
 def execute_sell(market_id: str, shares: float, reasoning: str = "") -> dict:
     """Execute a sell trade via Simmer SDK with source tagging."""
     try:
-        result = get_client().trade(
+        client = get_client()
+        if client.live:
+            pf = client.preflight(planned_amount=0, exposure_cap_usd=0, venue=client.venue)
+            if not pf.ok_to_trade:
+                blockers = ", ".join(pf.blockers)
+                print(f"  ⛔ Preflight blocked: {blockers}")
+                return {"error": f"preflight_blocked: {blockers}"}
+        result = client.trade(
             market_id=market_id, side="yes", action="sell",
             shares=shares, source=TRADE_SOURCE, skill_slug=SKILL_SLUG,
             reasoning=reasoning,
@@ -786,6 +800,19 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                 log(f"  💰 Redeemed {r['market_id'][:8]}... ({r.get('side', '?')})")
     except Exception as e:
         log(f"  ⚠️  auto_redeem failed: {e}", force=True)
+
+    # Balance pre-flight: skip cleanly when wallet is underfunded instead of
+    # looping on rejected trades.
+    if not dry_run:
+        _preflight = client.ensure_can_trade(min_usd=1.0)
+        if not _preflight["ok"]:
+            log(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
+                f"(need ≥ $1.00) — skip", force=True)
+            return
+        if _preflight["max_safe_size"] < MAX_POSITION_USD:
+            log(f"  💰 Capping max bet ${MAX_POSITION_USD:.2f} → ${_preflight['max_safe_size']:.2f} "
+                f"(balance ${_preflight['balance']:.2f} {_preflight['collateral']})", force=True)
+            MAX_POSITION_USD = _preflight["max_safe_size"]
 
     # Show portfolio if smart sizing enabled
     if smart_sizing:


### PR DESCRIPTION
Adds the two balance-gate checks to `kalshi-weather-trader` that already exist in `polymarket-weather-trader`.

## Changes
- `skills/kalshi-weather-trader/weather_trader.py`: Added `client.preflight()` check in `execute_trade` and `execute_sell` (blocks the trade if wallet is insufficient), and `client.ensure_can_trade(min_usd=1.0)` at the top of `run_weather_strategy` (exits the run cleanly before the market scan when balance < $1).
- `CHANGELOG.md`: Added entry under `[Unreleased] > Fixed`.

## Tests
- `skills/kalshi-weather-trader/tests/` — 3 passed (`test_sources_none.py` etc.)
- Pattern mirrors the existing polymarket-weather-trader implementation, which was gated with the same checks in SIM-2312.

Closes SIM-2501