### PR TITLE
fix(nothing-ever-happens): paper mode must not live-fire polymarket trades

### DIFF
--- a/skills/polymarket-nothing-ever-happens/SKILL.md
+++ b/skills/polymarket-nothing-ever-happens/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-nothing-ever-happens
 description: Buy NO on standalone non-sports yes/no Polymarket markets priced below a configurable cap. Based on the "nothing-ever-happens" thesis — binary markets often resolve NO, and cheap NO shares offer asymmetric value. Scans for candidates via Gamma API, filters out sports and grouped markets, checks fees, and executes.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.3"
+  version: "1.0.4"
   displayName: Polymarket Nothing-Ever-Happens
   difficulty: beginner
 ---
@@ -75,6 +75,7 @@ python nothing_ever_happens.py --set price_cap=0.03
 
 | Key | Env Var | Default | Description |
 |-----|---------|---------|-------------|
+| — | `TRADING_VENUE` | polymarket | Venue to trade on. Set `sim` for $SIM paper trading on the Simmer venue (no wallet, no USDC). |
 | `price_cap` | `SIMMER_NEH_PRICE_CAP` | 0.05 | Max NO price to buy (0.05 = 5¢) |
 | `max_bet_usd` | `SIMMER_NEH_MAX_BET_USD` | 5.0 | USDC per trade |
 | `max_trades_per_run` | `SIMMER_NEH_MAX_TRADES_PER_RUN` | 3 | Max trades per execution |

