### PR TITLE
docs: sync skill builder ClawHub release version

### DIFF
--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-skill-builder
 description: Generate complete, installable OpenClaw trading skills from natural language strategy descriptions. Use when your human wants to create a new trading strategy, build a bot, generate a skill, automate a trade idea, turn a tweet into a strategy, or asks "build me a skill that...". Produces a full skill folder (SKILL.md + Python script + config) ready to install and run.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.2.5"
+  version: "1.3.2"
   displayName: Simmer Skill Builder
   difficulty: beginner
 ---


### PR DESCRIPTION
Closes SIM-2940

Syncs `simmer-skill-builder` source metadata with the ClawHub release used for the World Cup campaign funnel.

Why this branch exists:
- The requested `1.2.5` version was published, but ClawHub already had a higher `1.3.0`, so unpinned installs still resolved away from the WC content.
- Published `1.3.2` under the `simmer` owner with the correct display name so `clawhub install simmer-skill-builder` receives the WC fast path and worked example.
- This PR updates repo metadata from `1.2.5` to `1.3.2` so source and registry stay aligned.

Verification:
- `npx --yes clawhub@latest inspect simmer-skill-builder --versions --limit 4` shows latest `1.3.2`, owner `simmer`, display name `Simmer Skill Builder`, moderation `CLEAN`.
- Clean default install into an isolated workdir returns `metadata.version: "1.3.2"` and includes the World Cup campaign content.
- `git diff --check` passed.