### PR TITLE
feat(skills): World Cup category — declare on shock-ladder + fix builder guidance

### DIFF
--- a/skills/polymarket-soccer-shock-ladder/SKILL.md
+++ b/skills/polymarket-soccer-shock-ladder/SKILL.md
@@ -6,9 +6,14 @@ tags:
   - soccer
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.1"
+  version: "0.1.2"
   displayName: World Cup Shock Ladder
   difficulty: intermediate
+  simmer:
+    credit:
+      name: "@RohOnChain"
+      url: "https://x.com/RohOnChain"
+      label: via
 ---
 # World Cup Shock Ladder
 

--- a/skills/polymarket-soccer-shock-ladder/SKILL.md
+++ b/skills/polymarket-soccer-shock-ladder/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: polymarket-soccer-shock-ladder
 description: Fade sharp in-play price shocks on Polymarket soccer markets with a laddered limit-buy strategy (Roan's FIFA-quant framework). Pro skill. Currently scoped to 2026 World Cup markets. Simmer's server detects shocks in real time and emits pre-sized signals; this skill places the recovery ladder and manages the exit.
+category: world-cup
 tags:
   - world-cup
   - soccer
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.2"
+  version: "0.1.3"
   displayName: World Cup Shock Ladder
   difficulty: intermediate
   simmer:

--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-skill-builder
 description: Generate complete, installable OpenClaw trading skills from natural language strategy descriptions. Use when your human wants to create a new trading strategy, build a bot, generate a skill, automate a trade idea, turn a tweet into a strategy, or asks "build me a skill that...". Produces a full skill folder (SKILL.md + Python script + config) ready to install and run.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.4"
+  version: "1.3.5"
   displayName: Simmer Skill Builder
   difficulty: beginner
 ---
@@ -111,7 +111,8 @@ Keep the first version narrow. A skill that does one World Cup signal well is mo
 **Make it discoverable.** A World Cup campaign skill should surface under the World Cup tab at simmer.markets/skills and carry a real name. In the SKILL.md frontmatter:
 
 - Set `metadata.displayName` to a human name (e.g. "World Cup Shock Ladder"). The registry shows this; the slug is only the install ID, so the displayName is what builders and traders read on the card.
-- Add a `world-cup` tag, and keep "World Cup", "FIFA", or "soccer" in the displayName or description. Either the tag or one of those keywords makes the skill appear under the World Cup tab. Without one, it only shows under its auto-assigned Sports / Multi-market category.
+- **Declare `category: world-cup` as a top-level frontmatter key. This is the lever** — the World Cup tab and the /markets featured-skill banner both filter on the `category` column being exactly `world-cup`. An author-declared category wins over auto-detection. A `world-cup` tag alone does NOT surface the skill (tags are not used by the filter), so don't rely on it. Note this becomes the skill's single category for the campaign — a WC-scoped skill belongs under World Cup now; generalize to `sports` / `multi-market` after the tournament.
+- Still add a `world-cup` tag (and keep "World Cup", "FIFA", or "soccer" in the displayName/description) as supplementary discovery labels, but the `category` declaration is what makes it appear.
 
 ### Step 2: Load References
 
@@ -174,7 +175,8 @@ Rules:
 - `description` is required. AgentSkills spec allows up to 1024 chars, **but keep it ≤160 chars** — ClawHub truncates longer descriptions when generating the skill's `summary`, and that truncated value is what renders as the one-line description on `simmer.markets/skills/<owner>/<slug>` and in social-share cards. Write a complete sentence that fits.
 - `metadata` values must be flat strings (AgentSkills spec)
 - `metadata.displayName` is the name the Simmer registry renders on the skill card. Always set a clean human name; the slug is only the install ID.
-- Optional top-level `tags:` are discovery labels. For a World Cup campaign skill, include `world-cup` so it appears under the World Cup tab on simmer.markets/skills.
+- Top-level `category:` is the registry taxonomy bucket and the lever for tab/banner filters. Declare `category: world-cup` for a World Cup campaign skill (see the World Cup section) — it appears under the World Cup tab only when this is set.
+- Optional top-level `tags:` are supplementary discovery labels. Include `world-cup`, but the `tags` are not used by the tab filter — `category` is.
 - `metadata.simmer.credit` attributes the original strategy author (see below). **When you built this skill from someone's X thread or post, always set it** so the registry shows "via @them".
 - NO `clawdbot`, `requires`, `tunables`, or `automaton` in SKILL.md — those go in `clawhub.json`
 - Body must include: "This is a template" callout, setup flow, configuration table, quick commands, example output, troubleshooting section

--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-skill-builder
 description: Generate complete, installable OpenClaw trading skills from natural language strategy descriptions. Use when your human wants to create a new trading strategy, build a bot, generate a skill, automate a trade idea, turn a tweet into a strategy, or asks "build me a skill that...". Produces a full skill folder (SKILL.md + Python script + config) ready to install and run.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.3"
+  version: "1.3.4"
   displayName: Simmer Skill Builder
   difficulty: beginner
 ---
@@ -39,6 +39,8 @@ Ask your human to clarify until you understand these five parameters:
 #### 1c. From-post extraction
 
 When the human pastes a strategy post or campaign brief, extract — don't ask first. The post often contains the strategy shape already. Ask follow-ups only after you have separated what is explicit from what is missing.
+
+**Capture the author handle.** If the post is the strategy author's own (an X thread, a quant write-up), note their handle and source URL — you'll set `metadata.simmer.credit` so the published skill is attributed "via @them" (see the frontmatter section). Confirm the handle with the human before crediting; a pasted thread isn't always the author's own idea.
 
 **Extraction steps:**
 1. Identify the **deterministic skeleton**: most trading strategies follow `scan → score → gate → size → execute`. Find these blocks in the post.
@@ -173,6 +175,7 @@ Rules:
 - `metadata` values must be flat strings (AgentSkills spec)
 - `metadata.displayName` is the name the Simmer registry renders on the skill card. Always set a clean human name; the slug is only the install ID.
 - Optional top-level `tags:` are discovery labels. For a World Cup campaign skill, include `world-cup` so it appears under the World Cup tab on simmer.markets/skills.
+- `metadata.simmer.credit` attributes the original strategy author (see below). **When you built this skill from someone's X thread or post, always set it** so the registry shows "via @them".
 - NO `clawdbot`, `requires`, `tunables`, or `automaton` in SKILL.md — those go in `clawhub.json`
 - Body must include: "This is a template" callout, setup flow, configuration table, quick commands, example output, troubleshooting section
 
@@ -190,6 +193,21 @@ metadata:
 ```
 
 Rendered as a row of icon-pills (Twitter/X / YouTube / generic) near the top of the skill detail page. Up to 10 URLs per skill. URLs must start with `https://` or `http://`.
+
+#### `metadata.simmer.credit` (attribute the original strategy author)
+
+When this skill implements a strategy from someone else's post (a KOL X thread, a quant write-up), credit them. The registry renders it as "via @author" on the skill card and detail page, and it links to their profile. This is **display-only attribution** — it does not transfer ownership, and earnings are bound separately by the Simmer team.
+
+```yaml
+metadata:
+  simmer:
+    credit:
+      name: "@RohOnChain"
+      url: "https://x.com/RohOnChain"
+      label: via          # via | by | powered by | from | after (default: via)
+```
+
+**Auto-set this when you build from a pasted post or thread** (the §1c from-post path): the source author's handle becomes the credit. Confirm the handle with the human first — a pasted thread is not always the author's own strategy (they may be quoting a third party), and you do not want to mis-credit. `name` is required; `url` must be `http(s)`.
 
 #### Your SKILL.md body renders publicly
 


### PR DESCRIPTION
Gets the World Cup skill cohort to actually populate, and republishes the @RohOnChain credit (committed to main earlier but never republished to ClawHub).

## Why
The `/skills` World Cup tab and the `/markets` featured-skill banner both filter on the registry `category` column being exactly `world-cup`. The Shock Ladder was only *tagged* `world-cup` (tags don't sync to the registry — they're empty), so it landed in `sports` and the entire WC cohort was empty. The classifier honors an author-declared `category`, so declaring it is the fix.

## Changes
- **polymarket-soccer-shock-ladder 0.1.2 → 0.1.3:** declare `category: world-cup`. (The 0.1.2 @RohOnChain credit block is already on main; this republish finally takes it live too.)
- **simmer-skill-builder 1.3.6 → 1.3.7:** correct the World Cup discoverability guidance. The old text claimed a `world-cup` tag or keyword surfaces the skill — false. Now: declare `category: world-cup` (the lever); the tag is supplementary.

## After merge
Republish both skills to ClawHub + `POST /api/admin/skills/sync`, then verify shock-ladder flips to `category='world-cup'` and the /markets banner renders.

Refs SIM-2997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)