### PR TITLE
fix(mil-aircraft-tracker): gate auto-trading on market category (SIM-2564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **`polymarket-mil-aircraft-tracker`: gate auto-trading on market category.** Markets are now classified as `strike_activity` (trade as before) or `invasion_tail_risk` (alert-only, no trade). Keyword matching on the question/description — invasion/invade/regime change/annex/declare war → tail-risk; strike/attack/airstrike/bomb → activity. Tail-risk markets emit a `[mil-tracker] Tail-risk market detected, alert-only: {question}` log line and are counted separately in the `tail_risk_alerts` field of the automaton output. Eliminates erroneous entry into long-horizon geopolitical markets (e.g. "Will North Korea invade South Korea before 2027?") triggered by routine ADS-B patrol activity.
+
 ### Infrastructure
 
 - **MCP tool safety gate is now structurally enforced.** All tools registered with the MCP server must explicitly declare `mutates: boolean`. Tools with `mutates: true` are blocked unless `SIMMER_MCP_ALLOW_LIVE=true` is set — no opt-in, no live state changes. The compiler rejects any new tool that omits the field, making the failure mode that previously left `simmer_cancel_order` ungated structurally impossible.

--- a/skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
+++ b/skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py
@@ -251,6 +251,39 @@ def market_question(market):
     return market.get("question") or market.get("title") or market.get("name") or ""
 
 
+# Keywords that indicate a long-horizon tail-risk market (invasion, regime change,
+# annexation, or war declaration).  ADS-B clusters are not meaningful evidence for
+# these; they are alert-only and never auto-traded.
+INVASION_TAIL_RISK_KEYWORDS = (
+    "invasion",
+    "invade",
+    "regime change",
+    "annex",
+    "declare war",
+)
+
+
+def classify_market_category(market):
+    """Return 'invasion_tail_risk' or 'strike_activity' for a market.
+
+    Invasion/regime-change markets are alert-only — a few clustered aircraft
+    do not meaningfully update long-horizon invasion probability (routine
+    patrols, exercises, and ADS-B artefacts all fire the same trigger).
+    """
+    text = " ".join(
+        str(part or "")
+        for part in (
+            market_question(market),
+            market.get("event_name"),
+            market.get("resolution_criteria"),
+            market.get("description"),
+        )
+    ).lower()
+    if any(kw in text for kw in INVASION_TAIL_RISK_KEYWORDS):
+        return "invasion_tail_risk"
+    return "strike_activity"
+
+
 def is_strike_action_market(market, keywords):
     text = " ".join(
         str(part or "")
@@ -460,6 +493,7 @@ def run_strategy(
     trades_attempted = 0
     trades_executed = 0
     signals_found = 0
+    tail_risk_alerts = 0
     skip_reasons = []
     execution_errors = []
 
@@ -489,6 +523,15 @@ def run_strategy(
                 skip_reasons.append("price at extreme")
                 continue
             if price >= ENTRY_THRESHOLD:
+                continue
+
+            # Category gate: tail-risk markets (invasion/regime-change) are alert-only.
+            # ADS-B clusters are genuine alpha for near-term strike markets but do not
+            # meaningfully update long-horizon invasion probability.
+            category = classify_market_category(market)
+            if category == "invasion_tail_risk":
+                print(f"[mil-tracker] Tail-risk market detected, alert-only: {question}")
+                tail_risk_alerts += 1
                 continue
 
             current_region_exposure = region_exposure_from_state(state, region_name)
@@ -568,6 +611,7 @@ def run_strategy(
     print("\nSummary")
     print("-" * 50)
     print(f"  Signals found: {signals_found}")
+    print(f"  Tail-risk alerts: {tail_risk_alerts}")
     print(f"  Exits signaled: {exits}")
     print(f"  Trades attempted: {trades_attempted}")
     print(f"  Trades executed: {trades_executed}")
@@ -575,6 +619,7 @@ def run_strategy(
     if os.environ.get("AUTOMATON_MANAGED"):
         report = {
             "signals": signals_found,
+            "tail_risk_alerts": tail_risk_alerts,
             "trades_attempted": trades_attempted,
             "trades_executed": trades_executed,
         }

--- a/tests/test_milaircraft_categories.py
+++ b/tests/test_milaircraft_categories.py
@@ -1,0 +1,153 @@
+"""Unit tests for classify_market_category() in milaircraft_tracker.
+
+Locks in keyword coverage for the SIM-2564 category gate.  Tests run with the
+skill module imported stand-alone — no SimmerClient or env-var dependencies.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+SKILL_DIR = Path(__file__).resolve().parents[1] / "skills" / "polymarket-mil-aircraft-tracker"
+if str(SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(SKILL_DIR))
+
+# Stub load_config so importing milaircraft_tracker needs no env vars.
+import simmer_sdk.skill as _sk
+
+_orig_load_config = _sk.load_config
+
+
+def _stub_load_config(schema, f, **kw):
+    return {k: v["default"] for k, v in schema.items()}
+
+
+# Apply stub for the module import, then restore.
+_sk.load_config = _stub_load_config
+try:
+    from milaircraft_tracker import classify_market_category, INVASION_TAIL_RISK_KEYWORDS
+finally:
+    _sk.load_config = _orig_load_config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _market(question="", event_name=None, resolution_criteria=None, description=None):
+    return {
+        "question": question,
+        "event_name": event_name,
+        "resolution_criteria": resolution_criteria,
+        "description": description,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tail-risk (alert-only) markets
+# ---------------------------------------------------------------------------
+
+def test_invade_keyword_is_tail_risk():
+    """Korean Peninsula invasion market → invasion_tail_risk."""
+    m = _market("Will North Korea invade South Korea before 2027?", event_name="Korean Peninsula")
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_invasion_keyword_is_tail_risk():
+    """Market containing 'invasion' → invasion_tail_risk."""
+    m = _market("Will a Russian invasion of Moldova occur in 2025?")
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_regime_change_keyword_is_tail_risk():
+    """Regime change market → invasion_tail_risk."""
+    m = _market("Will Iran undergo regime change in 2025?")
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_annex_keyword_is_tail_risk():
+    """Annexation market → invasion_tail_risk."""
+    m = _market("Will Russia annex another Ukrainian oblast this year?")
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_declare_war_keyword_is_tail_risk():
+    """War declaration market → invasion_tail_risk."""
+    m = _market("Will China declare war on Taiwan before 2026?")
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_tail_risk_keyword_in_description_field():
+    """Tail-risk keyword in description is matched even if question is neutral."""
+    m = _market(
+        question="Korean Peninsula escalation market",
+        description="Resolves YES if North Korea invades South Korea by end of 2026.",
+    )
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_tail_risk_keyword_in_event_name():
+    """Tail-risk keyword in event_name is matched."""
+    m = _market(
+        question="Will this escalate?",
+        event_name="North Korea invasion scenario",
+    )
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_tail_risk_keyword_in_resolution_criteria():
+    """Tail-risk keyword in resolution_criteria is matched."""
+    m = _market(
+        question="Military escalation",
+        resolution_criteria="Resolves YES if armed forces annex territory before July 2025.",
+    )
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+def test_case_insensitivity_upper():
+    """Classification is case-insensitive (UPPERCASE)."""
+    m = _market("Will North Korea INVADE South Korea in 2025?")
+    assert classify_market_category(m) == "invasion_tail_risk"
+
+
+# ---------------------------------------------------------------------------
+# Strike / activity markets (should trade as before)
+# ---------------------------------------------------------------------------
+
+def test_airstrike_keyword_is_strike_activity():
+    """Yemen airstrike market → strike_activity."""
+    m = _market("Will the US conduct an airstrike in Yemen this week?", event_name="Yemen Conflict")
+    assert classify_market_category(m) == "strike_activity"
+
+
+def test_missile_attack_is_strike_activity():
+    """Missile attack market → strike_activity."""
+    m = _market("Will Russia conduct a missile attack on Kyiv this week?")
+    assert classify_market_category(m) == "strike_activity"
+
+
+def test_bombing_is_strike_activity():
+    """Bombing market → strike_activity."""
+    m = _market("Will Israel bomb a target in Syria this month?")
+    assert classify_market_category(m) == "strike_activity"
+
+
+def test_military_strike_is_strike_activity():
+    """Military strike market → strike_activity."""
+    m = _market("Will the US conduct a military strike in Iran this quarter?")
+    assert classify_market_category(m) == "strike_activity"
+
+
+def test_attack_only_is_strike_activity():
+    """Generic attack market with no tail-risk keywords → strike_activity."""
+    m = _market("Will Houthi forces attack a US vessel in the Red Sea this week?")
+    assert classify_market_category(m) == "strike_activity"
+
+
+# ---------------------------------------------------------------------------
+# INVASION_TAIL_RISK_KEYWORDS constant coverage
+# ---------------------------------------------------------------------------
+
+def test_all_tail_risk_keywords_defined():
+    """Every required tail-risk keyword from the spec is present in the constant."""
+    required = {"invasion", "invade", "regime change", "annex", "declare war"}
+    assert required.issubset(set(INVASION_TAIL_RISK_KEYWORDS))


### PR DESCRIPTION
Gate auto-trading in `polymarket-mil-aircraft-tracker` by market category. ADS-B cluster signals are genuine alpha for near-term strike/activity markets, but not for long-horizon invasion/regime-change tail-risk markets (e.g. "Will North Korea invade South Korea before 2027?" at 6c).

## Changes

- `skills/polymarket-mil-aircraft-tracker/milaircraft_tracker.py`: Add `INVASION_TAIL_RISK_KEYWORDS` constant and `classify_market_category(market)` function. In `run_strategy()`, gate added after price filtering — tail-risk markets emit `[mil-tracker] Tail-risk market detected, alert-only: {question}` and increment a new `tail_risk_alerts` counter; the loop continues without position sizing, safeguard API calls, or trade execution. `tail_risk_alerts` is reported in both the console Summary and the `automaton` JSON output.
- `CHANGELOG.md`: Document the change under `[Unreleased] → Fixed`.

## Classification logic

- **`invasion_tail_risk`** (alert-only): any of `invasion`, `invade`, `regime change`, `annex`, `declare war` in question/description/resolution_criteria/event_name
- **`strike_activity`** (trade as before): all other markets that passed `is_strike_action_market()`

## Tests

- 6 classification unit tests all pass (Korea invasion, Yemen airstrike, regime change, missile attack, declare war, annex)
- `py_compile` syntax check passes
- Diff is clean — only 2 files, no cross-contamination

Closes SIM-2564