### PR TITLE
fix(sdk): truthful venue logging — TRADING_VENUE no longer falsely implied (SIM-2932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-## [0.17.26] - 2026-06-05
+## [0.17.27] - 2026-06-06
+
+### Fixed
+
+- **Truthful venue logging — `TRADING_VENUE` no longer falsely implied (SIM-2932).** The client init logged *"TRADING_VENUE not set, using venue='…'. Set TRADING_VENUE=sim for paper trading"*, which implied the `TRADING_VENUE` env var controlled the trading venue. It never did — `venue` is set only by the `venue=` argument (or `from_env(venue=…)`) and defaults to `"sim"`. The misleading log led an operator to believe live trades were active while orders were going to the simulated `$SIM` venue. The env-var read is removed; the client now logs the active mode truthfully — a clear PAPER warning on `venue='sim'` (with the exact way to go live) and a LIVE warning on real-funds venues. **No behavior change:** `sim` remains the default; live trading still requires explicit `venue="polymarket"`.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.26"
+version = "0.17.27"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -294,12 +294,19 @@ class SimmerClient:
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
         self.venue = venue
-        if not os.environ.get("TRADING_VENUE"):
-            logger.info(
-                "TRADING_VENUE not set, using venue='%s'. "
-                "Set TRADING_VENUE=sim for paper trading with $SIM.",
-                venue
+        # venue is set explicitly via the `venue=` arg (or from_env(venue=...))
+        # and defaults to "sim" (paper). NOTE: the TRADING_VENUE env var is
+        # intentionally NOT read here — do not reintroduce a log that implies
+        # an env var controls the venue. Surface the active mode truthfully so
+        # callers never mistake paper ($SIM) trades for live ones, or vice versa.
+        if venue == "sim":
+            logger.warning(
+                "venue='sim' — PAPER trading with virtual $SIM (no real money). "
+                "For LIVE trading pass venue='polymarket' per trade, or "
+                "SimmerClient.from_env(venue='polymarket')."
             )
+        else:
+            logger.warning("venue='%s' — LIVE trading with real funds.", venue)
         self._private_key: Optional[str] = None  # EVM private key (Polymarket)
         self._wallet_address: Optional[str] = None  # EVM wallet address
         self._wallet_linked: Optional[bool] = None  # Cached linking status


### PR DESCRIPTION
## Problem

Client init logged:
> `TRADING_VENUE not set, using venue='…'. Set TRADING_VENUE=sim for paper trading with $SIM.`

This implied the `TRADING_VENUE` env var controlled the trading venue. **It never did** — `venue` is set only by the `venue=` argument (or `from_env(venue=…)`) and defaults to `"sim"`. The advice was also backwards (sim is already the default; the var does nothing).

An operator (johng) set `TRADING_VENUE=polymarket`, saw the log, believed live trading was active, and paused a working scanner when his **simulated `$SIM` test trades** didn't appear in live history. Second venue-confusion incident from the same root cause.

## Fix (Option B — truth-in-logging, no behavior change)

- Remove the `TRADING_VENUE` env-var read entirely (it was never wired to `self.venue`).
- Log the active mode truthfully:
  - `venue='sim'` → **PAPER** warning incl. the exact way to go live (`venue="polymarket"` / `from_env(venue="polymarket")`).
  - live venue → **LIVE / real funds** warning.

**No behavior change:** `sim` remains the default; live trading still requires explicit `venue="polymarket"`. Keeping the explicit opt-in to real money is deliberate — wiring an env var to flip *all* trades live would be a worse (real-money) footgun.

## Tests

- `tests/test_client_constructors.py`: 6 pass (incl. venue paths). 4 failures are **pre-existing on `main`** (OWS `my-agent` wallet / `[ows]` env not present on this machine) — unrelated to this change; verified by running the same suite on clean `main`.

Bumps `0.17.26` → `0.17.27`. Publishing to PyPI after merge.

Refs SIM-2932

🤖 Generated with [Claude Code](https://claude.com/claude-code)