--- a/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
+++ b/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
@@ -148,9 +148,13 @@ def resolve_effective_dry_run(dry_run: bool, client_venue) -> bool:
     """
     is_paper_venue = resolve_venue() == "sim"
     effective = dry_run and not is_paper_venue
-    if dry_run and not effective and client_venue != "sim":
+    # The venue assertion must cover EVERY execution where TRADING_VENUE=sim
+    # ends up live — including explicit --live runs where dry_run was never
+    # True (codex P1): if env says sim but the client would hit a real venue,
+    # preflight is skipped downstream and trades would live-fire.
+    if is_paper_venue and not effective and client_venue != "sim":
         print(
-            f"FATAL: TRADING_VENUE=sim disabled dry-run, but the client venue is "
+            f"FATAL: TRADING_VENUE=sim implies paper mode, but the client venue is "
             f"{client_venue!r} (not 'sim') — refusing to live-fire a real venue.",
             flush=True,
         )

--- a/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
+++ b/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
@@ -113,6 +113,11 @@ SPORTS_CATEGORIES = {
 _client = None
 
 
+def resolve_venue() -> str:
+    """Effective trading venue. TRADING_VENUE=sim is the $SIM paper switch."""
+    return os.environ.get("TRADING_VENUE", "polymarket")
+
+
 def get_client(live=True):
     """Lazy-init SimmerClient singleton."""
     global _client
@@ -127,8 +132,36 @@ def get_client(live=True):
             print("Error: SIMMER_API_KEY environment variable not set")
             print("Get your API key from: simmer.markets/dashboard -> SDK tab")
             sys.exit(1)
-        _client = SimmerClient(api_key=api_key, venue="polymarket", live=live)
+        _client = SimmerClient(api_key=api_key, venue=resolve_venue(), live=live)
     return _client
+
+
+def resolve_effective_dry_run(dry_run: bool, client_venue) -> bool:
+    """
+    Compute the effective dry_run flag.
+
+    TRADING_VENUE=sim is documented paper mode: trades execute against the
+    Simmer venue with $SIM, so dry_run is disabled (sim IS the paper layer).
+    Belt-and-braces: that branch may only disable dry_run when the client's
+    effective venue really is "sim" — if the client would hit a real venue,
+    abort loudly instead of live-firing (SIM-3058).
+    """
+    is_paper_venue = resolve_venue() == "sim"
+    effective = dry_run and not is_paper_venue
+    if dry_run and not effective and client_venue != "sim":
+        print(
+            f"FATAL: TRADING_VENUE=sim disabled dry-run, but the client venue is "
+            f"{client_venue!r} (not 'sim') — refusing to live-fire a real venue.",
+            flush=True,
+        )
+        sys.exit(1)
+    return effective
+
+
+def should_run_balance_preflight(dry_run: bool) -> bool:
+    """USDC/pUSD balance preflight applies to live runs on real venues only —
+    the sim venue trades $SIM and has no collateral preflight."""
+    return not dry_run and resolve_venue() != "sim"
 
 
 # =============================================================================
@@ -323,10 +356,10 @@ def get_market_context(market_id: str) -> dict | None:
 
 
 def get_positions() -> list:
-    """Get current positions, filtered to polymarket venue."""
+    """Get current positions, filtered to the effective trading venue."""
     try:
         client = get_client()
-        positions = client.get_positions(venue="polymarket")
+        positions = client.get_positions(venue=resolve_venue())
         from dataclasses import asdict
         return [asdict(p) for p in positions]
     except Exception:
@@ -579,10 +612,10 @@ def main():
 
     # Balance pre-flight: skip cleanly when wallet is underfunded instead of
     # looping on rejected trades. Helper is collateral-agnostic — checks pUSD
-    # on V2, USDC.e on V1 per server's exchange_version.
+    # on V2, USDC.e on V1 per server's exchange_version. Sim venue ($SIM paper
+    # mode) has no collateral preflight — see should_run_balance_preflight().
     global MAX_BET_USD, _automaton_reported
-    is_paper_venue_pre = os.environ.get("TRADING_VENUE", "polymarket") == "sim"
-    if not dry_run and not is_paper_venue_pre:
+    if should_run_balance_preflight(dry_run):
         _preflight = get_client().ensure_can_trade(min_usd=1.0)
         if not _preflight["ok"]:
             print(f"  ⏸️  insufficient_balance: ${_preflight['balance']:.2f} {_preflight['collateral']} "
@@ -611,10 +644,12 @@ def main():
     if args.scan:
         return
 
-    is_paper_venue = os.environ.get("TRADING_VENUE", "polymarket") == "sim"
+    effective_dry_run = resolve_effective_dry_run(
+        dry_run, getattr(get_client(), "venue", None)
+    )
     signals, attempted, executed, skip_reasons, total_usd, execution_errors = run_trades(
         candidates,
-        dry_run=dry_run and not is_paper_venue,
+        dry_run=effective_dry_run,
         quiet=args.quiet,
     )
 

--- a/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
+++ b/skills/polymarket-nothing-ever-happens/nothing_ever_happens.py
@@ -605,14 +605,20 @@ def main():
     dry_run = not args.live
     get_client(live=not dry_run)  # Validate API key early
 
-    # Redeem any winning positions
-    try:
-        redeemed = get_client().auto_redeem()
-        for r in redeemed:
-            if r.get("success"):
-                print(f"  Redeemed {r['market_id'][:8]}... (NO)")
-    except Exception:
-        pass  # Non-critical
+    # Redeem any winning positions — LIVE polymarket runs only. auto_redeem()
+    # submits REAL Polymarket redemption transactions regardless of the
+    # client's venue, so paper mode (TRADING_VENUE=sim), dry-run, and --scan
+    # must never reach it (codex pass-2 P1; same class as wc-copytrader fix).
+    if args.live and not args.scan and resolve_venue() == "polymarket":
+        try:
+            redeemed = get_client().auto_redeem()
+            for r in redeemed:
+                if r.get("success"):
+                    print(f"  Redeemed {r['market_id'][:8]}... (NO)")
+        except Exception:
+            pass  # Non-critical
+    elif not args.quiet:
+        print("  (auto-redeem skipped: live polymarket runs only)")
 
     # Balance pre-flight: skip cleanly when wallet is underfunded instead of
     # looping on rejected trades. Helper is collateral-agnostic — checks pUSD

--- a/skills/polymarket-nothing-ever-happens/tests/test_paper_mode_venue.py
+++ b/skills/polymarket-nothing-ever-happens/tests/test_paper_mode_venue.py
@@ -190,3 +190,42 @@ class TestSimEnvExplicitLiveGuard(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAutoRedeemGating(unittest.TestCase):
+    """auto_redeem submits REAL Polymarket transactions regardless of client
+    venue — only live polymarket runs (not sim/paper, dry-run, or --scan)
+    may reach it (codex pass-2 P1)."""
+
+    def _run_main(self, argv, env):
+        with patch.dict(os.environ, env):
+            with patch.object(sys, "argv", ["nothing_ever_happens.py"] + argv):
+                neh._client = None
+                with patch.object(neh, "fetch_candidate_markets", return_value=[]):
+                    with patch.object(_sdk_stub, "SimmerClient") as MockClient:
+                        mock = MockClient.return_value
+                        mock.venue = env.get("TRADING_VENUE", "polymarket")
+                        mock.ensure_can_trade.return_value = {
+                            "ok": True, "max_safe_size": 999.0, "balance": 100.0}
+                        mock.auto_redeem.return_value = []
+                        try:
+                            neh.main()
+                        except SystemExit:
+                            pass
+                        return mock
+
+    def test_sim_env_never_calls_auto_redeem(self):
+        mock = self._run_main(["--live", "--quiet"], {"TRADING_VENUE": "sim", "SIMMER_API_KEY": "sk"})
+        mock.auto_redeem.assert_not_called()
+
+    def test_dry_run_never_calls_auto_redeem(self):
+        mock = self._run_main(["--quiet"], {"TRADING_VENUE": "polymarket", "SIMMER_API_KEY": "sk"})
+        mock.auto_redeem.assert_not_called()
+
+    def test_scan_never_calls_auto_redeem(self):
+        mock = self._run_main(["--scan", "--live", "--quiet"], {"TRADING_VENUE": "polymarket", "SIMMER_API_KEY": "sk"})
+        mock.auto_redeem.assert_not_called()
+
+    def test_live_polymarket_calls_auto_redeem(self):
+        mock = self._run_main(["--live", "--quiet"], {"TRADING_VENUE": "polymarket", "SIMMER_API_KEY": "sk"})
+        mock.auto_redeem.assert_called_once()

--- a/skills/polymarket-nothing-ever-happens/tests/test_paper_mode_venue.py
+++ b/skills/polymarket-nothing-ever-happens/tests/test_paper_mode_venue.py
@@ -170,5 +170,23 @@ class PositionsVenueTests(unittest.TestCase):
         self.assertEqual(kwargs.get("venue"), "sim")
 
 
+class TestSimEnvExplicitLiveGuard(unittest.TestCase):
+    """TRADING_VENUE=sim with --live (dry_run already False) must STILL
+    assert the client venue is sim before any live path (codex P1)."""
+
+    def test_sim_env_live_with_real_client_venue_aborts(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}):
+            with self.assertRaises(SystemExit):
+                neh.resolve_effective_dry_run(False, "polymarket")
+
+    def test_sim_env_live_with_sim_client_venue_proceeds(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}):
+            self.assertFalse(neh.resolve_effective_dry_run(False, "sim"))
+
+    def test_real_env_live_unaffected(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "polymarket"}):
+            self.assertFalse(neh.resolve_effective_dry_run(False, "polymarket"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/skills/polymarket-nothing-ever-happens/tests/test_paper_mode_venue.py
+++ b/skills/polymarket-nothing-ever-happens/tests/test_paper_mode_venue.py
@@ -1,0 +1,174 @@
+"""
+Regression tests for the paper-mode live-fire bug (SIM-3058 audit).
+
+Bug: the client was constructed with hardcoded venue="polymarket" while
+TRADING_VENUE=="sim" (the documented $SIM paper switch, SKILL.md) skipped the
+balance preflight AND forced dry_run off — so "paper mode" live-fired real
+Polymarket trades with the preflight disabled.
+
+Verifies:
+  - TRADING_VENUE=sim  -> SimmerClient constructed with venue="sim"
+  - TRADING_VENUE unset/polymarket -> venue="polymarket"
+  - resolve_effective_dry_run(): the sim branch may only disable dry_run when
+    the client's effective venue really is "sim"; if the client is on a real
+    venue, it aborts loudly (SystemExit) instead of live-firing.
+  - TRADING_VENUE unset/polymarket -> dry_run is unaffected by the sim branch.
+  - Balance preflight runs for live real-venue runs, is skipped for sim
+    (sim has no USDC preflight) and for dry runs.
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import io
+import os
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "price_cap": 0.10,
+    "max_bet_usd": 5.0,
+    "max_trades_per_run": 3,
+    "daily_budget": 15.0,
+    "min_liquidity": 500.0,
+    "min_volume_24h": 100.0,
+    "candidate_pages": 20,
+}
+
+# Stub simmer_sdk before importing the skill module. Installed persistently in
+# sys.modules (not a context manager) because get_client() does a lazy
+# `from simmer_sdk import SimmerClient` at call time, inside each test.
+_sdk_stub = types.ModuleType("simmer_sdk")
+_sdk_stub.SimmerClient = MagicMock(name="SimmerClient")
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = _sdk_stub
+sys.modules["simmer_sdk.skill"] = _skill_stub
+
+import nothing_ever_happens as neh  # noqa: E402
+
+
+class VenueThreadingTests(unittest.TestCase):
+    """TRADING_VENUE must reach the SimmerClient constructor."""
+
+    def setUp(self):
+        neh._client = None
+        _sdk_stub.SimmerClient.reset_mock()
+
+    def tearDown(self):
+        neh._client = None
+
+    def test_sim_venue_constructs_client_with_sim(self):
+        env = {"SIMMER_API_KEY": "test-key", "TRADING_VENUE": "sim"}
+        with patch.dict(os.environ, env, clear=False):
+            neh.get_client(live=True)
+        _, kwargs = _sdk_stub.SimmerClient.call_args
+        self.assertEqual(kwargs.get("venue"), "sim")
+
+    def test_unset_venue_defaults_to_polymarket(self):
+        env = {"SIMMER_API_KEY": "test-key"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("TRADING_VENUE", None)
+            neh.get_client(live=True)
+        _, kwargs = _sdk_stub.SimmerClient.call_args
+        self.assertEqual(kwargs.get("venue"), "polymarket")
+
+    def test_explicit_polymarket_venue(self):
+        env = {"SIMMER_API_KEY": "test-key", "TRADING_VENUE": "polymarket"}
+        with patch.dict(os.environ, env, clear=False):
+            neh.get_client(live=True)
+        _, kwargs = _sdk_stub.SimmerClient.call_args
+        self.assertEqual(kwargs.get("venue"), "polymarket")
+
+
+class EffectiveDryRunTests(unittest.TestCase):
+    """The sim paper branch must never disable dry_run on a real venue."""
+
+    def test_sim_branch_disables_dry_run_when_client_is_sim(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}, clear=False):
+            self.assertFalse(
+                neh.resolve_effective_dry_run(dry_run=True, client_venue="sim")
+            )
+
+    def test_sim_branch_aborts_when_client_is_polymarket(self):
+        # Belt-and-braces: TRADING_VENUE=sim would disable dry_run, but the
+        # client's effective venue is a real venue -> abort loudly.
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}, clear=False):
+            buf = io.StringIO()
+            with self.assertRaises(SystemExit), redirect_stdout(buf):
+                neh.resolve_effective_dry_run(dry_run=True, client_venue="polymarket")
+            self.assertIn("refus", buf.getvalue().lower())
+
+    def test_sim_branch_aborts_when_client_venue_unknown(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}, clear=False):
+            with self.assertRaises(SystemExit), redirect_stdout(io.StringIO()):
+                neh.resolve_effective_dry_run(dry_run=True, client_venue=None)
+
+    def test_unset_venue_leaves_dry_run_untouched(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TRADING_VENUE", None)
+            self.assertTrue(
+                neh.resolve_effective_dry_run(dry_run=True, client_venue="polymarket")
+            )
+
+    def test_polymarket_venue_leaves_dry_run_untouched(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "polymarket"}, clear=False):
+            self.assertTrue(
+                neh.resolve_effective_dry_run(dry_run=True, client_venue="polymarket")
+            )
+
+    def test_explicit_live_stays_live_on_polymarket_without_abort(self):
+        # --live on a real venue is the user's explicit choice; no sim branch
+        # involvement, no abort.
+        with patch.dict(os.environ, {"TRADING_VENUE": "polymarket"}, clear=False):
+            self.assertFalse(
+                neh.resolve_effective_dry_run(dry_run=False, client_venue="polymarket")
+            )
+
+
+class PreflightGateTests(unittest.TestCase):
+    """Balance preflight runs for live real-venue runs only."""
+
+    def test_preflight_runs_live_polymarket(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "polymarket"}, clear=False):
+            self.assertTrue(neh.should_run_balance_preflight(dry_run=False))
+
+    def test_preflight_runs_live_unset_venue(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TRADING_VENUE", None)
+            self.assertTrue(neh.should_run_balance_preflight(dry_run=False))
+
+    def test_preflight_skipped_for_sim(self):
+        # sim has no USDC preflight — skipping is correct once venue is real.
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}, clear=False):
+            self.assertFalse(neh.should_run_balance_preflight(dry_run=False))
+
+    def test_preflight_skipped_for_dry_run(self):
+        with patch.dict(os.environ, {"TRADING_VENUE": "polymarket"}, clear=False):
+            self.assertFalse(neh.should_run_balance_preflight(dry_run=True))
+
+
+class PositionsVenueTests(unittest.TestCase):
+    """Position dedup must look at the effective venue, not hardcoded polymarket."""
+
+    def tearDown(self):
+        neh._client = None
+
+    def test_get_positions_uses_effective_venue(self):
+        fake_client = MagicMock()
+        fake_client.get_positions.return_value = []
+        neh._client = fake_client
+        with patch.dict(os.environ, {"TRADING_VENUE": "sim"}, clear=False):
+            neh.get_positions()
+        _, kwargs = fake_client.get_positions.call_args
+        self.assertEqual(kwargs.get("venue"), "sim")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Urgent: paper-mode live-fire bug (SIM-3058 audit; Paperclip 5c54f8e0-8688-40ff-b547-a9e452d19dae)

