### PR TITLE
skill(wallet-xray, skill-builder): doc links → docs.simmer.markets

### DIFF
--- a/skills/polymarket-wallet-xray/SKILL.md
+++ b/skills/polymarket-wallet-xray/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-wallet-xray
 description: X-ray any Polymarket wallet — skill level, entry quality, bot detection, and edge analysis. Queries Polymarket's public APIs, no authentication needed. Inspired by @thejayden's "Autopsy of a Polymarket Whale" analysis.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.1.3"
+  version: "1.1.4"
   displayName: Polymarket Wallet X-Ray
   difficulty: beginner
 ---
@@ -327,7 +327,7 @@ All metrics and analysis patterns used here are derived from that work. If you f
 
 ## Links
 
-- **Full Simmer API Reference:** [simmer.markets/docs.md](https://simmer.markets/docs.md)
+- **Full Simmer API Reference:** [docs.simmer.markets/api/overview](https://docs.simmer.markets/api/overview)
 - **Original Analysis:** [The Autopsy: How to Read the Mind of a Polymarket Whale](https://x.com/thejayden/status/2020891572389224878)
 - **Dashboard:** [simmer.markets/dashboard](https://simmer.markets/dashboard)
 - **Support:** [Telegram](https://t.me/+m7sN0OLM_780M2Fl)

--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-skill-builder
 description: Generate complete, installable OpenClaw trading skills from natural language strategy descriptions. Use when your human wants to create a new trading strategy, build a bot, generate a skill, automate a trade idea, turn a tweet into a strategy, or asks "build me a skill that...". Produces a full skill folder (SKILL.md + Python script + config) ready to install and run.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.5"
+  version: "1.3.6"
   displayName: Simmer Skill Builder
   difficulty: beginner
 ---
@@ -293,7 +293,7 @@ After publishing, the Simmer sync job picks it up within ~1 hour (runs hourly at
 Tell your human:
 > ✅ Skill published to ClawHub. It will appear in the Simmer Skills Registry within ~1 hour at simmer.markets/skills.
 
-For full publishing details: [simmer.markets/skillregistry.md](https://simmer.markets/skillregistry.md)
+For full publishing details: [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building)
 
 ### Step 6b (optional): Distribute beyond Simmer via skills.sh
 


### PR DESCRIPTION
Repoints the last 2 published skills off the retired flat simmer.markets docs: wallet-xray → docs.simmer.markets/api/overview (1.1.4), skill-builder → docs.simmer.markets/skills/building (1.3.6). Republished to ClawHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)