### PR TITLE
fix: route BTC up-down skill live trades through trade API

### DIFF
--- a/skills/polymarket-btc-up-down-trader/SKILL.md
+++ b/skills/polymarket-btc-up-down-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-btc-up-down-trader
 description: Trade Polymarket BTC daily and weekly UP/DOWN markets with empirically-anchored exit discipline. Enters on CEX momentum divergence; exits automatically on time cap, volume spike, or target capture. Use when the user wants to trade BTC direction markets (hours/days duration), not fast 5-minute markets.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.1"
+  version: "1.0.2"
   displayName: Polymarket BTC Up-Down Trader
   difficulty: intermediate
 ---

--- a/skills/polymarket-btc-up-down-trader/strategy.py
+++ b/skills/polymarket-btc-up-down-trader/strategy.py
@@ -661,11 +661,14 @@ def run_exit_monitor(client, live=False, quiet=False):
             print(f"  🚪 EXIT triggered: {exit_reason} | {details}")
             if live:
                 try:
-                    result = client.sell(
+                    result = client.trade(
                         market_id=market_id,
-                        side=side,
-                        quantity=quantity,
+                        side=side.lower(),
+                        action="sell",
+                        shares=quantity,
+                        venue="polymarket",
                         source=TRADE_SOURCE,
+                        skill_slug=SKILL_SLUG,
                     )
                     log_trade(
                         market_id=market_id,
@@ -779,11 +782,14 @@ def run_entry_scan(client, live=False, quiet=False):
 
         if live:
             try:
-                result = client.buy(
+                result = client.trade(
                     market_id=market_id,
-                    side=side,
-                    amount_usd=trade_size,
+                    side=side.lower(),
+                    action="buy",
+                    amount=trade_size,
+                    venue="polymarket",
                     source=TRADE_SOURCE,
+                    skill_slug=SKILL_SLUG,
                 )
                 log_trade(
                     market_id=market_id,

--- a/skills/polymarket-btc-up-down-trader/tests/test_exits.py
+++ b/skills/polymarket-btc-up-down-trader/tests/test_exits.py
@@ -435,5 +435,87 @@ class TestEntryEdgeSemantics(unittest.TestCase):
         self.assertGreater(self._edge_down(0.60), threshold)  # YES at 0.60, down momentum
 
 
+class TestLiveTradeCalls(unittest.TestCase):
+    """Regression coverage for live execution using SimmerClient.trade()."""
+
+    def setUp(self):
+        strat.DAILY_BUDGET = 50.0
+        strat.MAX_POSITION_USD = 10.0
+        strat.MIN_MOMENTUM_PCT = 0.3
+        strat.MIN_HOURS_TO_RESOLUTION = 4.0
+        strat.ENTRY_THRESHOLD = 0.05
+
+    def test_exit_monitor_sells_with_client_trade(self):
+        class ClientWithoutSell:
+            def __init__(self):
+                self.trade = MagicMock(return_value={"success": True})
+
+            def get_positions(self):
+                return [
+                    {
+                        "marketId": "mkt_exit",
+                        "side": "YES",
+                        "quantity": 3.25,
+                        "source": strat.TRADE_SOURCE,
+                    }
+                ]
+
+        client = ClientWithoutSell()
+        market_data = {
+            "question": "Bitcoin up or down?",
+            "endDate": (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat(),
+            "clobTokenIds": ["yes_token", "no_token"],
+        }
+
+        with patch.object(strat, "_api_request", return_value=market_data), \
+             patch.object(strat, "evaluate_exit_triggers", return_value=(True, "time_cap", {"hours": 2})), \
+             patch.object(strat, "log_trade"):
+            closed = strat.run_exit_monitor(client, live=True, quiet=True)
+
+        self.assertEqual(closed, 1)
+        client.trade.assert_called_once_with(
+            market_id="mkt_exit",
+            side="yes",
+            action="sell",
+            shares=3.25,
+            venue="polymarket",
+            source=strat.TRADE_SOURCE,
+            skill_slug=strat.SKILL_SLUG,
+        )
+
+    def test_entry_scan_buys_with_client_trade(self):
+        class ClientWithoutBuy:
+            def __init__(self):
+                self.trade = MagicMock(return_value={"success": True})
+
+        client = ClientWithoutBuy()
+        market = {
+            "conditionId": "mkt_entry",
+            "question": "Bitcoin up or down?",
+            "clobTokenIds": ["yes_token", "no_token"],
+            "_hours_to_resolution": 8.0,
+            "_end_dt": datetime.now(timezone.utc) + timedelta(hours=8),
+        }
+
+        with patch.object(strat, "_load_daily_spend", return_value={"spent": 0.0, "trades": 0}), \
+             patch.object(strat, "_save_daily_spend"), \
+             patch.object(strat, "fetch_btc_momentum", return_value=(0.8, "up", 100000.0)), \
+             patch.object(strat, "fetch_btc_updown_markets", return_value=[market]), \
+             patch.object(strat, "fetch_live_midpoint", return_value=0.40), \
+             patch.object(strat, "log_trade"):
+            entered = strat.run_entry_scan(client, live=True, quiet=True)
+
+        self.assertEqual(entered, 1)
+        client.trade.assert_called_once_with(
+            market_id="mkt_entry",
+            side="yes",
+            action="buy",
+            amount=10.0,
+            venue="polymarket",
+            source=strat.TRADE_SOURCE,
+            skill_slug=strat.SKILL_SLUG,
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- replace nonexistent `client.buy()` / `client.sell()` calls in `polymarket-btc-up-down-trader` live paths with `client.trade(...)`
- pass SDK-valid buy/sell args, explicit `venue="polymarket"`, and `skill_slug` attribution
- bump skill metadata to `1.0.2` and publish `polymarket-btc-up-down-trader@1.0.2` to ClawHub

## Verification
- `python3 -m pytest skills/polymarket-btc-up-down-trader/tests/test_exits.py`
- `rg -n "client\.(buy|sell)\(" skills/polymarket-btc-up-down-trader -S` returned no matches
- `npx --yes clawhub@latest inspect polymarket-btc-up-down-trader` shows `Latest: 1.0.2`
- installed ClawHub copy verifies `version: "1.0.2"` and `strategy.py` live call sites use `client.trade(...)`

ClawHub version id: `k973mwebyxhexxk03rtp7j5h1s88e3v6`

Closes SIM-3093