### PR TITLE
feat(client): SIMMER_API_URL env override for base_url (SIM-3070)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.29"
+version = "0.17.30"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -222,7 +222,7 @@ class SimmerClient:
     def __init__(
         self,
         api_key: str,
-        base_url: str = "https://api.simmer.markets",
+        base_url: Optional[str] = None,
         venue: str = "sim",
         private_key: Optional[str] = None,
         ows_wallet: Optional[str] = None,
@@ -234,7 +234,11 @@ class SimmerClient:
 
         Args:
             api_key: Your SDK API key (sk_live_...)
-            base_url: API base URL (default: production)
+            base_url: API base URL. Resolution order: this argument, then the
+                SIMMER_API_URL environment variable, then production
+                (https://api.simmer.markets). The env override exists so
+                harnesses (e.g. Simmer's replay engine) can redirect an
+                unmodified skill to a local server without code changes.
             venue: Trading venue (default: "sim")
                 - "sim": Trade on Simmer's LMSR market with $SIM (virtual currency)
                 - "polymarket": Execute real trades on Polymarket CLOB with USDC
@@ -293,6 +297,10 @@ class SimmerClient:
             venue = "sim"
 
         self.api_key = api_key
+        # base_url resolution: explicit arg > SIMMER_API_URL env > production.
+        # Additive (SIM-3070): lets harnesses redirect unmodified skills.
+        if base_url is None:
+            base_url = os.getenv("SIMMER_API_URL") or "https://api.simmer.markets"
         self.base_url = base_url.rstrip("/")
         # Enforce HTTPS so the API key (Authorization: Bearer) and the EIP-712
         # batches we sign can't be read or tampered with on the wire. A plain

--- a/tests/test_base_url_env_override.py
+++ b/tests/test_base_url_env_override.py
@@ -1,0 +1,39 @@
+"""SIM-3070: base_url resolution — explicit arg > SIMMER_API_URL env > production.
+
+The env override lets harnesses (replay engine) redirect an UNMODIFIED skill
+to a local server. Loopback http is already allowed by the HTTPS guard.
+"""
+
+import os
+
+import pytest
+
+from simmer_sdk import SimmerClient
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("SIMMER_API_URL", raising=False)
+
+
+def test_explicit_arg_wins(monkeypatch):
+    monkeypatch.setenv("SIMMER_API_URL", "http://127.0.0.1:1")
+    c = SimmerClient(api_key="sk_test", base_url="http://localhost:9999", live=False)
+    assert c.base_url == "http://localhost:9999"
+
+
+def test_env_overrides_default(monkeypatch):
+    monkeypatch.setenv("SIMMER_API_URL", "http://127.0.0.1:8123")
+    c = SimmerClient(api_key="sk_test", live=False)
+    assert c.base_url == "http://127.0.0.1:8123"
+
+
+def test_default_is_production():
+    c = SimmerClient(api_key="sk_test", live=False)
+    assert c.base_url == "https://api.simmer.markets"
+
+
+def test_non_loopback_http_still_rejected(monkeypatch):
+    monkeypatch.setenv("SIMMER_API_URL", "http://evil.example.com")
+    with pytest.raises(ValueError, match="https"):
+        SimmerClient(api_key="sk_test", live=False)


### PR DESCRIPTION
Additive base-url resolution: explicit `base_url` arg > `SIMMER_API_URL` env > production default. Exists so Simmer's replay engine (SIM-3070) can point an **unmodified** skill bundle at a local replay server — the moat claim requires zero skill changes, and the client previously had no env path. Security posture unchanged: the existing HTTPS guard still rejects non-loopback http (test included). 4 new tests; version 0.17.30 (no PyPI publish yet — rides the next release train; the replay harness consumes the repo directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)