### PR TITLE
fix(client): registered raw-key per-agent wallets skip user-level auto-link (0.17.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **`polymarket-fast-scaler` skill published to ClawHub at v1.0.0.** Magnitude-gated BTC 5-minute fast-market strategy. Fires only when |1m BTC momentum| ≥ 0.10% — the EV-positive regime validated by backtest. Position sizes across 3 conviction tiers ($3/$5/$10). Live-tested for 48h on a real Polymarket wallet; trades filled and budget cap honored. Available via `clawhub install polymarket-fast-scaler`.
 - **`polymarket-worldcup-copytrader` skill — World Cup Copytrader (Regular mode).** New skill that copies the auto-curated top World Cup traders on Polymarket. Unlike the base `polymarket-copytrading` skill (which requires a manual wallet list), this skill fetches the wallet list automatically from Simmer's daily curation endpoint: PolyNode top-traders → slippage-adjusted copy-PnL screen → top-10 copyable WC sharps. Portfolio-level, size-weighted aggregation across all leaders; conflict detection; drift/stale filters. Dry-run default; sim-first (`--venue sim`) before any real USDC. Category: `world-cup`. Sensitivity: `sensitive` (novel-risk automation — copytrading executes without per-trade approval).
 
+## [0.17.30] - 2026-06-11
+
+### Fixed
+
+- **Raw-key registered per-agent wallets no longer hang in the user-level auto-link path.** The `registered_agent_wallet` gate in `trade()` required an OWS wallet, so a dedicated per-agent wallet registered with a raw key (`WALLET_PRIVATE_KEY` / `private_key=`, the SIM-2897 browser/Phantom cohort) fell into `_ensure_wallet_linked()` — which saw the agent EOA didn't match the account's linked wallet and tried to auto-link over it, hanging indefinitely in the link flow (and, had it succeeded, orphaning the account's primary deposit wallet — CREATE2 binds the DW to its owner EOA). Registered raw-key wallets now take the same per-agent branch as OWS: skip user-level link, fetch DW routing flags from `/api/sdk/agents/me`, and inject `wallet_address` into trade payloads for per-agent attribution. "Dedicated" and "OWS" are orthogonal — the `user_agent_wallets` registration row is what routes, not the signing-key flavor. Surfaced by the johng `insider-bets-live` redemption investigation (the wrong-signer half of that incident was fixed server-side in simmer PR #1223).
+
 ## [0.17.29] - 2026-06-10
 
 ### Security

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1226,8 +1226,8 @@ class SimmerClient:
     def _load_per_agent_dw_state(self) -> None:
         """Populate DW routing flags from /api/sdk/agents/me for per-agent wallets.
 
-        Registered per-agent OWS wallets skip _ensure_wallet_linked() (to avoid
-        the user-level re-link path), but _build_signed_order() needs
+        Registered per-agent wallets (OWS or raw-key) skip _ensure_wallet_linked()
+        (to avoid the user-level re-link path), but _build_signed_order() needs
         _uses_deposit_wallet and _deposit_wallet_address for sig-type selection.
         Fetches from the same endpoint preflight() uses. Cached for the session.
         """
@@ -1759,17 +1759,25 @@ class SimmerClient:
             payload["price"] = price
 
         registered_agent_wallet = (
-            self._ows_wallet
+            (self._ows_wallet or self._private_key)
             and self._wallet_address
             and self._is_agent_wallet_registered()
         )
 
         # Include wallet_address only for users who explicitly opted into per-agent
-        # wallet attribution by registering this OWS wallet (Elite feature).
-        # Otherwise the server would reject with "Agent wallet not found" because
-        # the wallet has no row in user_agent_wallets — but the user-level
-        # linked_wallet_address path still works fine. Don't conflate "OWS configured"
-        # with "wants per-agent isolation."
+        # wallet attribution by registering this wallet (Elite feature) — OWS or
+        # raw-key, the registration row is what matters ("dedicated" and "OWS" are
+        # orthogonal, SIM-2897). Otherwise the server would reject with "Agent
+        # wallet not found" because the wallet has no row in user_agent_wallets —
+        # but the user-level linked_wallet_address path still works fine. Don't
+        # conflate "signing key configured" with "wants per-agent isolation."
+        #
+        # The raw-key arm was added 2026-06-11: a registered raw-key per-agent
+        # wallet previously failed this check and fell into the user-level
+        # _ensure_wallet_linked() below, which tried to auto-link the agent EOA
+        # over the account's primary wallet — hanging in the link flow and, had
+        # it succeeded, orphaning the primary deposit wallet (CREATE2 binds DW
+        # to owner EOA). Same OWS/raw-key asymmetry class as SIM-2899/2900.
         if registered_agent_wallet:
             payload["wallet_address"] = self._wallet_address
 

--- a/tests/test_agent_wallets_sdk.py
+++ b/tests/test_agent_wallets_sdk.py
@@ -311,6 +311,50 @@ class TestTradeWalletAddress:
         assert payload["wallet_address"] == "0x1234567890abcdef1234567890abcdef12345678"
         assert payload["signed_order"] == {"signed": "order"}
 
+    def test_registered_raw_key_polymarket_trade_skips_user_level_auto_link(self):
+        """Raw-key registered per-agent wallets must skip auto-link too.
+
+        Regression for the johng insider-bets-live hang (2026-06-11): the
+        registered_agent_wallet gate required self._ows_wallet, so a
+        browser/raw-key dedicated wallet (SIM-2897 cohort) fell into the
+        user-level _ensure_wallet_linked() — which tried to auto-link the
+        agent EOA over the account's primary wallet and hung. "Dedicated"
+        and "OWS" are orthogonal; the registration row is what matters.
+        """
+        client = _make_client(
+            private_key="0x" + "11" * 32,
+            wallet_address="0x1234567890abcdef1234567890abcdef12345678",
+        )
+        client._agent_wallet_registered = True
+        client._request.return_value = {
+            "success": True,
+            "market_id": "test-market",
+            "side": "yes",
+            "shares_bought": 10.0,
+            "cost": 5.0,
+            "new_price": 0.5,
+            "fill_status": "filled",
+        }
+        client._get_held_markets = MagicMock(return_value={})
+        client._ensure_wallet_linked = MagicMock(
+            side_effect=RuntimeError(
+                "Cannot re-link: your current external wallet has open positions on Polymarket."
+            )
+        )
+        client._load_per_agent_dw_state = MagicMock()
+        client._warn_approvals_once = MagicMock()
+        client._build_signed_order = MagicMock(return_value={"signed": "order"})
+
+        result = client.trade("test-market", "yes", amount=10.0, venue="polymarket")
+
+        assert result.success is True
+        client._ensure_wallet_linked.assert_not_called()
+        client._load_per_agent_dw_state.assert_called_once()
+        call_args = client._request.call_args
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert payload["wallet_address"] == "0x1234567890abcdef1234567890abcdef12345678"
+        assert payload["signed_order"] == {"signed": "order"}
+
     def test_registered_ows_populates_dw_state_from_agents_me(self):
         """_load_per_agent_dw_state must populate _uses_deposit_wallet and
         _deposit_wallet_address so _build_signed_order picks sig type 3."""


### PR DESCRIPTION
## Why

Second half of the johng `insider-bets-live` redemption incident (first half: simmer #1223, deployed — its new signer-mismatch 400 is what surfaced this). With `OWS_WALLET` removed per our guidance, his raw-key attempts hung: **`_ensure_wallet_linked` blocks indefinitely** when `WALLET_PRIVATE_KEY` (or `private_key=`) is set for a registered per-agent wallet.

Root cause: the `registered_agent_wallet` gate in `trade()` required `self._ows_wallet`. A **raw-key** dedicated per-agent wallet (SIM-2897 browser/Phantom cohort) failed the gate and fell into the user-level `_ensure_wallet_linked()` — which saw the agent EOA (`0xf129…`) ≠ the account's linked wallet (`0xa503…`) and attempted to auto-link over it. That hangs in the link flow, and had it succeeded it would have relinked the user's primary EOA — orphaning their primary deposit wallet (CREATE2 binds DW↔owner EOA). Same OWS/raw-key asymmetry class as SIM-2899/2900/2901, SDK side.

## What

- `registered_agent_wallet` now accepts `self._ows_wallet or self._private_key` — the `user_agent_wallets` registration row is what routes, not the signing-key flavor ("dedicated" and "OWS" are orthogonal, Adrian decision 2026-06-04).
- Registered raw-key wallets take the per-agent branch: skip user-level link, `_load_per_agent_dw_state()` for DW routing flags, `wallet_address` injected into trade payloads.
- Version 0.17.30 + changelog.

## Tests

New `test_registered_raw_key_polymarket_trade_skips_user_level_auto_link` (raw-key mirror of the existing OWS skip test — `_ensure_wallet_linked` raises if called). Touched suites green: `test_agent_wallets_sdk` (20), `test_link_wallet_confirm_replace_managed`, `test_cred_recovery_retry`. The 4 `test_client_constructors` failures are pre-existing on main (env-dependent real-OWS lookups; fail with this change stashed).

## Unblocks

johng's `insider-bets-live` (~$315 redeemable): on 0.17.30, `SimmerClient(api_key=…, private_key=<phantom key>)` + `auto_redeem()` signs with the correct EOA and never enters the link path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)