### PR TITLE
security(sdk): validate server-supplied signing batches + enforce https + pin signing deps (audit R3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.17.29] - 2026-06-10
+
+### Security
+
+- **Client-side validation of server-supplied signing batches (defense-in-depth).** The DW activation, redemption, and wrap flows fetch an EIP-712 batch from the server and sign it locally. Previously the SDK signed whatever the server returned after only a presence check — so a compromised, malicious, or MITM'd server could return an `approve(attacker, MAX)` (or third-party `wrap` recipient) batch and have your own key authorize draining your deposit wallet. The SDK now mirrors the server's own submit-time guards *before signing*: `activate_polymarket_dw()`, `redeem()` (external DW path), and `wrap_on_dw()` validate that every call targets a pinned Polymarket contract, uses an allowed selector (`approve`/`setApprovalForAll`/`redeemPositions`/`wrap`), names a pinned spender/operator, moves no native value, and (for wrap) pays out only to your own deposit wallet. Refuses to sign anything else. New module `simmer_sdk/batch_validation.py`. Because it mirrors the logic an honest server already applies, it cannot reject a legitimate batch.
+- **HTTPS enforced on `base_url`.** The client now rejects a non-`https://` `base_url` (which would expose your `sk_live_` API key and let a network attacker tamper with the transactions the SDK signs). Loopback hosts stay allowed for local dev; set `SIMMER_ALLOW_INSECURE_BASE_URL=1` to opt out for testing against a non-loopback dev server.
+- **Supply-chain: upper bounds on signing-critical dependencies.** `py-clob-client`, `py-clob-client-v2`, `polynode`, `solders`, and the `[ows]` extra now carry version ceilings so a breaking or compromised new release can't be pulled silently into a key-bearing environment on a fresh install. `eth-account` and `requests` are left uncapped to avoid resolver conflicts with `web3.py` and the wider ecosystem.
+
 ## [0.17.28] - 2026-06-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.28"
