### PR TITLE
fix(mcp): Tier-A skills return SKILL.md instructions instead of erroring

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/mcp/src/per-skill-tools.ts
+++ b/mcp/src/per-skill-tools.ts
@@ -5,6 +5,7 @@
 
 import { z, ZodType } from "zod";
 import * as path from "node:path";
+import * as fs from "node:fs/promises";
 import type { Skill, Tunable } from "./core/types.js";
 import { filterBlockedFlags } from "./blocked-flags.js";
 import { buildEnv, envToArgName } from "./env-translation.js";
@@ -94,10 +95,38 @@ export async function invokeSkillTool(
   options: InvokeSkillOptions = {}
 ): Promise<InvokeSkillResponse> {
   if (!skill.entrypoint) {
-    return {
-      content: [{ type: "text", text: `Skill ${skill.slug} has no entrypoint (Tier A, instruction-only).` }],
-      isError: true,
-    };
+    // Tier-A skills are instruction-only — they have no runnable entrypoint.
+    // Rather than dead-ending an agent that reasonably tried to "call" the
+    // skill with an opaque error, return the SKILL.md playbook so the agent
+    // can read and follow it directly. This matches how the docs treat these
+    // skills: conversational, not executable.
+    const skillMdPath = path.join(skill.skillDir, "SKILL.md");
+    try {
+      const instructions = await fs.readFile(skillMdPath, "utf8");
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `${skill.slug} is an instruction-only skill (Tier A) — there is nothing to execute. ` +
+              `Read and follow these instructions directly:\n\n${instructions}`,
+          },
+        ],
+        isError: false,
+      };
+    } catch {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `${skill.slug} is an instruction-only skill (Tier A) with no runnable entrypoint. ` +
+              `Its instructions live in SKILL.md at ${skillMdPath} — locate and follow that file directly.`,
+          },
+        ],
+        isError: false,
+      };
+    }
   }
 
   const skillPath = path.join(skill.skillDir, skill.entrypoint);

--- a/mcp/tests/fixtures/SKILL.md
+++ b/mcp/tests/fixtures/SKILL.md
@@ -1,0 +1,6 @@
+# Fixture Instruction-Only Skill
+
+This is a Tier-A instruction-only fixture used to verify that invoking an
+instruction-only skill returns its SKILL.md playbook instead of an error.
+
+UNIQUE_FIXTURE_MARKER_4815162342

--- a/mcp/tests/per-skill-tools.test.ts
+++ b/mcp/tests/per-skill-tools.test.ts
@@ -65,3 +65,39 @@ test("invokeSkillTool passes arbitrary sanitized extra_args when explicitly enab
   assert.equal(resp.isError, false, resp.content[0]?.text);
   assert.deepEqual(resultArgv(resp), ["--positions-only", "--config"]);
 });
+
+test("invokeSkillTool returns SKILL.md instructions for a Tier-A instruction-only skill", async () => {
+  const instructionOnlySkill: Skill = {
+    ...fixtureSkill,
+    slug: "fixture-instruction-only",
+    toolName: "simmer_fixture_instruction_only",
+    tier: "instruction",
+    entrypoint: undefined,
+  };
+
+  const resp = await invokeSkillTool(instructionOnlySkill, {}, { processEnv });
+
+  // Must NOT dead-end with an error — it returns the playbook instead.
+  assert.equal(resp.isError, false, resp.content[0]?.text);
+  const text = resp.content[0]?.text ?? "";
+  assert.match(text, /instruction-only skill \(Tier A\)/);
+  assert.match(text, /UNIQUE_FIXTURE_MARKER_4815162342/);
+});
+
+test("invokeSkillTool gives a locate-the-file fallback when a Tier-A skill has no SKILL.md", async () => {
+  const missingMdSkill: Skill = {
+    ...fixtureSkill,
+    slug: "fixture-no-md",
+    toolName: "simmer_fixture_no_md",
+    tier: "instruction",
+    entrypoint: undefined,
+    skillDir: path.join(__dirname, "fixtures", "does-not-exist"),
+  };
+
+  const resp = await invokeSkillTool(missingMdSkill, {}, { processEnv });
+
+  assert.equal(resp.isError, false, resp.content[0]?.text);
+  const text = resp.content[0]?.text ?? "";
+  assert.match(text, /instruction-only skill \(Tier A\)/);
+  assert.match(text, /SKILL\.md/);
+});


### PR DESCRIPTION
## What

When an agent invokes an **instruction-only (Tier A)** skill via MCP — e.g. `simmer-skill-builder` — it now receives the skill's `SKILL.md` playbook as a successful tool result, instead of an opaque error.

## Why

Tier-A skills are registered on the MCP tool surface, so an agent reasonably tries to "call" them. Previously that returned:

```
Skill <slug> has no entrypoint (Tier A, instruction-only).   (isError: true)
```

A dead end. The docs treat these skills as conversational, but the MCP surface implied they were runnable. Nick hit this during World Cup skill dogfooding.

## Behavior change

`invokeSkillTool` on a skill with no entrypoint now:
- reads `<skillDir>/SKILL.md` and returns it as a non-error result prefixed with a one-line "this is instruction-only, follow these directly" note, so the agent gets the instructions inline and proceeds;
- falls back to a clear "instructions live in SKILL.md at `<path>` — locate and follow that file" message (still non-error) if the file can't be read.

## Tests

Adds two tests (instructions-returned via a unique fixture marker + missing-file fallback) and a fixture `SKILL.md`. Full suite: **144/144 pass**.

Bumps `simmer-mcp 3.4.1 → 3.4.2` (`BUNDLED_VERSION` follows package.json). Publish to npm after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)