### PR TITLE
fix(copytrading): ignore foreign signal types on shared reactor feed

### DIFF
--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.11.1"
+  version: "1.11.2"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---

--- a/skills/polymarket-copytrading/copytrading_trader.py
+++ b/skills/polymarket-copytrading/copytrading_trader.py
@@ -859,6 +859,15 @@ def _poll_reactor_once(client) -> int:
         return 0
 
     signals = resp.get("reactor_signals", []) if isinstance(resp, dict) else []
+    # The Pro reactor feed is shared across strategies. Ignore signals tagged for
+    # another strategy (e.g. "shock_ladder") — copytrading only mirrors whale
+    # signals (type absent or "copytrade"). Without this, a foreign signal looks
+    # malformed here, posts a "failed" reaction, and can trip the circuit breaker.
+    # We do NOT delete foreign signals; their owning skill consumes them (or they TTL).
+    _foreign = [s for s in signals if s.get("type") not in (None, "copytrade")]
+    if _foreign:
+        print(f"[reactor] ignoring {len(_foreign)} non-copytrade signal(s) on the shared feed")
+    signals = [s for s in signals if s.get("type") in (None, "copytrade")]
     if not signals:
         print("[reactor] 0 pending signals")
         return 0


### PR DESCRIPTION
## What
The Pro reactor feed (`/api/sdk/reactor/pending`) is **shared across strategies**. Copytrading currently processes *every* `reactor_signals` entry. WC Shock Ladder chunk 3.3 (simmer) starts emitting `type:"shock_ladder"` signals onto this same feed — and copytrading would treat them as malformed (no `tx_hash`/`amount`), post a `failed` reaction each poll, and eventually **trip its circuit breaker** for any user running both skills.

## Fix
One filter in the reactor poll: copytrading now processes only `type in (None, "copytrade")` and ignores the rest. Foreign signals are **left untouched** (the owning skill consumes + deletes them, or they TTL out) — copytrading neither processes nor deletes them.

This is the copytrading half of the D2 signal-type discriminator (the shock-ladder skill already filters to `type=="shock_ladder"`).

## Impact / safety
- No behavior change for copytrade signals (which have no `type` today → caught by the `None` branch).
- No collision exists yet in production (only Herman will be armed for shock-ladder, and he doesn't run copytrading) — this ships the guard *before* anyone runs both, per "the whole fix."
- Patch bump 1.11.1 → 1.11.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)