### PR TITLE
fix(skill): correct per-agent OWS activation in simmer-wallet-setup

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -5162,8 +5162,10 @@ class SimmerClient:
         """Register an OWS wallet for this agent. Elite-only (beta).
 
         Creates a per-agent wallet record on the server. After registration,
-        set on-chain approvals via set_approvals(), then call
-        update_agent_wallet_creds() to cache CLOB credentials server-side.
+        set on-chain approvals via activate_polymarket_dw(agent_id=...), then
+        call update_agent_wallet_creds(ows_wallet_name=...) to cache CLOB
+        credentials server-side. Both are required before trading. (set_approvals()
+        is the user-primary EOA path and is a no-op for per-agent deposit wallets.)
 
         Args:
             ows_wallet_name: Name of the OWS wallet (e.g. "agent-mybot")

--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-wallet-setup
-version: "0.3.1"
+version: "0.3.2"
 published: true
 description: Self-custody wallet setup for Simmer agents. Choose OWS (recommended), external raw key, or connect an existing dashboard-registered agent to your local runtime. Skip this skill if you use a managed wallet — managed setup is a one-time dashboard flow, not an agent task.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.3.1"
+  version: "0.3.2"
   displayName: Simmer Wallet Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -63,11 +63,12 @@ client = SimmerClient(
     ows_wallet="my-agent-wallet",   # name from `ows wallet create`
 )
 
-client.register_agent_wallet()  # one-time, Elite-tier gated, fully headless
-client.set_approvals()          # one-time per chain — signs locally via OWS, fully headless
+wallet = client.register_agent_wallet()  # one-time, Elite-tier gated, fully headless
+client.activate_polymarket_dw(agent_id=wallet["agent_id"])   # sets on-chain CLOB approvals on the agent's deposit wallet — signs via OWS, gasless relay, headless
+client.update_agent_wallet_creds(ows_wallet_name="my-agent-wallet")  # caches CLOB API creds server-side
 ```
 
-> Both calls are fully headless — they authenticate with your SDK API key, no dashboard session or browser required. `register_agent_wallet()` requires Elite tier. After both run once, all trading is API-only.
+> All three calls are fully headless — they authenticate with your SDK API key, no dashboard session or browser required. `register_agent_wallet()` requires Elite tier. `activate_polymarket_dw(agent_id=...)` sets the deposit-wallet approvals; `update_agent_wallet_creds()` then caches CLOB creds. Both are required before trading — caching creds alone does not set on-chain allowances. (Don't use `set_approvals()` here — that's the user-primary EOA path and a no-op for per-agent deposit wallets.) After all three run once, all trading is API-only.
 >
 > Elite users can alternatively register a per-agent wallet through the dashboard's agent-creation wizard (My Agents → Create agent → optional "Link dedicated wallet" step) or retrofit an existing agent via its Wallet tab. The SDK path and the dashboard path produce the same `user_agent_wallets` row — pick whichever fits your workflow.
 
@@ -182,7 +183,7 @@ You already created an agent in the dashboard and have its API key. Now wire it 
 
 1. **Install packages**
    ```bash
-   pip install simmer-sdk[ows] open-wallet-standard
+   pip install 'simmer-sdk[ows]'
    ```
 
 2. **Import wallet key into OWS**
@@ -198,13 +199,14 @@ You already created an agent in the dashboard and have its API key. Now wire it 
    export OWS_WALLET=<name>
    ```
 
-4. **Cache CLOB credentials (one-time)**
+4. **Activate trading: on-chain approvals + CLOB credentials (one-time)**
    ```bash
    python -c "from simmer_sdk import SimmerClient; \
      c = SimmerClient.from_env(venue='polymarket'); \
+     c.activate_polymarket_dw(agent_id='<agent_id>'); \
      c.update_agent_wallet_creds(ows_wallet_name='<name>')"
    ```
-   This signs an EIP-712 message via OWS, derives CLOB creds, persists server-side. Required before any Polymarket trades.
+   First sets the deposit wallet's on-chain CLOB approvals (OWS-signed EIP-712 batch, relayed gasless), then derives + caches CLOB creds server-side. **Both** are required before any Polymarket trades — approvals alone or creds alone is not enough. Get `<agent_id>` from `client.get_agent_wallets()`.
 
 5. **Verify**
    ```bash
@@ -215,7 +217,7 @@ You already created an agent in the dashboard and have its API key. Now wire it 
 
 ### Anti-patterns
 - Don't paste your private key from clipboard into a pipe — use `read -s` (per SIM-2118).
-- Don't use `client.activate_polymarket_dw()` — that's user-primary only. Use `update_agent_wallet_creds(ows_wallet_name)` for per-agent.
+- Don't skip `activate_polymarket_dw(agent_id=...)` — `update_agent_wallet_creds` alone caches creds without setting on-chain approvals, so trades fail at the relayer. Run both, approvals first.
 
 ## Risk monitor
 
@@ -224,7 +226,7 @@ The auto risk monitor (stop-loss, take-profit) is configured at simmer.markets/d
 ## Troubleshooting
 
 - **"External wallet requires a pre-signed order"** → key not configured. For OWS: `ows wallet list` to verify the wallet exists. For external: confirm `WALLET_PRIVATE_KEY` is set.
-- **"insufficient allowance"** → run `client.set_approvals()` once per wallet.
+- **"insufficient allowance"** → set approvals once per wallet: `client.activate_polymarket_dw(agent_id=...)` for a per-agent OWS/deposit-wallet, or `client.set_approvals()` for a raw-key/user-primary EOA wallet.
 - **Balance shows $0 but funds visible elsewhere** → check chain (Polygon vs Solana) and token (pUSD vs USDC.e). See dashboard migration tool for V2 conversion.
 - **API key format wrong / 401 with a key that "looks set"** → inspect the raw value: `printenv SIMMER_API_KEY | cut -c1-20`. Must start with `sk_live_`. A common silent failure: install commands that use `pbpaste` or similar clipboard-read primitives write the *install command text itself* as the key value when the user copies the command after copying the key. Fix: get a fresh key from simmer.markets/dashboard, then `export SIMMER_API_KEY="sk_live_..."` (type/paste the key directly, never pipe from clipboard into the variable assignment).
 


### PR DESCRIPTION
## What
`simmer-wallet-setup` is the deep ClawHub walkthrough a fresh OWS user follows. It carried the same backwards per-agent guidance as the overview skill (fixed in simmer#1106):
- **Path A** (recommended): `register_agent_wallet()` → `set_approvals()` — but `set_approvals()` is a no-op for per-agent deposit wallets (SIM-1613).
- **Connect-existing**: cached creds with no approvals step.
- **Anti-pattern**: `Don't use client.activate_polymarket_dw() — user-primary only` (false since the agent_id variant shipped, SDK #127).

## Fix
Corrected to the verified sequence: `register_agent_wallet()` → `activate_polymarket_dw(agent_id=...)` (on-chain DW approvals) → `update_agent_wallet_creds(ows_wallet_name=...)` (CLOB creds), both required. Plus canonical `pip install 'simmer-sdk[ows]'` and a per-agent-aware insufficient-allowance fix. Left the raw-key / user-primary refs (Path B, lines ~129-141) untouched — `set_approvals()`/`activate_polymarket_dw()` are correct there. Version 0.3.1 → 0.3.2.

## Verification / caveat
Verified against herman-v3 (approvals_set + 22 PM trades) + the SDK CHANGELOG. One evidenced assumption: `register_agent_wallet()` triggers the DW deploy (johng's agent deployed 12s after register). Worth one live `activate_polymarket_dw(agent_id=)` run before the next ClawHub publish.

## Publish note
`published: true` — this is a ClawHub skill. Merge does **not** auto-publish; needs a manual `npx clawhub skill publish` (approval-gated).

Refs SIM-2688

🤖 Generated with [Claude Code](https://claude.com/claude-code)