### PR TITLE
feat(sdk): client.get_candles — data-plane candles helper (Refs SIM-3070)

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1523,6 +1523,99 @@ class SimmerClient:
 
         return [self._parse_market(m) for m in data.get("markets", [])]
 
+    def get_candles(
+        self,
+        symbol: str,
+        start: str,
+        end: str,
+        *,
+        interval: str = "1m",
+        allow_live_fallback: bool = True,
+    ) -> List[dict]:
+        """
+        Historical closed OHLCV candles from Simmer's data plane (SIM-3070).
+
+        One code path live AND under replay: the server serves archived
+        Binance klines (closed candles only — never an in-progress candle);
+        under replay the same endpoint is clamped to the frozen tick. Prefer
+        this over calling Binance directly in skill decision logic — direct
+        ``urlopen(api.binance.com)`` makes a skill non-replayable (the
+        fast-scaler look-ahead retraction came from exactly that class).
+
+        Args:
+            symbol: e.g. "BTCUSDT" (server-side allowlist)
+            start/end: ISO timestamps (UTC assumed when naive)
+            interval: "1m" (v1)
+            allow_live_fallback: when the SERVER says its archive coverage
+                ends before ``end`` (``complete: false``), fetch the uncovered
+                tail from live Binance — closed candles only. The replay
+                server always answers ``complete: true``, so the fallback can
+                never fire under replay (no look-ahead path). Set False for
+                strictly-archived data.
+
+        Returns:
+            List of candle dicts: open_time, close_time (ISO), open, high,
+            low, close, volume — ascending by open_time.
+        """
+        data = self._request(
+            "GET", "/api/replay-data/candles",
+            params={"symbol": symbol, "interval": interval, "start": start, "end": end},
+        )
+        candles = list(data.get("candles") or [])
+        if data.get("complete") or not allow_live_fallback:
+            return candles
+
+        tail = self._live_binance_tail(
+            data.get("symbol") or symbol.upper(), interval,
+            data.get("served_through") or start, end,
+        )
+        return candles + tail
+
+    @staticmethod
+    def _live_binance_tail(symbol: str, interval: str, start: str, end: str) -> List[dict]:
+        """Closed candles from live Binance for the archive-uncovered tail.
+
+        Mirrors the server's closed-candle rule client-side: a candle whose
+        close_time is in the future (in progress) is dropped — its final
+        OHLCV would be look-ahead relative to now. Errors degrade to an
+        empty tail (the archived head is still returned).
+        """
+        import json as _json
+        import urllib.parse as _up
+        import urllib.request as _ur
+        from datetime import datetime as _dt, timezone as _tz
+
+        def _ms(s):
+            d = _dt.fromisoformat(str(s).replace("Z", "+00:00"))
+            if d.tzinfo is None:
+                d = d.replace(tzinfo=_tz.utc)
+            return int(d.timestamp() * 1000)
+
+        try:
+            params = _up.urlencode({
+                "symbol": symbol, "interval": interval,
+                "startTime": _ms(start), "endTime": _ms(end), "limit": 1000,
+            })
+            req = _ur.Request(f"https://api.binance.com/api/v3/klines?{params}",
+                              headers={"User-Agent": "simmer-sdk"})
+            with _ur.urlopen(req, timeout=15) as resp:
+                rows = _json.loads(resp.read().decode())
+            now_ms = _dt.now(_tz.utc).timestamp() * 1000
+            out = []
+            for r in rows:
+                open_ms, close_ms = int(r[0]), int(r[6])
+                if close_ms > now_ms:
+                    continue  # in-progress candle — look-ahead, drop
+                out.append({
+                    "open_time": _dt.fromtimestamp(open_ms / 1000, tz=_tz.utc).isoformat(),
+                    "close_time": _dt.fromtimestamp(close_ms / 1000, tz=_tz.utc).isoformat(),
+                    "open": float(r[1]), "high": float(r[2]), "low": float(r[3]),
+                    "close": float(r[4]), "volume": float(r[5]),
+                })
+            return out
+        except Exception:
+            return []
+
     def get_fast_markets(
         self,
         asset: Optional[str] = None,

--- a/tests/test_get_candles.py
+++ b/tests/test_get_candles.py
@@ -1,0 +1,79 @@
+"""client.get_candles — data-plane consumption contract (SIM-3070 1.5C)."""
+
+from unittest.mock import patch
+
+from simmer_sdk.client import SimmerClient
+
+
+def _client():
+    return SimmerClient(api_key="sk_test", venue="polymarket")
+
+
+def test_complete_response_returns_candles_no_fallback():
+    c = _client()
+    payload = {"complete": True, "symbol": "BTCUSDT",
+               "candles": [{"open_time": "t", "close": 0.5}]}
+    with patch.object(c, "_request", return_value=payload) as req, \
+         patch.object(SimmerClient, "_live_binance_tail") as tail:
+        out = c.get_candles("BTCUSDT", "2026-04-15T12:00:00", "2026-04-15T16:00:00")
+    assert out == payload["candles"]
+    tail.assert_not_called()
+    assert req.call_args[0][1] == "/api/replay-data/candles"
+
+
+def test_incomplete_response_fetches_tail_from_served_through():
+    c = _client()
+    payload = {"complete": False, "symbol": "BTCUSDT",
+               "served_through": "2026-06-01T00:00:00+00:00",
+               "candles": [{"open_time": "head"}]}
+    with patch.object(c, "_request", return_value=payload), \
+         patch.object(SimmerClient, "_live_binance_tail",
+                      return_value=[{"open_time": "tail"}]) as tail:
+        out = c.get_candles("BTCUSDT", "2026-05-30T00:00:00", "2026-06-02T00:00:00")
+    assert [x["open_time"] for x in out] == ["head", "tail"]
+    # tail starts where the server's coverage ended, not at the user's start
+    assert tail.call_args[0][2] == "2026-06-01T00:00:00+00:00"
+
+
+def test_fallback_disabled_returns_archived_head_only():
+    c = _client()
+    payload = {"complete": False, "served_through": "x", "candles": [{"open_time": "head"}]}
+    with patch.object(c, "_request", return_value=payload), \
+         patch.object(SimmerClient, "_live_binance_tail") as tail:
+        out = c.get_candles("BTCUSDT", "a", "b", allow_live_fallback=False)
+    assert out == [{"open_time": "head"}]
+    tail.assert_not_called()
+
+
+def test_live_tail_drops_in_progress_candle():
+    """The client-side closed-candle rule: a candle closing in the future is
+    look-ahead and must be dropped."""
+    import json
+    from io import BytesIO
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    closed = [int((now - timedelta(minutes=5)).timestamp() * 1000), "1", "2", "0.5", "1.5",
+              "100", int((now - timedelta(minutes=4)).timestamp() * 1000) - 1]
+    in_progress = [int(now.timestamp() * 1000), "1", "2", "0.5", "1.5",
+                   "100", int((now + timedelta(minutes=1)).timestamp() * 1000)]
+    body = json.dumps([closed, in_progress]).encode()
+
+    class FakeResp(BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with patch("urllib.request.urlopen", return_value=FakeResp(body)):
+        out = SimmerClient._live_binance_tail(
+            "BTCUSDT", "1m",
+            (now - timedelta(minutes=10)).isoformat(), now.isoformat())
+    assert len(out) == 1
+    assert out[0]["volume"] == 100.0
+
+
+def test_live_tail_errors_degrade_to_empty():
+    with patch("urllib.request.urlopen", side_effect=OSError("net down")):
+        assert SimmerClient._live_binance_tail("BTCUSDT", "1m", "2026-06-01", "2026-06-02") == []


### PR DESCRIPTION
Companion to SupaFund/simmer#1289 (Phase 1.5C endpoint). `client.get_candles(symbol, start, end)` consumes the coverage contract: archived closed candles from the Simmer data plane; live-Binance tail ONLY on `complete: false` (the replay server always answers `complete: true`, so the fallback structurally can't fire under replay). Client-side closed-candle rule on the tail (in-progress candle dropped); errors degrade to the archived head. 5 new tests; full SDK suite green (4 pre-existing OWS-constructor failures on main unchanged). No version bump — ships with the next skill-fix release batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)