### PR TITLE
skill(simmer): consolidate overview to single canonical source (Refs SIM-2695)

### DIFF
--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.1"
+  version: "1.24.2"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -92,6 +92,7 @@ Documentation references — open when the situation matches.
 | When | Where |
 |---|---|
 | Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers OWS (recommended), external raw key, and managed paths |
+| Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. |
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |


### PR DESCRIPTION
## What

Makes `simmer-sdk/skills/simmer/SKILL.md` the **single canonical source** for the `simmer` overview skill, and reconciles the drifted website copy into it. Bumps `1.24.1 → 1.24.2`.

Part 1 of 2 for SIM-2695 (source-of-truth cleanup). The companion simmer PR adds the prebuild sync + CI drift check so `website/public/skill.md` is generated from this file.

## Why

The overview skill existed in two hand-maintained, drifted copies with no sync:
- `simmer-sdk/skills/simmer/SKILL.md` (canonical, ClawHub publish home) — v1.24.1, 149 lines
- `simmer/website/public/skill.md` (served at simmer.markets/skill.md) — v1.24.0, 200 lines, drift source

## Changes (this PR)

Reconciled the two against the locked decision "overview stays lean, match the SDK canonical":
- **FOLD** → added the `simmer-mcp-setup` row to the "Where to learn more" table. It's the one genuinely-needed web-only addition — `simmer-mcp-setup` is a real published skill (lives in `skills/`), parallel to the existing `simmer-wallet-setup` row.
- **DROP** (intentionally not carried into the lean overview):
  - The per-agent OWS activation block — now lives only in `simmer-wallet-setup` (corrected in #164).
  - The web copy's "Connect existing agent" section — also covered in `simmer-wallet-setup`.
  - Cosmetic "Start here." description suffix and the `find_markets` example variant (both `get_markets` and `find_markets` exist in the SDK; canonical keeps `get_markets`).

## Follow-up (companion simmer PR)

`website/public/skill.md` becomes generated: a prebuild script fetches this file's raw bytes from `simmer-sdk` main, writes it with a provenance header, and a CI drift check fails if the committed copy diverges from the freshly-fetched canonical.

## Note for reviewer

Both `skill.md` surfaces are public (ClawHub + simmer.markets). **Awaiting Adrian's approval before merge.** ClawHub re-publish is a separate manual `npx clawhub skill publish` step (not done here).

Refs SIM-2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)