### PR TITLE
feat(client): expose q keyword search on get_markets (+ skill-builder validator path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.17.28] - 2026-06-08
+
+### Added
+
+- **`get_markets(q=...)` keyword search.** `client.get_markets()` now accepts a `q` keyword-search argument that filters by market question (min 2 chars, case-insensitive), matching the documented `get_markets(q="bitcoin", limit=5)` example in the quickstart and trading guide. The backend `/api/sdk/markets` endpoint already supported `q`; the SDK method simply never exposed it, so callers were forced to fetch all active markets and filter client-side. Surfaced during World Cup skill dogfooding.
+
 ## [0.17.27] - 2026-06-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.27"
+version = "0.17.28"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1415,6 +1415,7 @@ class SimmerClient:
         import_source: Optional[str] = None,
         limit: int = 50,
         include: Optional[str] = None,
+        q: Optional[str] = None,
     ) -> List[Market]:
         """
         Get available markets.
@@ -1424,15 +1425,21 @@ class SimmerClient:
             import_source: Filter by source ('polymarket', 'kalshi', or None for all)
             limit: Maximum number of markets to return
             include: Opt-in extra fields, e.g. "resolution_criteria"
+            q: Keyword search on market question (min 2 chars, case-insensitive)
 
         Returns:
             List of Market objects
+
+        Example:
+            markets = client.get_markets(q="bitcoin", limit=5)
         """
         params = {"status": status, "limit": limit}
         if import_source:
             params["import_source"] = import_source
         if include:
             params["include"] = include
+        if q:
+            params["q"] = q
 
         data = self._request("GET", "/api/sdk/markets", params=params)
 

--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -244,11 +244,14 @@ Customize:
 
 ### Step 5: Validate
 
-Run the validator against the generated skill:
+Run the validator against the generated skill. The validator ships **inside this skill** at `scripts/validate_skill.py`, co-located with this `SKILL.md` — when the skill is installed (e.g. `npx simmer-mcp install-skill`) it lands in your runtime's skill directory alongside the instructions. Resolve the path relative to this file:
 
 ```bash
-python /path/to/simmer-skill-builder/scripts/validate_skill.py /path/to/generated-skill/
+# from the simmer-skill-builder skill directory:
+python scripts/validate_skill.py /path/to/generated-skill/
 ```
+
+If you're unsure where the skill installed, locate it with `find ~ -name validate_skill.py -path '*simmer-skill-builder*' 2>/dev/null`.
 
 Fix any FAIL results before delivering to your human.
 


### PR DESCRIPTION
## What

`client.get_markets()` now accepts a **`q`** keyword-search argument (min 2 chars, case-insensitive), matching the documented `get_markets(q="bitcoin", limit=5)` example in the quickstart, trading guide, and SDK overview.

## Why

The backend `/api/sdk/markets` endpoint **already supports `q`** (plus `venue`/`ids`/`tags`/`sort`) — the SDK method just never exposed it. So agents following the docs hit `TypeError: get_markets() got an unexpected keyword argument 'q'` and had to fetch all active markets and filter client-side. Surfaced by Nick during World Cup skill dogfooding.

Scoped to `q` only — `import_source` already covers venue filtering in the SDK, and `ids`/`tags`/`sort` are YAGNI for now.

## Also

- Documents that `scripts/validate_skill.py` ships **co-located** with the skill-builder `SKILL.md` (it exists and bundles via `prepack`; it was just under-documented where it lands post-install).

## Test

`inspect.signature` smoke test confirms `q` is present; behavior is a passthrough to the existing backend param.

Bumps `0.17.27 → 0.17.28`. Publish to PyPI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)