### PR TITLE
fix(mert-sniper): prefer API seconds_to_resolution over wall-clock (1.3.3)

### DIFF
--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes, filters for strongly-skewed splits (60/40+), and places bounded trades against the under-priced side. Defaults — $10 max per trade, 5 trades/run, 8-minute expiry window, dry-run unless `--live`.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.2"
+  version: "1.3.3"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/clawhub.json
+++ b/skills/polymarket-mert-sniper/clawhub.json
@@ -6,7 +6,7 @@
       "SIMMER_API_KEY"
     ],
     "pip": [
-      "simmer-sdk>=0.11.1"
+      "simmer-sdk>=0.17.25"
     ]
   },
   "envVars": [

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -18,6 +18,7 @@ Requires:
 import os
 import sys
 import json
+import math
 import re
 import argparse
 from datetime import datetime, timezone, timedelta
@@ -493,17 +494,16 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
             continue
 
         resolves_at = parse_resolves_at(market.get("resolves_at"))
+        if not resolves_at:
+            continue
 
-        minutes_remaining = None
+        # Strict numeric check: bool is an int subclass (float(True) would read
+        # as ~1s to expiry), and strings/NaN/inf signal a schema bug — all of
+        # those fall back to the wall-clock path instead of being trusted.
         secs = market.get("seconds_to_resolution")
-        if secs is not None:
-            try:
-                minutes_remaining = float(secs) / 60
-            except (TypeError, ValueError):
-                minutes_remaining = None
-        if minutes_remaining is None:
-            if not resolves_at:
-                continue
+        if isinstance(secs, (int, float)) and not isinstance(secs, bool) and math.isfinite(secs):
+            minutes_remaining = secs / 60
+        else:
             minutes_remaining = (resolves_at - now).total_seconds() / 60
 
         # Must be within window and not already past

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -479,7 +479,10 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
         print("  No markets available")
         return
 
-    # Filter by expiry window
+    # Filter by expiry window. Prefer the API's server-computed
+    # seconds_to_resolution over local wall-clock: immune to host clock skew,
+    # and deterministic under replay (where "now" is the server's frozen tick,
+    # not this process's datetime.now()).
     now = datetime.now(timezone.utc)
     expiring_markets = []
 
@@ -490,10 +493,18 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
             continue
 
         resolves_at = parse_resolves_at(market.get("resolves_at"))
-        if not resolves_at:
-            continue
 
-        minutes_remaining = (resolves_at - now).total_seconds() / 60
+        minutes_remaining = None
+        secs = market.get("seconds_to_resolution")
+        if secs is not None:
+            try:
+                minutes_remaining = float(secs) / 60
+            except (TypeError, ValueError):
+                minutes_remaining = None
+        if minutes_remaining is None:
+            if not resolves_at:
+                continue
+            minutes_remaining = (resolves_at - now).total_seconds() / 60
 
         # Must be within window and not already past
         if 0 < minutes_remaining <= expiry_mins:


### PR DESCRIPTION
## Summary
- Fixes the wall-clock leak in mert-sniper's expiry filter (the `replayable='partial'` blocker from the SIM-3070 seed run): `minutes_remaining` now prefers the server-computed `seconds_to_resolution` field when present, falling back to the existing `resolves_at` vs `datetime.now()` path for API responses that don't include it (the live API today).
- Under replay, the replay server serves `seconds_to_resolution` derived from the frozen tick, so the decision becomes deterministic. In live, behavior is unchanged until the API grows the field — at which point the skill also becomes immune to host clock skew.
- Bumps `clawhub.json` pip floor `simmer-sdk>=0.11.1` → `>=0.17.25`: the news-recency veto (#161, merged but not yet published) added a top-level import of `simmer_sdk.guards.news_recency_veto`, which first shipped on PyPI in 0.17.25. Without the bump, publishing 1.3.3 would crash older installs at import.
- SKILL.md version → 1.3.3. Publishing this version to ClawHub also ships the two merged-but-unpublished changes (news veto default-off #161, expiry-window doc fix #151).

## Test plan
- `python3 -m pytest skills/polymarket-mert-sniper/tests/` — 6 passed
- Full suite: 417 passed; 4 failures in `test_client_constructors.py` pre-exist on main (verified via stash), unrelated OWS constructor tests
- Post-merge: republish 1.3.3 to ClawHub, re-run the SIM-3070 minute-cadence seed against the published bundle (recipe in `simmer/_dev/active/_skill-intelligence/pilot-reports/seed-runs-2026-06-12.md`)

Refs SIM-3070

🤖 Generated with [Claude Code](https://claude.com/claude-code)