### PR TITLE
fix: fetch live positions for empty dry-run portfolios

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2082,27 +2082,10 @@ class SimmerClient:
             error=data.get("error")
         )
 
-    def get_positions(self, venue: Optional[str] = None, source: Optional[str] = None) -> List[Position]:
-        """
-        Get all positions for this agent.
-
-        In paper mode, returns simulated positions from the in-memory
-        portfolio and auto-settles any markets that have resolved.
-
-        Args:
-            venue: Filter by venue ("sim" or "polymarket"). If None, returns both.
-            source: Filter by trade source (e.g., "weather", "copytrading"). Partial match.
-
-        Returns:
-            List of Position objects with P&L info
-        """
-        # Paper mode: return in-memory positions (auto-settle first)
-        if not self.live and self._paper_portfolio is not None:
-            self._settle_paper_positions()
-            return self._get_paper_positions()
-
+    def _get_api_positions(self, venue: Optional[str] = None, source: Optional[str] = None) -> List[Position]:
+        """Fetch positions from the Simmer API and hydrate Position objects."""
         params = {}
-        if venue:
+        if venue and venue != "all":
             params["venue"] = venue
         if source:
             params["source"] = source
@@ -2139,6 +2122,36 @@ class SimmerClient:
         import time as _t
         self._position_holder_ts = _t.time()
         return positions
+
+    def get_positions(self, venue: Optional[str] = None, source: Optional[str] = None) -> List[Position]:
+        """
+        Get all positions for this agent.
+
+        In paper mode, returns simulated positions from the in-memory
+        portfolio and auto-settles any markets that have resolved.
+
+        Args:
+            venue: Filter by venue ("sim" or "polymarket"). If None, returns both.
+            source: Filter by trade source (e.g., "weather", "copytrading"). Partial match.
+
+        Returns:
+            List of Position objects with P&L info
+        """
+        if venue in ("simmer", "sandbox"):
+            venue = "sim"
+
+        # Paper mode: return in-memory positions when they exist. For real-venue
+        # clients, an empty paper portfolio should not hide live receipt data from
+        # /api/sdk/positions (SIM-2585).
+        if not self.live and self._paper_portfolio is not None:
+            self._settle_paper_positions()
+            paper_positions = self._get_paper_positions()
+            if paper_positions:
+                return paper_positions
+            if self.venue == "sim" and (venue is None or venue in ("sim", "all")):
+                return paper_positions
+
+        return self._get_api_positions(venue=venue, source=source)
 
     _HELD_MARKETS_TTL = 30  # seconds
     _HOLDER_CACHE_TTL = 30  # seconds — same as held-markets TTL

--- a/tests/test_get_positions_live_false.py
+++ b/tests/test_get_positions_live_false.py
@@ -1,0 +1,97 @@
+"""Regression tests for live=False position receipt reads (SIM-2585)."""
+
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+from simmer_sdk.paper import PaperPortfolio
+
+
+def _make_client(*, venue="polymarket", live=False) -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client.live = live
+    client.venue = venue
+    client._paper_portfolio = PaperPortfolio() if not live else None
+    client._position_holder_cache = {}
+    client._position_holder_ts = 0.0
+    client._request = MagicMock()
+    client.get_market_context = MagicMock(return_value={
+        "market": {
+            "question": "Will it rain in Chicago?",
+            "external_price_yes": 0.61,
+            "status": "active",
+        }
+    })
+    return client
+
+
+def _api_positions_response() -> dict:
+    return {
+        "positions": [
+            {
+                "market_id": "pm-weather-1",
+                "question": "Will it rain in Chicago?",
+                "shares_yes": 7.5,
+                "shares_no": 0.0,
+                "current_value": 4.58,
+                "pnl": -0.42,
+                "status": "active",
+                "venue": "polymarket",
+                "holder_address": "0xabc",
+            }
+        ]
+    }
+
+
+def test_live_false_real_venue_empty_paper_portfolio_fetches_api_positions():
+    client = _make_client(venue="polymarket", live=False)
+    client._request.return_value = _api_positions_response()
+
+    positions = client.get_positions()
+
+    assert len(positions) == 1
+    assert positions[0].market_id == "pm-weather-1"
+    assert positions[0].venue == "polymarket"
+    client._request.assert_called_once_with("GET", "/api/sdk/positions", params=None)
+
+
+def test_live_false_real_venue_keeps_existing_paper_positions_local():
+    client = _make_client(venue="polymarket", live=False)
+    client._paper_portfolio.log_trade(
+        "paper-market",
+        side="yes",
+        action="buy",
+        shares=10.0,
+        cost=5.0,
+        price=0.5,
+        venue="polymarket",
+    )
+
+    positions = client.get_positions()
+
+    assert len(positions) == 1
+    assert positions[0].market_id == "paper-market"
+    assert positions[0].venue == "polymarket"
+    client._request.assert_not_called()
+
+
+def test_live_false_sim_venue_empty_paper_portfolio_stays_local():
+    client = _make_client(venue="sim", live=False)
+
+    positions = client.get_positions()
+
+    assert positions == []
+    client._request.assert_not_called()
+
+
+def test_get_positions_venue_all_omits_backend_venue_param():
+    client = _make_client(venue="polymarket", live=True)
+    client._request.return_value = _api_positions_response()
+
+    positions = client.get_positions(venue="all", source="sdk:weather")
+
+    assert len(positions) == 1
+    client._request.assert_called_once_with(
+        "GET",
+        "/api/sdk/positions",
+        params={"source": "sdk:weather"},
+    )


### PR DESCRIPTION
## Summary
- keep existing in-memory paper positions when live=False has simulated trades
- fall through to /api/sdk/positions when a real-venue dry-run client has no paper positions, so receipt checks see active Polymarket holdings
- treat venue="all" as no backend venue filter

## Tests
- python3 -m pytest tests/test_get_positions_live_false.py tests/test_dual_wallet_positions.py -q

Closes SIM-2585