+version = "0.17.29"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [
@@ -24,21 +24,28 @@ classifiers = [
     "Topic :: Office/Business :: Financial :: Investment",
 ]
 requires-python = ">=3.8"
+# Supply-chain note: the signing-critical Polymarket/OWS libraries below carry
+# UPPER BOUNDS so a compromised or breaking new major/minor release can't be
+# pulled silently into a key-bearing environment on a fresh install. These are
+# niche packages (low chance of co-dependency conflicts). eth-account and
+# requests are deliberately left uncapped — capping eth-account fights web3.py's
+# own pin and would break installs, and requests is the most-vetted package on
+# PyPI. Bump the ceilings deliberately when validating a new upstream release.
 dependencies = [
     "requests>=2.31.0",
-    "solders>=0.27.1",
+    "solders>=0.27.1,<0.28.0",
     "base58>=2.1.1",
     "eth-account>=0.13.0",
     "py-order-utils>=0.3.0",
-    "py-clob-client>=0.30.0",
+    "py-clob-client>=0.30.0,<1.0.0",
     # V2 CLOB client for Polymarket V2 (2026-04-28 cutover). V1 deps
     # retained for users who pin SIMMER_POLYMARKET_EXCHANGE_VERSION=v1.
-    "py-clob-client-v2>=1.0.0",
+    "py-clob-client-v2>=1.0.0,<2.0.0",
     # POLY_1271 (sig type 3) signing for Polymarket deposit-wallet users
     # (SIM-1521). Provides ERC-7739 TypedDataSign wrapping via
     # `polynode.trading.eip712.create_signed_order_v2`. Pinned to a known-
     # working release; the helper API is stable.
-    "polynode>=0.10.3",
+    "polynode>=0.10.3,<0.11.0",
 ]
 
 [project.optional-dependencies]
@@ -55,7 +62,7 @@ dependencies = [
 # users searching PyPI for `ows` find nothing. The `[ows]` extra
 # eliminates the asymmetry: one install command, no package-name lookup
 # required.
-ows = ["open-wallet-standard>=1.3.0"]
+ows = ["open-wallet-standard>=1.3.0,<2.0.0"]
 
 [project.urls]
 Homepage = "https://simmer.markets"

--- a/simmer_sdk/batch_validation.py
+++ b/simmer_sdk/batch_validation.py
@@ -1,0 +1,333 @@
+"""Client-side validation of server-supplied DepositWallet (DW) batches.
+
+Why this exists
+---------------
+The DW activation / redemption / wrap flows fetch an EIP-712 ``typed_data``
+blob (plus a ``calls`` list of ``{target, value, data}``) from a Simmer server
+``/prepare`` endpoint, and the SDK signs it locally with the user's wallet key.
+The server runs its own ``validate_*`` guards at SUBMIT time — but those protect
+the *server* (its builder-HMAC relayer) from a malicious *user*. They do NOT
+protect the *user* from a malicious / compromised / MITM'd *server*: a hostile
+server simply wouldn't run them.
+
+So the SDK signs whatever the server hands it. A server that returned an
+``approve(attacker, MAX_UINT256)`` batch could have the user's own key authorize
+draining their deposit wallet, while the SDK printed only "Signing batch
+locally…". The "your key never leaves the process" guarantee is real but
+insufficient — *what* the key signs was fully server-dictated.
+
+These functions are the symmetric client-side copy of the server guards
+(``simmer_v3/dw_approvals.py::validate_dw_approval_calls``,
+``dw_redeem_external.py::validate_redeem_calls``,
+``dw_wrap_on_dw.py::validate_wrap_on_dw_calls``). They are deliberately a faithful
+mirror: any batch an *honest* server produces already passes the server's own
+identical check, so mirroring it here cannot false-reject a legitimate batch —
+it only rejects batches an honest server would never build.
+
+All spender / target / token addresses are sourced from the SDK's own pinned
+``polymarket_contracts`` constants, never from the server response.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ERC-20 / ERC-1155 / CTF selectors (4-byte function signatures).
+_APPROVE_SELECTOR = "0x095ea7b3"            # approve(address,uint256)
+_SET_APPROVAL_FOR_ALL_SELECTOR = "0xa22cb465"  # setApprovalForAll(address,bool)
+_REDEEM_SELECTOR = "0x01b7037c"             # redeemPositions(address,bytes32,bytes32,uint256[])
+_WRAP_SELECTOR = "0x62355638"               # CollateralOnramp.wrap(address,address,uint256)
+
+_MAX_UINT256 = (1 << 256) - 1
+
+
+class BatchValidationError(ValueError):
+    """Raised when a server-supplied DW batch fails client-side validation.
+
+    A subclass of ``ValueError`` so existing ``except ValueError`` handlers
+    still catch it, but distinct enough to special-case ("the server tried to
+    get you to sign something it shouldn't have").
+    """
+
+
+def _get(call: Any, key: str) -> Any:
+    """Read a field from a call entry that may be a dict (JSON) or an object."""
+    if isinstance(call, dict):
+        return call.get(key)
+    return getattr(call, key, None)
+
+
+def _require_eth_abi():
+    try:
+        from eth_abi import decode as abi_decode  # noqa: WPS433 (local import)
+        return abi_decode
+    except ImportError as exc:  # pragma: no cover - eth-account pulls eth-abi in
+        raise BatchValidationError(
+            "eth-abi is required to validate DW batches before signing. "
+            "It ships with eth-account; install with: pip install eth-account"
+        ) from exc
+
+
+def _check_common(call: Any, i: int) -> tuple[str, str]:
+    """Validate the target / value / data envelope shared by every call shape.
+
+    Returns ``(target_lower, data_lower)``. Raises on any structural problem.
+    """
+    target = (_get(call, "target") or "")
+    target_l = target.lower()
+    data = (_get(call, "data") or "")
+    data_l = data.lower()
+    value = _get(call, "value")
+
+    if not target_l.startswith("0x") or len(target_l) != 42:
+        raise BatchValidationError(
+            f"call[{i}]: target must be a 0x-prefixed 20-byte address; got {target!r}"
+        )
+    # value must be zero — none of these flows move native POL/MATIC.
+    if str(value) not in ("0", "0x0", "0x00"):
+        raise BatchValidationError(
+            f"call[{i}]: value must be '0' (DW batches don't move native currency); "
+            f"got {value!r}"
+        )
+    if not data_l.startswith("0x") or len(data_l) < 10:
+        raise BatchValidationError(
+            f"call[{i}]: data must be 0x-prefixed calldata of >= 4 bytes; "
+            f"got {data!r}"
+        )
+    return target_l, data_l
+
+
+def validate_dw_approval_calls(calls: list) -> None:
+    """Validate a DW *activation* (approvals) batch before signing.
+
+    Mirror of ``simmer_v3/dw_approvals.py::validate_dw_approval_calls``. Accepts
+    only ``approve`` / ``setApprovalForAll`` calls to pinned (token, spender)
+    pairs, each granting MAX (full activation), with no duplicates.
+    """
+    from .polymarket_contracts import (
+        CONDITIONAL_TOKENS,
+        PUSD,
+        V2_FEE_ESCROW,
+        CTF_COLLATERAL_ADAPTER,
+        active_spenders,
+        redemption_spenders,
+    )
+
+    abi_decode = _require_eth_abi()
+
+    pusd_l = PUSD.lower()
+    ctf_l = CONDITIONAL_TOKENS.lower()
+    allowed_pairs: set[tuple[str, str]] = set()
+    for spender in active_spenders():
+        s = spender.lower()
+        allowed_pairs.add((pusd_l, s))   # pUSD → spender (ERC20 approve)
+        allowed_pairs.add((ctf_l, s))    # CTF  → spender (ERC1155 setApprovalForAll)
+    allowed_pairs.add((pusd_l, V2_FEE_ESCROW.lower()))
+    for adapter in redemption_spenders():
+        allowed_pairs.add((ctf_l, adapter.lower()))
+    allowed_pairs.add((pusd_l, CTF_COLLATERAL_ADAPTER.lower()))
+
+    if not calls:
+        raise BatchValidationError("Approval batch must contain at least 1 call; got 0.")
+
+    seen: set[tuple[str, str]] = set()
+    for i, call in enumerate(calls):
+        target_l, data_l = _check_common(call, i)
+        selector = data_l[:10]
+        if selector not in (_APPROVE_SELECTOR, _SET_APPROVAL_FOR_ALL_SELECTOR):
+            raise BatchValidationError(
+                f"call[{i}]: selector {selector} not allowed — DW activation only "
+                f"accepts ERC20.approve and ERC1155.setApprovalForAll."
+            )
+        try:
+            args = bytes.fromhex(data_l[10:])
+            if selector == _APPROVE_SELECTOR:
+                spender, amount = abi_decode(["address", "uint256"], args)
+            else:
+                spender, approved = abi_decode(["address", "bool"], args)
+                amount = _MAX_UINT256 if approved else 0
+        except BatchValidationError:
+            raise
+        except Exception as exc:
+            raise BatchValidationError(
+                f"call[{i}]: could not decode approval calldata: {type(exc).__name__}: {exc}"
+            )
+
+        if amount != _MAX_UINT256:
+            raise BatchValidationError(
+                f"call[{i}]: approval must be MAX (full activation); got {amount}. "
+                f"Revokes/partials are not part of a legitimate activation batch."
+            )
+        pair = (target_l, spender.lower())
+        if pair not in allowed_pairs:
+            raise BatchValidationError(
+                f"call[{i}]: (token={pair[0][:10]}…, spender={pair[1][:10]}…) is not a "
+                f"known approval pair. The server tried to get you to approve an "
+                f"unexpected token/spender — refusing to sign."
+            )
+        if pair in seen:
+            raise BatchValidationError(
+                f"call[{i}]: duplicate (token, spender) pair — refusing to sign."
+            )
+        seen.add(pair)
+
+
+def validate_redeem_calls(calls: list) -> None:
+    """Validate a DW *redeem* batch before signing.
+
+    Mirror of ``dw_redeem_external.py::validate_redeem_calls``: 1 or 2 calls
+    (optional JIT setApprovalForAll then redeemPositions); the redeem targets a
+    pinned adapter; the approval targets CTF and names a pinned redemption
+    adapter as operator; index_sets ⊆ {1, 2}.
+    """
+    from .polymarket_contracts import (
+        CONDITIONAL_TOKENS,
+        CTF_COLLATERAL_ADAPTER,
+        NEG_RISK_CTF_COLLATERAL_ADAPTER,
+    )
+
+    abi_decode = _require_eth_abi()
+
+    ctf_l = CONDITIONAL_TOKENS.lower()
+    allowed_targets = {
+        ctf_l: {_SET_APPROVAL_FOR_ALL_SELECTOR},
+        CTF_COLLATERAL_ADAPTER.lower(): {_REDEEM_SELECTOR},
+        NEG_RISK_CTF_COLLATERAL_ADAPTER.lower(): {_REDEEM_SELECTOR},
+    }
+    allowed_ops = {CTF_COLLATERAL_ADAPTER.lower(), NEG_RISK_CTF_COLLATERAL_ADAPTER.lower()}
+
+    if not (1 <= len(calls) <= 2):
+        raise BatchValidationError(
+            f"Redeem batch must be 1 or 2 calls (optional JIT approval + redeem); "
+            f"got {len(calls)}."
+        )
+
+    saw_redeem = False
+    saw_approval = False
+    for i, call in enumerate(calls):
+        target_l, data_l = _check_common(call, i)
+        selector = data_l[:10]
+        if target_l not in allowed_targets:
+            raise BatchValidationError(
+                f"call[{i}]: target {target_l[:10]}… is not CTF or a redemption "
+                f"adapter — refusing to sign."
+            )
+        if selector not in allowed_targets[target_l]:
+            raise BatchValidationError(
+                f"call[{i}]: selector {selector} not allowed on target "
+                f"{target_l[:10]}… — refusing to sign."
+            )
+        if selector == _SET_APPROVAL_FOR_ALL_SELECTOR:
+            if i != 0:
+                raise BatchValidationError(
+                    f"call[{i}]: setApprovalForAll must be the first call (precedes redeem)."
+                )
+            try:
+                operator, approved = abi_decode(["address", "bool"], bytes.fromhex(data_l[10:]))
+            except Exception as exc:
+                raise BatchValidationError(
+                    f"call[{i}]: could not decode setApprovalForAll args: {exc}"
+                )
+            if not approved:
+                raise BatchValidationError(
+                    f"call[{i}]: setApprovalForAll must grant (approved=true)."
+                )
+            if operator.lower() not in allowed_ops:
+                raise BatchValidationError(
+                    f"call[{i}]: setApprovalForAll operator {operator.lower()[:10]}… is "
+                    f"not a redemption adapter — refusing to sign."
+                )
+            saw_approval = True
+        elif selector == _REDEEM_SELECTOR:
+            try:
+                _coll, _parent, _cond, index_sets = abi_decode(
+                    ["address", "bytes32", "bytes32", "uint256[]"], bytes.fromhex(data_l[10:])
+                )
+            except Exception as exc:
+                raise BatchValidationError(
+                    f"call[{i}]: could not decode redeemPositions args: {exc}"
+                )
+            if not index_sets or any(s not in (1, 2) for s in index_sets):
+                raise BatchValidationError(
+                    f"call[{i}]: redeemPositions index_sets must be a subset of {{1, 2}}; "
+                    f"got {list(index_sets)}."
+                )
+            saw_redeem = True
+
+    if not saw_redeem:
+        raise BatchValidationError("Redeem batch must contain exactly one redeemPositions call.")
+    if len(calls) == 2 and not saw_approval:
+        raise BatchValidationError(
+            "Two-call redeem batch must be (setApprovalForAll, redeemPositions)."
+        )
+
+
+def validate_wrap_on_dw_calls(calls: list, deposit_wallet_address: str) -> None:
+    """Validate a DW *wrap* (USDC.e → pUSD) batch before signing.
+
+    Mirror of ``dw_wrap_on_dw.py::validate_wrap_on_dw_calls``: 1 or 2 calls
+    (optional approve(USDC.e → Onramp) then Onramp.wrap(USDC.e, DW, amount)).
+    The wrap recipient MUST be the user's own DW — never a third party.
+    """
+    from .polymarket_contracts import COLLATERAL_ONRAMP, USDC_E
+
+    abi_decode = _require_eth_abi()
+
+    onramp_l = COLLATERAL_ONRAMP.lower()
+    usdce_l = USDC_E.lower()
+    dw_l = (deposit_wallet_address or "").lower()
+    if not dw_l.startswith("0x") or len(dw_l) != 42:
+        raise BatchValidationError(
+            f"deposit_wallet_address must be a 0x 20-byte address; got "
+            f"{deposit_wallet_address!r}"
+        )
+
+    if not calls:
+        raise BatchValidationError("Wrap batch must contain at least 1 call; got 0.")
+    if len(calls) > 2:
+        raise BatchValidationError(
+            f"Wrap batch must contain at most 2 calls (optional approve + wrap); "
+            f"got {len(calls)}."
+        )
+
+    for i, call in enumerate(calls):
+        _check_common(call, i)  # target/value/data envelope
+
+    if len(calls) == 2:
+        a_target, a_data = _check_common(calls[0], 0)
+        if a_target != usdce_l:
+            raise BatchValidationError("call[0] (approve): target must be USDC.e.")
+        if not a_data.startswith(_APPROVE_SELECTOR):
+            raise BatchValidationError("call[0] (approve): selector must be ERC20.approve.")
+        try:
+            spender, _amt = abi_decode(["address", "uint256"], bytes.fromhex(a_data[10:]))
+        except Exception as exc:
+            raise BatchValidationError(f"call[0] (approve): decode failed: {exc}")
+        if spender.lower() != onramp_l:
+            raise BatchValidationError(
+                f"call[0] (approve): spender must be the Onramp ({onramp_l[:10]}…)."
+            )
+
+    w_target, w_data = _check_common(calls[-1], len(calls) - 1)
+    if w_target != onramp_l:
+        raise BatchValidationError(
+            f"call[{len(calls)-1}] (wrap): target must be the Onramp ({onramp_l[:10]}…)."
+        )
+    if not w_data.startswith(_WRAP_SELECTOR):
+        raise BatchValidationError(
+            f"call[{len(calls)-1}] (wrap): selector must be CollateralOnramp.wrap."
+        )
+    try:
+        token, recipient, _amt = abi_decode(
+            ["address", "address", "uint256"], bytes.fromhex(w_data[10:])
+        )
+    except Exception as exc:
+        raise BatchValidationError(f"call[{len(calls)-1}] (wrap): decode failed: {exc}")
+    if token.lower() != usdce_l:
+        raise BatchValidationError(f"call[{len(calls)-1}] (wrap): token must be USDC.e.")
+    if recipient.lower() != dw_l:
+        raise BatchValidationError(
+            f"call[{len(calls)-1}] (wrap): recipient must be your own deposit wallet "
+            f"({dw_l[:10]}…), not {recipient.lower()[:10]}… — refusing to sign a wrap "
+            f"to a third-party recipient."
+        )

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -12,6 +12,7 @@ import logging
 import requests
 from typing import Optional, List, Dict, Any
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +294,23 @@ class SimmerClient:
 
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
+        # Enforce HTTPS so the API key (Authorization: Bearer) and the EIP-712
+        # batches we sign can't be read or tampered with on the wire. A plain
+        # http:// endpoint is a downgrade/MITM vector, and a MITM'd server can
+        # feed malicious typed-data to sign. Allow http only for loopback (local
+        # dev against a dev server) or an explicit, documented opt-in env flag.
+        if not self.base_url.startswith("https://"):
+            _host = urlparse(self.base_url).hostname or ""
+            _is_loopback = _host in ("localhost", "127.0.0.1", "::1") or _host.endswith(".localhost")
+            _opt_in = os.getenv("SIMMER_ALLOW_INSECURE_BASE_URL", "").strip().lower() in ("1", "true", "yes")
+            if not (_is_loopback or _opt_in):
+                raise ValueError(
+                    f"base_url must use https:// (got {self.base_url!r}). Plaintext "
+                    f"HTTP exposes your API key and lets a network attacker tamper "
+                    f"with the transactions this SDK signs. Use https://, or set "
+                    f"SIMMER_ALLOW_INSECURE_BASE_URL=1 for local/testing against a "
+                    f"non-loopback host."
+                )
         self.venue = venue
         # venue is set explicitly via the `venue=` arg (or from_env(venue=...))
         # and defaults to "sim" (paper). NOTE: the TRADING_VENUE env var is
@@ -5028,6 +5046,14 @@ class SimmerClient:
                 f"Got keys: {list(prepare.keys())}"
             )
 
+        # Validate the server-supplied batch BEFORE signing. The server's own
+        # submit-time guard protects the relayer from a malicious user; it does
+        # NOT protect this user from a malicious/compromised server. Mirror the
+        # guard client-side: approve / setApprovalForAll to pinned (token,
+        # spender) pairs at MAX only — refuse to sign anything else.
+        from .batch_validation import validate_dw_approval_calls
+        validate_dw_approval_calls(calls)
+
         # Step 2 — sign locally. Mirrors dw_redeem.sign_dw_redeem_typed_data:
         # pass the full typed_data dict via full_message so primaryType is
         # honoured. Key never leaves this process.
@@ -5137,6 +5163,15 @@ class SimmerClient:
                 f"Unexpected prepare response — missing required fields. "
                 f"Got keys: {list(prepare.keys())}"
             )
+
+        # Validate the server-supplied batch BEFORE signing — refuse a wrap
+        # whose recipient isn't our own deposit wallet, or whose calls aren't a
+        # USDC.e approve(Onramp) + Onramp.wrap pair.
+        from .batch_validation import validate_wrap_on_dw_calls
+        _dw_addr = prepare.get("deposit_wallet_address") or getattr(
+            self, "_deposit_wallet_address", None
+        )
+        validate_wrap_on_dw_calls(calls, _dw_addr)
 
         # Step 2 — sign locally. Same pattern as activate_polymarket_dw:
         # pass the full typed_data dict via full_message so primaryType is

--- a/simmer_sdk/dw_redeem.py
+++ b/simmer_sdk/dw_redeem.py
@@ -405,6 +405,12 @@ def redeem_dw_external(
         market_id=market_id,
         side=side,
     )
+    # Validate the server-supplied batch BEFORE signing it. A compromised /
+    # MITM'd server can't be relied on to run its own submit-time guard, so the
+    # client mirrors it: targets must be CTF / pinned redemption adapters,
+    # selectors must be setApprovalForAll / redeemPositions, value 0.
+    from .batch_validation import validate_redeem_calls
+    validate_redeem_calls(prepared.get("calls", []))
     if on_progress:
         on_progress("signing")
     signature = sign_dw_redeem_typed_data(

--- a/tests/test_activate_polymarket_dw.py
+++ b/tests/test_activate_polymarket_dw.py
@@ -38,16 +38,31 @@ FAKE_TYPED_DATA = {
     "message": {"calls": [], "nonce": "1", "deadline": 9999999999},
 }
 
-FAKE_CALLS = [{"target": "0xabc", "value": "0", "data": "0x095ea7b3"}]
+# A realistically-encoded valid approval batch — approve(spender, MAX) on pUSD,
+# where the spender is a pinned active spender. Client-side batch validation
+# (0.17.29) now runs before signing, so the fixture must pass the same guard the
+# server applies. `eth_abi` ships with `eth-account` (an SDK dependency).
+from eth_abi import encode as _abi_encode  # noqa: E402
+from simmer_sdk.polymarket_contracts import (  # noqa: E402
+    PUSD as _PUSD,
+    active_spenders as _active_spenders,
+)
+
+_MAX = (1 << 256) - 1
+_SPENDER = _active_spenders()[0]
+_APPROVE_DATA = "0x095ea7b3" + _abi_encode(["address", "uint256"], [_SPENDER, _MAX]).hex()
+FAKE_DW = "0x" + "11" * 20
+
+FAKE_CALLS = [{"target": _PUSD, "value": "0", "data": _APPROVE_DATA}]
 
 PREPARE_RESPONSE = {
     "already_set": False,
     "calls": FAKE_CALLS,
-    "calls_summary": [{"target": "0xabc", "data_prefix": "0x095ea7b"}],
+    "calls_summary": [{"target": _PUSD, "data_prefix": "0x095ea7b"}],
     "typed_data": FAKE_TYPED_DATA,
     "nonce": "42",
     "deadline": 9999999999,
-    "deposit_wallet_address": "0xDW",
+    "deposit_wallet_address": FAKE_DW,
 }
 
 PREPARE_ALREADY_SET = {

--- a/tests/test_batch_validation.py
+++ b/tests/test_batch_validation.py
@@ -1,0 +1,171 @@
+"""Tests for simmer_sdk.batch_validation — client-side guards that refuse to
+sign malicious server-supplied DepositWallet batches (0.17.29 security fix).
+
+The security-critical assertions are the REJECT cases: a compromised/MITM'd
+server must not be able to get the SDK to sign an approve-to-attacker,
+setApprovalForAll-to-attacker, wrap-to-third-party, or value-bearing batch.
+"""
+from __future__ import annotations
+
+import pytest
+from eth_abi import encode as abi_encode
+
+from simmer_sdk.batch_validation import (
+    BatchValidationError,
+    validate_dw_approval_calls,
+    validate_redeem_calls,
+    validate_wrap_on_dw_calls,
+)
+from simmer_sdk.polymarket_contracts import (
+    CONDITIONAL_TOKENS,
+    COLLATERAL_ONRAMP,
+    CTF_COLLATERAL_ADAPTER,
+    PUSD,
+    USDC_E,
+    active_spenders,
+)
+
+MAX = (1 << 256) - 1
+ATTACKER = "0x" + "de" * 20
+DW = "0x" + "11" * 20
+SPENDER = active_spenders()[0]
+
+
+def _approve(token, spender, amount=MAX):
+    return {
+        "target": token,
+        "value": "0",
+        "data": "0x095ea7b3" + abi_encode(["address", "uint256"], [spender, amount]).hex(),
+    }
+
+
+def _set_approval(token, operator, approved=True):
+    return {
+        "target": token,
+        "value": "0",
+        "data": "0xa22cb465" + abi_encode(["address", "bool"], [operator, approved]).hex(),
+    }
+
+
+def _redeem(adapter, index_sets=(1, 2)):
+    data = "0x01b7037c" + abi_encode(
+        ["address", "bytes32", "bytes32", "uint256[]"],
+        [PUSD, b"\x00" * 32, b"\x11" * 32, list(index_sets)],
+    ).hex()
+    return {"target": adapter, "value": "0", "data": data}
+
+
+def _wrap(recipient, amount=5_000_000):
+    data = "0x62355638" + abi_encode(
+        ["address", "address", "uint256"], [USDC_E, recipient, amount]
+    ).hex()
+    return {"target": COLLATERAL_ONRAMP, "value": "0", "data": data}
+
+
+# --- approvals -------------------------------------------------------------
+
+def test_approval_valid_passes():
+    validate_dw_approval_calls([_approve(PUSD, SPENDER)])
+    validate_dw_approval_calls([_set_approval(CONDITIONAL_TOKENS, SPENDER)])
+
+
+def test_approval_to_attacker_spender_rejected():
+    with pytest.raises(BatchValidationError, match="not a known approval pair"):
+        validate_dw_approval_calls([_approve(PUSD, ATTACKER)])
+
+
+def test_setapproval_to_attacker_operator_rejected():
+    with pytest.raises(BatchValidationError, match="not a known approval pair"):
+        validate_dw_approval_calls([_set_approval(CONDITIONAL_TOKENS, ATTACKER)])
+
+
+def test_approval_non_max_amount_rejected():
+    with pytest.raises(BatchValidationError, match="MAX"):
+        validate_dw_approval_calls([_approve(PUSD, SPENDER, amount=1)])
+
+
+def test_approval_transfer_selector_rejected():
+    # ERC20.transfer(attacker, amt) — selector 0xa9059cbb, not in the allowlist.
+    transfer = {
+        "target": PUSD,
+        "value": "0",
+        "data": "0xa9059cbb" + abi_encode(["address", "uint256"], [ATTACKER, MAX]).hex(),
+    }
+    with pytest.raises(BatchValidationError, match="not allowed"):
+        validate_dw_approval_calls([transfer])
+
+
+def test_approval_nonzero_value_rejected():
+    call = _approve(PUSD, SPENDER)
+    call["value"] = "1"
+    with pytest.raises(BatchValidationError, match="value must be '0'"):
+        validate_dw_approval_calls([call])
+
+
+def test_approval_duplicate_rejected():
+    with pytest.raises(BatchValidationError, match="duplicate"):
+        validate_dw_approval_calls([_approve(PUSD, SPENDER), _approve(PUSD, SPENDER)])
+
+
+# --- redeem ----------------------------------------------------------------
+
+def test_redeem_valid_single_passes():
+    validate_redeem_calls([_redeem(CTF_COLLATERAL_ADAPTER)])
+
+
+def test_redeem_valid_with_jit_approval_passes():
+    validate_redeem_calls([
+        _set_approval(CONDITIONAL_TOKENS, CTF_COLLATERAL_ADAPTER),
+        _redeem(CTF_COLLATERAL_ADAPTER),
+    ])
+
+
+def test_redeem_to_attacker_target_rejected():
+    bad = _redeem(CTF_COLLATERAL_ADAPTER)
+    bad["target"] = ATTACKER
+    with pytest.raises(BatchValidationError, match="not CTF or a redemption adapter"):
+        validate_redeem_calls([bad])
+
+
+def test_redeem_jit_approval_to_attacker_operator_rejected():
+    with pytest.raises(BatchValidationError, match="not a redemption adapter|not allowed"):
+        validate_redeem_calls([
+            _set_approval(CONDITIONAL_TOKENS, ATTACKER),
+            _redeem(CTF_COLLATERAL_ADAPTER),
+        ])
+
+
+def test_redeem_bad_index_sets_rejected():
+    with pytest.raises(BatchValidationError, match="index_sets"):
+        validate_redeem_calls([_redeem(CTF_COLLATERAL_ADAPTER, index_sets=(7,))])
+
+
+def test_redeem_too_many_calls_rejected():
+    with pytest.raises(BatchValidationError, match="1 or 2 calls"):
+        validate_redeem_calls([_redeem(CTF_COLLATERAL_ADAPTER)] * 3)
+
+
+# --- wrap ------------------------------------------------------------------
+
+def test_wrap_valid_to_own_dw_passes():
+    validate_wrap_on_dw_calls([_wrap(DW)], DW)
+
+
+def test_wrap_valid_with_approve_passes():
+    validate_wrap_on_dw_calls([_approve(USDC_E, COLLATERAL_ONRAMP), _wrap(DW)], DW)
+
+
+def test_wrap_to_attacker_recipient_rejected():
+    with pytest.raises(BatchValidationError, match="must be your own deposit wallet"):
+        validate_wrap_on_dw_calls([_wrap(ATTACKER)], DW)
+
+
+def test_wrap_approve_to_attacker_spender_rejected():
+    bad_approve = _approve(USDC_E, ATTACKER)
+    with pytest.raises(BatchValidationError, match="spender must be the Onramp"):
+        validate_wrap_on_dw_calls([bad_approve, _wrap(DW)], DW)
+
+
+def test_wrap_missing_dw_address_rejected():
+    with pytest.raises(BatchValidationError, match="deposit_wallet_address"):
+        validate_wrap_on_dw_calls([_wrap(DW)], "0xDW")

--- a/tests/test_wrap_on_dw.py
+++ b/tests/test_wrap_on_dw.py
@@ -40,7 +40,21 @@ FAKE_TYPED_DATA = {
     "message": {"calls": [], "nonce": "1", "deadline": 9999999999},
 }
 
-FAKE_CALLS = [{"target": "0xOnramp", "value": "0", "data": "0x12345678"}]
+# A realistically-encoded valid wrap call — Onramp.wrap(USDC.e, DW, amount),
+# recipient = our own deposit wallet. Client-side batch validation (0.17.29)
+# runs before signing, so the fixture must pass the same guard the server
+# applies. `eth_abi` ships with `eth-account` (an SDK dependency).
+from eth_abi import encode as _abi_encode  # noqa: E402
+from simmer_sdk.polymarket_contracts import (  # noqa: E402
+    COLLATERAL_ONRAMP as _ONRAMP,
+    USDC_E as _USDCE,
+)
+
+FAKE_DW = "0x" + "11" * 20
+_WRAP_DATA = "0x62355638" + _abi_encode(
+    ["address", "address", "uint256"], [_USDCE, FAKE_DW, 5_000_000]
+).hex()
+FAKE_CALLS = [{"target": _ONRAMP, "value": "0", "data": _WRAP_DATA}]
 
 PREPARE_RESPONSE = {
     "wrapped": False,
@@ -51,7 +65,7 @@ PREPARE_RESPONSE = {
     "amount_units": 5_000_000,  # $5.00
     "amount_usd": 5.0,
     "needs_approve": False,
-    "deposit_wallet_address": "0xDW",
+    "deposit_wallet_address": FAKE_DW,
     "eoa_address": "0xEOA",
 }
 


### PR DESCRIPTION
Round-3 security audit findings on the **published SDK** — the highest-trust surface, since it runs on users' machines with their own wallet keys. **Not yet published to PyPI (0.17.28 → 0.17.29) — holding the release for review.**

## SDK-H1 (HIGH) — Client-side validation of server-supplied EIP-712 batches
The DW activation / redeem / wrap flows fetched a `typed_data` + `calls[]` blob from a server `/prepare` endpoint and signed it locally after only a *presence* check. The server's own submit-time guards (`validate_dw_approval_calls` etc.) protect the *relayer* from a malicious **user** — they do **not** protect the **user** from a malicious / compromised / MITM'd **server**, which simply wouldn't run them. A hostile server could return an `approve(attacker, MAX)` or wrap-to-third-party batch and have the user's own key authorize draining their deposit wallet, while the SDK printed only `Signing batch locally…`.

**Fix:** new `simmer_sdk/batch_validation.py` mirrors the three server guards **client-side, before signing**, in `activate_polymarket_dw()`, `redeem()` (external DW path), and `wrap_on_dw()`. Every call must target a pinned Polymarket contract, use an allowed selector (`approve`/`setApprovalForAll`/`redeemPositions`/`wrap`), name a pinned spender/operator, move no native value, and (wrap) pay out only to the user's own DW. Addresses come from the SDK's own pinned `polymarket_contracts` constants. **Because it mirrors the logic an honest server already applies, it cannot false-reject a legitimate batch.**

## SDK-M2 (MED) — Enforce `https://` on `base_url`
Rejects plaintext HTTP (which would expose the `sk_live_` key and let a MITM tamper with signed txns). Loopback allowed for local dev; `SIMMER_ALLOW_INSECURE_BASE_URL=1` opt-out for non-loopback testing.

## SDK-M5 (MED) — Supply-chain upper bounds
`py-clob-client`, `py-clob-client-v2`, `polynode`, `solders`, and `[ows]` now carry ceilings so a breaking/compromised release can't auto-install into a key-bearing env. `eth-account`/`requests` left uncapped to avoid `web3.py` resolver conflicts.

## Deferred (documented, intentionally NOT here)
- **M3** (server price slippage bound): a bound tight enough to matter risks false-rejecting legitimate thin-book marketable fills, and the harm ceiling is a bad fill into the user's **own** wallet (maker==funder==user DW; signer-mismatch already refused), not theft. Better as an opt-in caller `max_price`.
- **M7** (`session.trust_env=False`/`allow_redirects=False`): breaks corporate-proxy users and FastAPI 307 trailing-slash redirects; the env-control threat model already implies key compromise.

## Testing
- New `tests/test_batch_validation.py` — 18 cases: valid batches pass; approve-to-attacker, setApprovalForAll-to-attacker, transfer-selector, non-MAX, nonzero-value, duplicate, redeem-to-attacker, bad index_sets, wrap-to-third-party all **rejected**.
- Existing flow fixtures re-encoded from fakes (`0xabc`) to realistic valid batches.
- Full suite: **408 passed**, 3 skipped; 4 failures are pre-existing OWS-env (`my-agent` vault absent on this machine, fails identically on clean `main`).
- M2 runtime-verified across https / http-loopback / http-reject / opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)