### PR TITLE
chore(release): cut 0.17.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.31] - 2026-06-12
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.30"
+version = "0.17.31"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Version bump + CHANGELOG cut for the 0.17.31 release: get_markets() keyword-only venue/sort/tags (#196), fast-scaler + worldcup-copytrader skills, copytrading --venue fix.

Refs SIM-3124, SIM-3125

🤖 Generated with [Claude Code](https://claude.com/claude-code)