### The bug
`skills/polymarket-nothing-ever-happens/nothing_ever_happens.py` constructed the client with hardcoded `venue="polymarket"` and trades omitted `venue=`, while `TRADING_VENUE=sim` — documented in SKILL.md as the $SIM paper switch — both **skipped the balance preflight** and **forced `dry_run` off**. Net effect: the documented paper switch live-fired real Polymarket trades with the preflight disabled.

### The fix (mirrors the safe `polymarket-ai-divergence` pattern)
- **`resolve_venue()`** — `TRADING_VENUE` env is threaded into the `SimmerClient` constructor (`nothing_ever_happens.py:135`), so `venue=sim` actually trades on the sim venue. `client.trade()` inherits the client's default venue (SDK `trade(venue=None)` semantics); `get_positions()` dedup now also filters on the effective venue (`:362`).
- **`resolve_effective_dry_run()`** (`:138`) — with the venue now real, the sim branch disabling `dry_run` is correct paper-mode design (sim IS the paper layer). Belt-and-braces: it may only disable `dry_run` when the client's effective venue really is `"sim"`; otherwise it aborts loudly (`SystemExit`) instead of live-firing a real venue.
- **`should_run_balance_preflight()`** (`:161`) — USDC/pUSD preflight runs for live real-venue runs; sim is correctly exempt ($SIM has no collateral preflight). Dry runs skip as before.
- **SKILL.md** — version `1.0.3` → `1.0.4`; `TRADING_VENUE` documented in the config table.

### Tests (TDD, red-first)
New `tests/test_paper_mode_venue.py` (pure-unit, no network / no API key, mirrors the mert-sniper test layout):
- `TRADING_VENUE=sim` → client constructed with `venue="sim"`; unset/explicit `polymarket` → `venue="polymarket"`
- sim branch + client on a real venue (or unknown) → loud abort, no live fire
- `TRADING_VENUE` unset/`polymarket` → `dry_run` unaffected by the sim branch; preflight runs for live runs
- positions dedup uses the effective venue

`python3 -m pytest tests/` in the skill dir: **14 passed** (was 12 failed / 2 passed pre-fix). `py_compile` clean.

### Publish note
`clawhub.json` has `"publish": false` (SDK reference skill, not on ClawHub). Version bumped regardless; any ClawHub republish is **Adrian-gated** — do not publish from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)