### PR TITLE
fix(milaircraft): detect invade markets and sim trades

### DIFF
--- a/skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
+++ b/skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
@@ -178,6 +178,7 @@ def check_context_safeguards(context):
 
 def execute_trade(market_id, side, amount, reasoning="", price=None, signal_data=None):
     try:
+        client = get_client()
         kwargs = dict(
             market_id=market_id,
             side=side,
@@ -188,9 +189,9 @@ def execute_trade(market_id, side, amount, reasoning="", price=None, signal_data
             order_type=ORDER_TYPE,
             signal_data=signal_data,
         )
-        if price is not None:
+        if price is not None and getattr(client, "venue", None) == "polymarket":
             kwargs["price"] = price
-        result = get_client().trade(**kwargs)
+        result = client.trade(**kwargs)
         return {
             "success": result.success,
             "trade_id": result.trade_id,
@@ -270,6 +271,7 @@ def is_strike_action_market(market, keywords):
         "missile",
         "airstrike",
         "invasion",
+        "invade",
         "bomb",
         "war",
         "conflict",
@@ -450,6 +452,7 @@ def run_strategy(
             print(f"    {name:<24} {data['count']}/{data['cluster_threshold']} {marker}")
 
     positions = get_positions()
+    open_market_ids = {str(pos.get("market_id")) for pos in positions if pos.get("market_id")}
     exits = handle_exits(positions, clusters, dry_run=dry_run)
 
     portfolio = get_portfolio() or {}
@@ -484,6 +487,9 @@ def run_strategy(
             question = market_question(market)
             if not market_id or price is None:
                 skip_reasons.append("missing market id or price")
+                continue
+            if market_id in open_market_ids:
+                skip_reasons.append(f"already positioned: {question[:40]}")
                 continue
             if price < MIN_TICK_SIZE or price > (1 - MIN_TICK_SIZE):
                 skip_reasons.append("price at extreme")

--- a/tests/test_milaircraft_regions.py
+++ b/tests/test_milaircraft_regions.py
@@ -86,3 +86,47 @@ def test_market_classifier_handles_nullable_text_fields():
     }
 
     assert is_strike_action_market(market, ["Korea"]) is True
+
+
+def test_market_classifier_matches_invade_wording():
+    """Polymarket often says 'invade' rather than 'invasion'."""
+    from milaircraft_tracker import is_strike_action_market
+
+    market = {
+        "question": "Will North Korea invade South Korea before 2027?",
+        "event_name": "Will North Korea invade South Korea before 2027?",
+        "resolution_criteria": None,
+        "description": None,
+    }
+
+    assert is_strike_action_market(market, ["North Korea", "Korea"]) is True
+
+
+def test_execute_trade_omits_limit_price_for_sim_venue(monkeypatch):
+    """Sim venue rejects explicit price; only Polymarket limit orders use it."""
+    import milaircraft_tracker
+
+    calls = []
+
+    class Result:
+        success = True
+        trade_id = "sim-trade"
+        shares_bought = 10
+        order_id = None
+        fill_status = "filled"
+        error = None
+        simulated = True
+
+    class FakeClient:
+        venue = "sim"
+
+        def trade(self, **kwargs):
+            calls.append(kwargs)
+            return Result()
+
+    monkeypatch.setattr(milaircraft_tracker, "get_client", lambda: FakeClient())
+
+    result = milaircraft_tracker.execute_trade("m1", "yes", 5, price=0.06)
+
+    assert result["success"] is True
+    assert "price" not in calls[0]


### PR DESCRIPTION
## Summary
- classify Polymarket 'invade' wording as strike/action market text so fired Korea clusters can map to the North Korea invasion market
- omit limit price when the skill executes against the SIM venue, because Simmer only supports explicit price for Polymarket
- skip already-held market IDs before opening new entries to avoid repeat buys after a previous signal/timeout reconciliation

## Verification
- python3 -m pytest tests/test_milaircraft_regions.py tests/test_milaircraft_pref_client.py tests/test_milaircraft_integration.py -q
- TRADING_VENUE=sim python3 skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py --dry-run observed 1 Korean Peninsula signal before SIM execution
- TRADING_VENUE=sim SIMMER_MILACFT_MAX_TRADES_PER_RUN=1 SIMMER_MILACFT_TRADE_SIZE=5 python3 skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py --live created/reconciled SIM position; repeat run skipped duplicate with 0 attempted

## Dogfood receipts
- Root cause: market classifier had 'invasion' but not verb 'invade', so 'Will North Korea invade South Korea before 2027?' was discovered but filtered out.
- Secondary root cause: SIM venue rejected explicit price passed by the skill; price is now Polymarket-only.
- No real-money trade executed; only SIM venue was used for verification.