### PR TITLE
fix: add Polymarket news recency veto

### DIFF
--- a/simmer_sdk/guards/__init__.py
+++ b/simmer_sdk/guards/__init__.py
@@ -1,0 +1,2 @@
+"""Trading guard primitives."""
+

--- a/simmer_sdk/guards/news_recency_veto.py
+++ b/simmer_sdk/guards/news_recency_veto.py
@@ -13,7 +13,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 
 DEFAULT_LOOKBACK_S = 30
@@ -23,24 +23,45 @@ DEFAULT_SCHEDULE_PATHS = (
     Path.home() / "Documents" / "code" / "active" / "kozy" / "simmer-labs" / "shared-knowledge" / "data" / "macro-news-schedule.json",
 )
 
-NEWS_KEYWORDS = (
-    "cpi",
-    "consumer price index",
-    "inflation",
-    "fomc",
-    "fed decision",
-    "federal reserve",
-    "interest rate decision",
-    "unemployment",
-    "jobs report",
-    "nonfarm payroll",
-    "non-farm payroll",
-    "payrolls",
-    "bls",
-    "earnings",
-    "eps",
-    "revenue",
-)
+EVENT_CATEGORY_PATTERNS = {
+    "CPI": (
+        re.compile(r"\bcpi\b", re.I),
+        re.compile(r"\bconsumer\s+price\s+index\b", re.I),
+        re.compile(r"\binflation\b", re.I),
+    ),
+    "FOMC": (
+        re.compile(r"\bfomc\b", re.I),
+        re.compile(r"\bfed(?:eral\s+reserve)?\s+(?:decision|rates?|meeting)\b", re.I),
+        re.compile(r"\binterest\s+rate\s+decision\b", re.I),
+    ),
+    "BLS_JOBS": (
+        re.compile(r"\bbls\b", re.I),
+        re.compile(r"\bunemployment\b", re.I),
+        re.compile(r"\bjobs\s+report\b", re.I),
+        re.compile(r"\bnon-?farm\s+payrolls?\b", re.I),
+        re.compile(r"\bpayrolls\b", re.I),
+    ),
+    "EARNINGS": (
+        re.compile(r"\bearnings\b", re.I),
+        re.compile(r"\beps\b", re.I),
+        re.compile(r"\bquarterly\s+results\b", re.I),
+    ),
+}
+
+SCHEDULE_CATEGORY_ALIASES = {
+    "CPI": {"CPI", "CONSUMER_PRICE_INDEX", "INFLATION"},
+    "FOMC": {"FOMC", "FED", "FEDERAL_RESERVE", "INTEREST_RATE_DECISION"},
+    "BLS_JOBS": {
+        "BLS",
+        "BLS_UNEMPLOYMENT",
+        "BLS_UNEMPLOYMENT_NONFARM_PAYROLLS",
+        "JOBS_REPORT",
+        "NONFARM_PAYROLLS",
+        "NON_FARM_PAYROLLS",
+        "UNEMPLOYMENT",
+    },
+    "EARNINGS": {"EARNINGS", "QUARTERLY_EARNINGS", "EPS", "QUARTERLY_RESULTS"},
+}
 
 CONTINUOUS_FEED_PATTERNS = (
     re.compile(r"\b(btc|bitcoin|eth|ethereum|sol|solana|xrp)\s+up\s+or\s+down\b", re.I),
@@ -73,19 +94,10 @@ def load_macro_news_schedule(path: Optional[str] = None) -> Dict[str, Any]:
 def is_news_resolution_market(market_id: Any) -> bool:
     """Return True when a market descriptor looks tied to a scheduled news drop."""
 
-    text_parts: List[str] = []
-    if isinstance(market_id, dict):
-        for key in ("id", "market_id", "question", "title", "slug", "category", "description"):
-            value = market_id.get(key)
-            if value:
-                text_parts.append(str(value))
-    else:
-        text_parts.append(str(market_id or ""))
-
-    text = " ".join(text_parts).lower()
+    text = _market_text(market_id)
     if any(pattern.search(text) for pattern in CONTINUOUS_FEED_PATTERNS):
         return False
-    return any(keyword in text for keyword in NEWS_KEYWORDS)
+    return bool(_market_event_categories(market_id))
 
 
 def is_within_news_window(
@@ -111,8 +123,14 @@ def news_window_match(
     if lookback_s <= 0 or not is_news_resolution_market(market_id):
         return False, None
 
-    current = _coerce_aware_datetime(now) or datetime.now(timezone.utc)
+    market_categories = _market_event_categories(market_id)
+    if not market_categories:
+        return False, None
+
+    current = _coerce_aware_datetime(now, allow_naive=True) or datetime.now(timezone.utc)
     for event in _iter_events(schedule):
+        if not (market_categories & _event_categories(event)):
+            continue
         event_dt = _parse_event_time(event)
         if not event_dt:
             continue
@@ -145,11 +163,11 @@ def _parse_event_time(event: Dict[str, Any]) -> Optional[datetime]:
     for key in ("timestamp", "datetime", "time", "released_at", "release_time"):
         value = event.get(key)
         if value:
-            return _coerce_aware_datetime(value)
+            return _coerce_aware_datetime(value, allow_naive=False)
     return None
 
 
-def _coerce_aware_datetime(value: Any) -> Optional[datetime]:
+def _coerce_aware_datetime(value: Any, *, allow_naive: bool = True) -> Optional[datetime]:
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -161,6 +179,46 @@ def _coerce_aware_datetime(value: Any) -> Optional[datetime]:
             return None
 
     if dt.tzinfo is None:
+        if not allow_naive:
+            return None
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
 
+
+def _market_text(market_id: Any) -> str:
+    text_parts: List[str] = []
+    if isinstance(market_id, dict):
+        for key in ("id", "market_id", "question", "title", "slug", "category", "description"):
+            value = market_id.get(key)
+            if value:
+                text_parts.append(str(value))
+    else:
+        text_parts.append(str(market_id or ""))
+    return " ".join(text_parts)
+
+
+def _market_event_categories(market_id: Any) -> Set[str]:
+    text = _market_text(market_id)
+    if any(pattern.search(text) for pattern in CONTINUOUS_FEED_PATTERNS):
+        return set()
+    return {
+        category
+        for category, patterns in EVENT_CATEGORY_PATTERNS.items()
+        if any(pattern.search(text) for pattern in patterns)
+    }
+
+
+def _event_categories(event: Dict[str, Any]) -> Set[str]:
+    categories: Set[str] = set()
+    for key in ("category", "type", "name", "id"):
+        value = event.get(key)
+        if not value:
+            continue
+        normalized = re.sub(r"[^A-Za-z0-9]+", "_", str(value)).strip("_").upper()
+        for category, aliases in SCHEDULE_CATEGORY_ALIASES.items():
+            if normalized in aliases:
+                categories.add(category)
+        for category, patterns in EVENT_CATEGORY_PATTERNS.items():
+            if any(pattern.search(str(value)) for pattern in patterns):
+                categories.add(category)
+    return categories

--- a/simmer_sdk/guards/news_recency_veto.py
+++ b/simmer_sdk/guards/news_recency_veto.py
@@ -1,0 +1,166 @@
+"""News-recency veto for short-dated news-resolution markets.
+
+This guard is defensive: it blocks entries only when a market looks tied to a
+scheduled macro/news event and the current time is inside the post-release
+lookback window. Continuous-feed crypto Up/Down markets are intentionally not
+classified as news-resolution markets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+DEFAULT_LOOKBACK_S = 30
+DEFAULT_SCHEDULE_PATHS = (
+    Path.cwd() / "shared-knowledge" / "data" / "macro-news-schedule.json",
+    Path.cwd().parent / "simmer-labs" / "shared-knowledge" / "data" / "macro-news-schedule.json",
+    Path.home() / "Documents" / "code" / "active" / "kozy" / "simmer-labs" / "shared-knowledge" / "data" / "macro-news-schedule.json",
+)
+
+NEWS_KEYWORDS = (
+    "cpi",
+    "consumer price index",
+    "inflation",
+    "fomc",
+    "fed decision",
+    "federal reserve",
+    "interest rate decision",
+    "unemployment",
+    "jobs report",
+    "nonfarm payroll",
+    "non-farm payroll",
+    "payrolls",
+    "bls",
+    "earnings",
+    "eps",
+    "revenue",
+)
+
+CONTINUOUS_FEED_PATTERNS = (
+    re.compile(r"\b(btc|bitcoin|eth|ethereum|sol|solana|xrp)\s+up\s+or\s+down\b", re.I),
+    re.compile(r"\bup\s+or\s+down\s*-\s*\w{3}\s+\d{1,2},?\s+\d{1,2}:\d{2}", re.I),
+)
+
+
+def load_macro_news_schedule(path: Optional[str] = None) -> Dict[str, Any]:
+    """Load a macro-news schedule JSON.
+
+    Returns an empty schedule when no configured file exists so installed skills
+    can fail closed only on explicit schedule data, not on missing local files.
+    """
+
+    candidates: List[Path] = []
+    explicit_path = path or os.environ.get("SIMMER_NEWS_SCHEDULE_PATH")
+    if explicit_path:
+        candidates.append(Path(explicit_path).expanduser())
+    candidates.extend(DEFAULT_SCHEDULE_PATHS)
+
+    for candidate in candidates:
+        try:
+            if candidate.exists():
+                return json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"events": []}
+    return {"events": []}
+
+
+def is_news_resolution_market(market_id: Any) -> bool:
+    """Return True when a market descriptor looks tied to a scheduled news drop."""
+
+    text_parts: List[str] = []
+    if isinstance(market_id, dict):
+        for key in ("id", "market_id", "question", "title", "slug", "category", "description"):
+            value = market_id.get(key)
+            if value:
+                text_parts.append(str(value))
+    else:
+        text_parts.append(str(market_id or ""))
+
+    text = " ".join(text_parts).lower()
+    if any(pattern.search(text) for pattern in CONTINUOUS_FEED_PATTERNS):
+        return False
+    return any(keyword in text for keyword in NEWS_KEYWORDS)
+
+
+def is_within_news_window(
+    market_id: Any,
+    schedule: Any,
+    lookback_s: int = DEFAULT_LOOKBACK_S,
+    now: Optional[datetime] = None,
+) -> bool:
+    """Return True when a news-eligible market is inside a recent event window."""
+
+    in_window, _event = news_window_match(market_id, schedule, lookback_s=lookback_s, now=now)
+    return in_window
+
+
+def news_window_match(
+    market_id: Any,
+    schedule: Any,
+    lookback_s: int = DEFAULT_LOOKBACK_S,
+    now: Optional[datetime] = None,
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Return whether the veto fires and the matching schedule event."""
+
+    if lookback_s <= 0 or not is_news_resolution_market(market_id):
+        return False, None
+
+    current = _coerce_aware_datetime(now) or datetime.now(timezone.utc)
+    for event in _iter_events(schedule):
+        event_dt = _parse_event_time(event)
+        if not event_dt:
+            continue
+        age_s = (current - event_dt).total_seconds()
+        if 0 <= age_s <= lookback_s:
+            return True, event
+    return False, None
+
+
+def _iter_events(schedule: Any) -> Iterable[Dict[str, Any]]:
+    if isinstance(schedule, list):
+        for item in schedule:
+            yield _normalize_event(item)
+        return
+
+    if isinstance(schedule, dict):
+        events = schedule.get("events", [])
+        if isinstance(events, list):
+            for item in events:
+                yield _normalize_event(item)
+
+
+def _normalize_event(item: Any) -> Dict[str, Any]:
+    if isinstance(item, dict):
+        return item
+    return {"timestamp": item}
+
+
+def _parse_event_time(event: Dict[str, Any]) -> Optional[datetime]:
+    for key in ("timestamp", "datetime", "time", "released_at", "release_time"):
+        value = event.get(key)
+        if value:
+            return _coerce_aware_datetime(value)
+    return None
+
+
+def _coerce_aware_datetime(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -19,7 +19,7 @@ Trade Polymarket's 5-minute crypto fast markets using real-time price signals. D
 
 > ⚠️ **Risk monitoring does not apply to sub-15-minute markets.** Simmer's stop-loss and take-profit monitors check positions every 15 minutes — which means they will never fire on 5m or 15m markets before resolution. Any risk settings you configure in the Simmer dashboard have no effect on these positions. Size accordingly and do not rely on automated stop-losses for fast market trades.
 
-> **News-recency veto.** By default, the skill checks Simmer's macro-news schedule before order placement and skips news-resolution markets inside the first 30 seconds after CPI, BLS jobs/unemployment, FOMC, nonfarm payrolls, or quarterly earnings events. Continuous-feed crypto Up/Down markets are not blocked by this veto. Set `enable_news_veto=false` only if you intentionally want to manage this risk yourself.
+> **News-recency veto.** Optional guard that checks Simmer's macro-news schedule before order placement and skips matching news-resolution markets inside the first 30 seconds after CPI, BLS jobs/unemployment, FOMC, nonfarm payrolls, or quarterly earnings events. Continuous-feed crypto Up/Down markets are not blocked by this veto. Default is off until internal positive backfill coverage exists; set `enable_news_veto=true` to enable it.
 
 ## How It Finds Markets
 
@@ -142,7 +142,7 @@ python fastloop_trader.py --set min_momentum_pct=0.3 --set max_position=10
 | `asset` | BTC | `SIMMER_SPRINT_ASSET` | Asset to trade (BTC, ETH, SOL) |
 | `window` | 5m | `SIMMER_SPRINT_WINDOW` | Market window duration (5m or 15m) |
 | `volume_confidence` | true | `SIMMER_SPRINT_VOL_CONF` | Weight signal by Binance volume |
-| `enable_news_veto` | true | `SIMMER_FASTLOOP_ENABLE_NEWS_VETO` | Skip news-resolution markets within 30s of scheduled macro/news releases |
+| `enable_news_veto` | false | `SIMMER_FASTLOOP_ENABLE_NEWS_VETO` | Skip matching news-resolution markets within 30s of scheduled macro/news releases |
 
 ### Example config.json
 
@@ -154,7 +154,7 @@ python fastloop_trader.py --set min_momentum_pct=0.3 --set max_position=10
   "asset": "BTC",
   "window": "5m",
   "signal_source": "binance",
-  "enable_news_veto": true
+  "enable_news_veto": false
 }
 ```
 

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -19,6 +19,8 @@ Trade Polymarket's 5-minute crypto fast markets using real-time price signals. D
 
 > ⚠️ **Risk monitoring does not apply to sub-15-minute markets.** Simmer's stop-loss and take-profit monitors check positions every 15 minutes — which means they will never fire on 5m or 15m markets before resolution. Any risk settings you configure in the Simmer dashboard have no effect on these positions. Size accordingly and do not rely on automated stop-losses for fast market trades.
 
+> **News-recency veto.** By default, the skill checks Simmer's macro-news schedule before order placement and skips news-resolution markets inside the first 30 seconds after CPI, BLS jobs/unemployment, FOMC, nonfarm payrolls, or quarterly earnings events. Continuous-feed crypto Up/Down markets are not blocked by this veto. Set `enable_news_veto=false` only if you intentionally want to manage this risk yourself.
+
 ## How It Finds Markets
 
 - Queries **Polymarket directly** (Gamma API) for live fast markets — doesn't depend on Simmer's market inventory
@@ -140,6 +142,7 @@ python fastloop_trader.py --set min_momentum_pct=0.3 --set max_position=10
 | `asset` | BTC | `SIMMER_SPRINT_ASSET` | Asset to trade (BTC, ETH, SOL) |
 | `window` | 5m | `SIMMER_SPRINT_WINDOW` | Market window duration (5m or 15m) |
 | `volume_confidence` | true | `SIMMER_SPRINT_VOL_CONF` | Weight signal by Binance volume |
+| `enable_news_veto` | true | `SIMMER_FASTLOOP_ENABLE_NEWS_VETO` | Skip news-resolution markets within 30s of scheduled macro/news releases |
 
 ### Example config.json
 
@@ -150,7 +153,8 @@ python fastloop_trader.py --set min_momentum_pct=0.3 --set max_position=10
   "max_position": 10.0,
   "asset": "BTC",
   "window": "5m",
-  "signal_source": "binance"
+  "signal_source": "binance",
+  "enable_news_veto": true
 }
 ```
 

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -74,6 +74,8 @@ CONFIG_SCHEMA = {
                        "help": "Annualised volatility for N(d) fair-value model (default: 0.55 = 55%)"},
     "order_type": {"default": "GTC", "env": "SIMMER_FASTLOOP_ORDER_TYPE", "type": str,
                    "help": "Order type for Polymarket trades: GTC (default, waits for fill) or FAK (cancel if not filled immediately)"},
+    "enable_news_veto": {"default": True, "env": "SIMMER_FASTLOOP_ENABLE_NEWS_VETO", "type": bool,
+                         "help": "Block news-resolution trades within 30s after scheduled macro/news releases"},
 }
 
 TRADE_SOURCE = "sdk:fastloop"
@@ -103,6 +105,7 @@ ASSET_PATTERNS = {
 
 
 from simmer_sdk.skill import load_config, update_config, get_config_path
+from simmer_sdk.guards.news_recency_veto import load_macro_news_schedule, news_window_match
 
 # Load config
 cfg = load_config(CONFIG_SCHEMA, __file__, slug="polymarket-fast-loop")
@@ -135,6 +138,7 @@ USE_FAIR_VALUE = cfg["use_fair_value"]
 FAIR_VALUE_MIN_EDGE = cfg["fair_value_min_edge"]
 BTC_ANNUAL_VOL = cfg["btc_annual_vol"]
 ORDER_TYPE = cfg["order_type"].upper() if cfg["order_type"] else "GTC"
+ENABLE_NEWS_VETO = cfg["enable_news_veto"]
 SECONDS_PER_YEAR = 31_536_000
 
 # Polymarket crypto taker fee formula (docs.polymarket.com/trading/fees)
@@ -1191,6 +1195,22 @@ def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=Fal
             log(f"  ❌ Import failed: {import_error}", force=True)
             return
         log(f"  ✅ Market ID: {market_id[:16]}...", force=True)
+
+    if ENABLE_NEWS_VETO:
+        market_for_veto = {
+            "id": market_id,
+            "question": best.get("question"),
+            "slug": best.get("slug"),
+        }
+        vetoed, event = news_window_match(market_for_veto, load_macro_news_schedule())
+        if vetoed:
+            event_id = event.get("id") or event.get("name") or event.get("category") or "scheduled-news"
+            log(f"  ⏸️  News-recency veto: {event_id} fired within the last 30s — skip", force=True)
+            if not quiet:
+                print("📊 Summary: No trade (news-recency veto)")
+            skip_reasons.append("news-recency veto")
+            _emit_skip_report()
+            return
 
     execution_error = None
     tag = "SIMULATED" if dry_run else "LIVE"

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -74,7 +74,7 @@ CONFIG_SCHEMA = {
                        "help": "Annualised volatility for N(d) fair-value model (default: 0.55 = 55%)"},
     "order_type": {"default": "GTC", "env": "SIMMER_FASTLOOP_ORDER_TYPE", "type": str,
                    "help": "Order type for Polymarket trades: GTC (default, waits for fill) or FAK (cancel if not filled immediately)"},
-    "enable_news_veto": {"default": True, "env": "SIMMER_FASTLOOP_ENABLE_NEWS_VETO", "type": bool,
+    "enable_news_veto": {"default": False, "env": "SIMMER_FASTLOOP_ENABLE_NEWS_VETO", "type": bool,
                          "help": "Block news-resolution trades within 30s after scheduled macro/news releases"},
 }
 
@@ -675,7 +675,7 @@ def get_positions():
         return []
 
 
-def execute_trade(market_id, side, amount, signal_data=None):
+def execute_trade(market_id, side, amount, signal_data=None, market_context=None):
     """Execute a trade on Simmer."""
     try:
         client = get_client()
@@ -685,6 +685,17 @@ def execute_trade(market_id, side, amount, signal_data=None):
                 blockers = ", ".join(pf.blockers)
                 print(f"  ⛔ Preflight blocked: {blockers}")
                 return {"error": f"preflight_blocked: {blockers}"}
+        if ENABLE_NEWS_VETO:
+            vetoed, event = news_window_match(market_context or {"id": market_id}, load_macro_news_schedule())
+            if vetoed:
+                event_id = event.get("id") or event.get("name") or event.get("category") or "scheduled-news"
+                print(json.dumps({
+                    "event": "news_recency_veto",
+                    "market_id": market_id,
+                    "news_event_id": event_id,
+                    "skill": SKILL_SLUG,
+                }))
+                return {"error": "news_recency_veto", "event_id": event_id, "retryable": False}
         result = client.trade(
             market_id=market_id,
             side=side,
@@ -1224,7 +1235,13 @@ def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=Fal
     }
     if USE_FAIR_VALUE and 'fair_yes' in locals():
         _signal_data["fair_value"] = round(fair_yes, 4)
-    result = execute_trade(market_id, side, position_size, signal_data=_signal_data)
+    result = execute_trade(
+        market_id,
+        side,
+        position_size,
+        signal_data=_signal_data,
+        market_context=market_for_veto if ENABLE_NEWS_VETO else None,
+    )
 
     if result and result.get("success"):
         shares = result.get("shares_bought") or result.get("shares") or 0

--- a/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
+++ b/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
@@ -25,15 +25,22 @@ _mock_cfg = {
     "signal_source": "binance", "lookback_minutes": 5, "min_time_remaining": 0,
     "asset": "BTC", "window": "5m", "volume_confidence": True, "daily_budget": 10.0,
     "use_fair_value": False, "fair_value_min_edge": 0.05, "btc_annual_vol": 0.55,
-    "order_type": "GTC",
+    "order_type": "GTC", "enable_news_veto": True,
 }
 
 _skill_stub = types.ModuleType("simmer_sdk.skill")
 _skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
 _skill_stub.update_config = lambda updates, file, slug=None: None
 _skill_stub.get_config_path = lambda file: "/tmp/config.json"
+_guards_stub = types.ModuleType("simmer_sdk.guards.news_recency_veto")
+_guards_stub.load_macro_news_schedule = lambda path=None: {"events": []}
+_guards_stub.news_window_match = lambda market_id, schedule, lookback_s=30, now=None: (False, None)
 
-with patch.dict(sys.modules, {"simmer_sdk": MagicMock(), "simmer_sdk.skill": _skill_stub}):
+with patch.dict(sys.modules, {
+    "simmer_sdk": MagicMock(),
+    "simmer_sdk.skill": _skill_stub,
+    "simmer_sdk.guards.news_recency_veto": _guards_stub,
+}):
     import fastloop_trader as ft  # noqa: E402
 
 

--- a/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
+++ b/skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py
@@ -102,6 +102,26 @@ class TestPreflightGateFastLoop(unittest.TestCase):
         mock_client.trade.assert_called_once()
         self.assertTrue(result["success"])
 
+    def test_news_veto_blocks_order_after_preflight(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+
+        with patch.object(ft, "get_client", return_value=mock_client), \
+             patch.object(ft, "news_window_match", return_value=(True, {"id": "cpi-2026-06"})), \
+             patch("builtins.print") as mock_print:
+            result = ft.execute_trade(
+                "mkt_cpi",
+                "yes",
+                5.0,
+                market_context={"id": "mkt_cpi", "question": "Will CPI be above 3%?"},
+            )
+
+        self.assertEqual(result, {"error": "news_recency_veto", "event_id": "cpi-2026-06", "retryable": False})
+        mock_client.trade.assert_not_called()
+        self.assertIn('"event": "news_recency_veto"', mock_print.call_args[0][0])
+
     def test_preflight_called_with_cap_zero(self):
         mock_client = MagicMock()
         mock_client.live = True

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -18,7 +18,7 @@ Near-expiry conviction trading on Polymarket. The skill scans markets in their f
 
 > Strategy attribution: [@mert](https://x.com/mert/status/2020216613279060433) — see source thread for the original methodology (topic filter, near-expiry timing, strong-split entry).
 
-> **News-recency veto.** By default, the skill checks Simmer's macro-news schedule before order placement and skips news-resolution markets inside the first 30 seconds after CPI, BLS jobs/unemployment, FOMC, nonfarm payrolls, or quarterly earnings events. Continuous-feed crypto Up/Down markets are not blocked by this veto. Set `enable_news_veto=false` only if you intentionally want to manage this risk yourself.
+> **News-recency veto.** Optional guard that checks Simmer's macro-news schedule before order placement and skips matching news-resolution markets inside the first 30 seconds after CPI, BLS jobs/unemployment, FOMC, nonfarm payrolls, or quarterly earnings events. Continuous-feed crypto Up/Down markets are not blocked by this veto. Default is off until internal positive backfill coverage exists; set `enable_news_veto=true` to enable it.
 
 ## When to Use This Skill
 
@@ -65,7 +65,7 @@ Use this skill when the user wants to:
 | Smart sizing % | `SIMMER_MERT_SIZING_PCT` | 0.05 | % of balance per trade |
 | Fee buffer | `SIMMER_MERT_FEE_BUFFER` | 0.02 | Extra alpha required above entry fee; only applies when `SIMMER_MERT_MIN_EDGE` is set |
 | Declared edge | `SIMMER_MERT_MIN_EDGE` | 0.00 | Your signal's claimed edge above market price (probability units). At 0 (default): fee is logged but gate is advisory only. Set to X to block trades where entry fee > X — e.g. `0.05` requires your signal to clear at least 5¢ above market after fees |
-| News-recency veto | `SIMMER_MERT_ENABLE_NEWS_VETO` | true | Skip news-resolution markets within 30s of scheduled macro/news releases |
+| News-recency veto | `SIMMER_MERT_ENABLE_NEWS_VETO` | false | Skip matching news-resolution markets within 30s of scheduled macro/news releases |
 
 ## Quick Commands
 

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -18,6 +18,8 @@ Near-expiry conviction trading on Polymarket. The skill scans markets in their f
 
 > Strategy attribution: [@mert](https://x.com/mert/status/2020216613279060433) — see source thread for the original methodology (topic filter, near-expiry timing, strong-split entry).
 
+> **News-recency veto.** By default, the skill checks Simmer's macro-news schedule before order placement and skips news-resolution markets inside the first 30 seconds after CPI, BLS jobs/unemployment, FOMC, nonfarm payrolls, or quarterly earnings events. Continuous-feed crypto Up/Down markets are not blocked by this veto. Set `enable_news_veto=false` only if you intentionally want to manage this risk yourself.
+
 ## When to Use This Skill
 
 Use this skill when the user wants to:
@@ -63,6 +65,7 @@ Use this skill when the user wants to:
 | Smart sizing % | `SIMMER_MERT_SIZING_PCT` | 0.05 | % of balance per trade |
 | Fee buffer | `SIMMER_MERT_FEE_BUFFER` | 0.02 | Extra alpha required above entry fee; only applies when `SIMMER_MERT_MIN_EDGE` is set |
 | Declared edge | `SIMMER_MERT_MIN_EDGE` | 0.00 | Your signal's claimed edge above market price (probability units). At 0 (default): fee is logged but gate is advisory only. Set to X to block trades where entry fee > X — e.g. `0.05` requires your signal to clear at least 5¢ above market after fees |
+| News-recency veto | `SIMMER_MERT_ENABLE_NEWS_VETO` | true | Skip news-resolution markets within 30s of scheduled macro/news releases |
 
 ## Quick Commands
 

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -46,7 +46,7 @@ CONFIG_SCHEMA = {
     "order_type": {"env": "SIMMER_MERT_ORDER_TYPE", "default": "GTC", "type": str},
     "fee_buffer": {"env": "SIMMER_MERT_FEE_BUFFER", "default": 0.02, "type": float},
     "min_edge": {"env": "SIMMER_MERT_MIN_EDGE", "default": 0.0, "type": float},
-    "enable_news_veto": {"env": "SIMMER_MERT_ENABLE_NEWS_VETO", "default": True, "type": bool},
+    "enable_news_veto": {"env": "SIMMER_MERT_ENABLE_NEWS_VETO", "default": False, "type": bool},
 }
 
 _config = load_config(CONFIG_SCHEMA, __file__, slug="polymarket-mert-sniper")
@@ -172,7 +172,7 @@ def check_context_safeguards(context):
     return True, reasons
 
 
-def execute_trade(market_id, side, amount, reasoning=""):
+def execute_trade(market_id, side, amount, reasoning="", market_context=None):
     try:
         client = get_client()
         if client.live:
@@ -181,6 +181,17 @@ def execute_trade(market_id, side, amount, reasoning=""):
                 blockers = ", ".join(pf.blockers)
                 print(f"  ⛔ Preflight blocked: {blockers}")
                 return {"error": f"preflight_blocked: {blockers}"}
+        if ENABLE_NEWS_VETO:
+            vetoed, event = news_window_match(market_context or {"id": market_id}, load_macro_news_schedule())
+            if vetoed:
+                event_id = event.get("id") or event.get("name") or event.get("category") or "scheduled-news"
+                print(json.dumps({
+                    "event": "news_recency_veto",
+                    "market_id": market_id,
+                    "news_event_id": event_id,
+                    "skill": SKILL_SLUG,
+                }))
+                return {"error": "news_recency_veto", "event_id": event_id, "retryable": False}
         result = client.trade(
             market_id=market_id,
             side=side,
@@ -631,7 +642,13 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
 
         tag = "SIMULATED" if dry_run else "LIVE"
         print(f"     Executing trade ({tag})...")
-        result = execute_trade(market_id, side, position_size, reasoning=reasoning)
+        result = execute_trade(
+            market_id,
+            side,
+            position_size,
+            reasoning=reasoning,
+            market_context=market_for_veto if ENABLE_NEWS_VETO else None,
+        )
 
         if result.get("success"):
             trades_executed += 1

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -33,6 +33,7 @@ sys.stdout.reconfigure(line_buffering=True)
 # =============================================================================
 
 from simmer_sdk.skill import load_config, update_config, get_config_path
+from simmer_sdk.guards.news_recency_veto import load_macro_news_schedule, news_window_match
 
 # Configuration schema
 CONFIG_SCHEMA = {
@@ -45,6 +46,7 @@ CONFIG_SCHEMA = {
     "order_type": {"env": "SIMMER_MERT_ORDER_TYPE", "default": "GTC", "type": str},
     "fee_buffer": {"env": "SIMMER_MERT_FEE_BUFFER", "default": 0.02, "type": float},
     "min_edge": {"env": "SIMMER_MERT_MIN_EDGE", "default": 0.0, "type": float},
+    "enable_news_veto": {"env": "SIMMER_MERT_ENABLE_NEWS_VETO", "default": True, "type": bool},
 }
 
 _config = load_config(CONFIG_SCHEMA, __file__, slug="polymarket-mert-sniper")
@@ -69,6 +71,7 @@ MIN_SPLIT = _config["min_split"]
 MAX_TRADES_PER_RUN = _config["max_trades_per_run"]
 SMART_SIZING_PCT = _config["sizing_pct"]
 ORDER_TYPE = _config["order_type"]
+ENABLE_NEWS_VETO = _config["enable_news_veto"]
 
 # Safeguard thresholds
 SLIPPAGE_MAX_PCT = 0.15
@@ -598,6 +601,19 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
             if reasons:
                 print(f"     Warnings: {'; '.join(reasons)}")
 
+        if ENABLE_NEWS_VETO:
+            market_for_veto = {
+                "id": market_id,
+                "question": question,
+                "category": market.get("category") or market.get("tag"),
+            }
+            vetoed, event = news_window_match(market_for_veto, load_macro_news_schedule())
+            if vetoed:
+                event_id = event.get("id") or event.get("name") or event.get("category") or "scheduled-news"
+                print(f"     News-recency veto: {event_id} fired within the last 30s")
+                skip_reasons.append("news-recency veto")
+                continue
+
         # Rate limit
         if trades_executed >= MAX_TRADES_PER_RUN:
             print(f"     Max trades ({MAX_TRADES_PER_RUN}) reached - skipping")
@@ -680,7 +696,10 @@ if __name__ == "__main__":
                 if key in CONFIG_SCHEMA:
                     type_fn = CONFIG_SCHEMA[key].get("type", str)
                     try:
-                        value = type_fn(value)
+                        if type_fn == bool:
+                            value = value.lower() in ("true", "1", "yes")
+                        else:
+                            value = type_fn(value)
                     except (ValueError, TypeError):
                         pass
                 updates[key] = value
@@ -695,6 +714,7 @@ if __name__ == "__main__":
             globals()["MIN_SPLIT"] = _config["min_split"]
             globals()["MAX_TRADES_PER_RUN"] = _config["max_trades_per_run"]
             globals()["SMART_SIZING_PCT"] = _config["sizing_pct"]
+            globals()["ENABLE_NEWS_VETO"] = _config["enable_news_veto"]
 
     dry_run = not args.live
 

--- a/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
+++ b/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
@@ -22,14 +22,22 @@ _mock_cfg = {
     "market_filter": "", "max_bet_usd": 10.00, "expiry_window_mins": 8,
     "min_split": 0.60, "max_trades_per_run": 5, "sizing_pct": 0.05,
     "order_type": "GTC", "fee_buffer": 0.02, "min_edge": 0.0,
+    "enable_news_veto": True,
 }
 
 _skill_stub = types.ModuleType("simmer_sdk.skill")
 _skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
 _skill_stub.update_config = lambda updates, file, slug=None: None
 _skill_stub.get_config_path = lambda file: "/tmp/config.json"
+_guards_stub = types.ModuleType("simmer_sdk.guards.news_recency_veto")
+_guards_stub.load_macro_news_schedule = lambda path=None: {"events": []}
+_guards_stub.news_window_match = lambda market_id, schedule, lookback_s=30, now=None: (False, None)
 
-with patch.dict(sys.modules, {"simmer_sdk": MagicMock(), "simmer_sdk.skill": _skill_stub}):
+with patch.dict(sys.modules, {
+    "simmer_sdk": MagicMock(),
+    "simmer_sdk.skill": _skill_stub,
+    "simmer_sdk.guards.news_recency_veto": _guards_stub,
+}):
     import mert_sniper as ms  # noqa: E402
 
 

--- a/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
+++ b/skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py
@@ -99,6 +99,26 @@ class TestPreflightGateMertSniper(unittest.TestCase):
         mock_client.trade.assert_called_once()
         self.assertTrue(result["success"])
 
+    def test_news_veto_blocks_order_after_preflight(self):
+        mock_client = MagicMock()
+        mock_client.live = True
+        mock_client.venue = "polymarket"
+        mock_client.preflight.return_value = _make_preflight(ok=True)
+
+        with patch.object(ms, "get_client", return_value=mock_client), \
+             patch.object(ms, "news_window_match", return_value=(True, {"id": "cpi-2026-06"})), \
+             patch("builtins.print") as mock_print:
+            result = ms.execute_trade(
+                "mkt_cpi",
+                "yes",
+                5.0,
+                market_context={"id": "mkt_cpi", "question": "Will CPI be above 3%?"},
+            )
+
+        self.assertEqual(result, {"error": "news_recency_veto", "event_id": "cpi-2026-06", "retryable": False})
+        mock_client.trade.assert_not_called()
+        self.assertIn('"event": "news_recency_veto"', mock_print.call_args[0][0])
+
     def test_preflight_called_with_cap_zero(self):
         mock_client = MagicMock()
         mock_client.live = True

--- a/tests/test_news_recency_veto.py
+++ b/tests/test_news_recency_veto.py
@@ -9,6 +9,11 @@ SCHEDULE = {
             "id": "cpi-2026-06",
             "category": "CPI",
             "timestamp": "2026-06-10T12:30:00Z",
+        },
+        {
+            "id": "earnings-2026-q2",
+            "category": "QUARTERLY_EARNINGS",
+            "timestamp": "2026-06-10T12:30:00Z",
         }
     ]
 }
@@ -37,3 +42,44 @@ def test_continuous_feed_crypto_updown_does_not_veto_inside_window():
 
     assert is_within_news_window(market, SCHEDULE, now=now) is False
 
+
+def test_cpi_event_does_not_veto_earnings_market():
+    market = {"id": "m3", "question": "Will ACME report positive earnings in Q2?"}
+    cpi_only_schedule = {"events": [SCHEDULE["events"][0]]}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    assert is_within_news_window(market, cpi_only_schedule, now=now) is False
+
+
+def test_earnings_event_vetoes_earnings_market():
+    market = {"id": "m4", "question": "Will ACME report positive EPS in Q2?"}
+    earnings_only_schedule = {"events": [SCHEDULE["events"][1]]}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    blocked, event = news_window_match(market, earnings_only_schedule, now=now)
+
+    assert blocked is True
+    assert event["id"] == "earnings-2026-q2"
+
+
+def test_keyword_matching_uses_boundaries():
+    market = {"id": "m5", "question": "Will Epstein files be released by Bigtumbls?"}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    assert is_within_news_window(market, SCHEDULE, now=now) is False
+
+
+def test_revenue_alone_does_not_classify_as_earnings_event():
+    market = {"id": "m5b", "question": "Will annual revenue exceed $1B?"}
+    earnings_only_schedule = {"events": [SCHEDULE["events"][1]]}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    assert is_within_news_window(market, earnings_only_schedule, now=now) is False
+
+
+def test_schedule_datetimes_must_include_timezone():
+    market = {"id": "m6", "question": "Will CPI inflation be above 3.0% in June?"}
+    schedule = {"events": [{"id": "cpi-naive", "category": "CPI", "timestamp": "2026-06-10T12:30:00"}]}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    assert is_within_news_window(market, schedule, now=now) is False

--- a/tests/test_news_recency_veto.py
+++ b/tests/test_news_recency_veto.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+from simmer_sdk.guards.news_recency_veto import is_within_news_window, news_window_match
+
+
+SCHEDULE = {
+    "events": [
+        {
+            "id": "cpi-2026-06",
+            "category": "CPI",
+            "timestamp": "2026-06-10T12:30:00Z",
+        }
+    ]
+}
+
+
+def test_cpi_market_vetoes_inside_30s_window():
+    market = {"id": "m1", "question": "Will CPI inflation be above 3.0% in June?"}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    blocked, event = news_window_match(market, SCHEDULE, now=now)
+
+    assert blocked is True
+    assert event["id"] == "cpi-2026-06"
+
+
+def test_cpi_market_does_not_veto_after_30s_window():
+    market = {"id": "m1", "question": "Will CPI inflation be above 3.0% in June?"}
+    now = datetime(2026, 6, 10, 12, 30, 35, tzinfo=timezone.utc)
+
+    assert is_within_news_window(market, SCHEDULE, now=now) is False
+
+
+def test_continuous_feed_crypto_updown_does_not_veto_inside_window():
+    market = {"id": "m2", "question": "BTC Up or Down - Jun 10, 12:30PM-12:45PM ET"}
+    now = datetime(2026, 6, 10, 12, 30, 5, tzinfo=timezone.utc)
+
+    assert is_within_news_window(market, SCHEDULE, now=now) is False
+


### PR DESCRIPTION
## Summary\n- add simmer_sdk.guards.news_recency_veto with schedule loading, market classification, and 30s post-news veto predicate\n- wire enable_news_veto=true into polymarket-fast-loop and polymarket-mert-sniper before order placement\n- add focused unit coverage for CPI +5s veto, +35s pass, and continuous-feed BTC Up/Down pass\n\n## Verification\n- python3 -m pytest tests/test_news_recency_veto.py skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py -q\n- python3 -m pytest mcp/bundled-skills/polymarket-fast-loop/tests/test_fastloop_preflight_gate.py mcp/bundled-skills/polymarket-mert-sniper/tests/test_mertsniper_preflight_gate.py -q\n- python3 -m py_compile simmer_sdk/guards/news_recency_veto.py skills/polymarket-fast-loop/fastloop_trader.py skills/polymarket-mert-sniper/mert_sniper.py mcp/bundled-skills/polymarket-fast-loop/fastloop_trader.py mcp/bundled-skills/polymarket-mert-sniper/mert_sniper.py\n\nCompanion shared-knowledge PR: https://github.com/SpartanLabsXyz/simmer-labs/pull/78\n\nCloses SIM-2617