### PR TITLE
fix(dw-redeem): handle 422 not_redeemable from prepare endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.23] — 2026-05-26
+
+### Fixed
+
+- **`dw_redeem.prepare_dw_redeem` handles 422 `not_redeemable` responses.** Server now returns HTTP 422 (not 200) when on-chain payout is not finalized. The SDK's error handler preserves the `not_redeemable`, `reason`, and `detail` flags so `client.redeem()` and `auto_redeem()` skip cleanly instead of retrying.
+
 ## [Unreleased]
 
 ### Infrastructure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.22"
+version = "0.17.23"
 description = "Python SDK for trading prediction markets with AI agents - includes Clawbot trading skills"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/dw_redeem.py
+++ b/simmer_sdk/dw_redeem.py
@@ -159,9 +159,26 @@ def prepare_dw_redeem(
     if not res.ok:
         try:
             data = res.json()
+            if data.get("not_redeemable"):
+                _reason = data.get("reason", "market_not_settled")
+                _detail = data.get("detail")
+                _msg = (
+                    "Payouts are not finalized on-chain yet. Try again later."
+                    if _detail == "neg_risk_not_determined"
+                    else f"Market not yet redeemable ({_detail or _reason})."
+                )
+                raise DwRedeemPrepareError(
+                    _msg,
+                    status_code=res.status_code,
+                    not_redeemable=True,
+                    reason=_reason,
+                    detail=_detail,
+                )
             detail = data.get("detail")
             if isinstance(detail, list) and detail:
                 detail = detail[0].get("msg") or str(detail[0])
+        except DwRedeemPrepareError:
+            raise
         except Exception:
             detail = None
         raise DwRedeemPrepareError(


### PR DESCRIPTION
## Summary
- Server-side companion change (simmer PR #1073) returns HTTP 422 for `not_redeemable` prepare responses instead of 200
- SDK's `!res.ok` handler now checks for `not_redeemable` in the 422 response body and raises `DwRedeemPrepareError` with proper `not_redeemable`, `reason`, `detail` flags
- `client.redeem()` and `auto_redeem()` continue to skip cleanly via `exc.not_redeemable`
- Bumps to v0.17.23

## Test plan
- [x] `pytest tests/ -k dw_redeem` — 20 passed
- [x] Backwards compatible: if server returns 200 with `not_redeemable`, the existing post-200 check (line 192) still catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)