### PR TITLE
docs(sdk): fix register_agent_wallet docstring per-agent activation sequence

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -5162,8 +5162,10 @@ class SimmerClient:
         """Register an OWS wallet for this agent. Elite-only (beta).
 
         Creates a per-agent wallet record on the server. After registration,
-        set on-chain approvals via set_approvals(), then call
-        update_agent_wallet_creds() to cache CLOB credentials server-side.
+        set on-chain approvals via activate_polymarket_dw(agent_id=...), then
+        call update_agent_wallet_creds(ows_wallet_name=...) to cache CLOB
+        credentials server-side. Both are required before trading. (set_approvals()
+        is the user-primary EOA path and is a no-op for per-agent deposit wallets.)
 
         Args:
             ows_wallet_name: Name of the OWS wallet (e.g. "agent-mybot")


### PR DESCRIPTION
## What
`register_agent_wallet` docstring told users to "set on-chain approvals via `set_approvals()`, then `update_agent_wallet_creds()`". For per-agent OWS/deposit wallets that's wrong — `set_approvals()` is the user-primary EOA path and a no-op for deposit-wallet users (SIM-1613).

## Change
Docstring now prescribes the verified per-agent sequence: `activate_polymarket_dw(agent_id=...)` (on-chain approvals) → `update_agent_wallet_creds(ows_wallet_name=...)` (CLOB creds), both required.

Docstring-only. Part of the SIM-2688 guidance sweep (backend correctness fix + dashboard + ClawHub skill.md land in the simmer repo).

Refs SIM-2688

🤖 Generated with [Claude Code](https://claude.com/claude-code)