### PR TITLE
feat(skills): Binance trio on the Simmer data plane (Refs SIM-3070 1.5C)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.31"
+version = "0.17.32"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/skills/polymarket-btc-up-down-trader/SKILL.md
+++ b/skills/polymarket-btc-up-down-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-btc-up-down-trader
 description: Trade Polymarket BTC daily and weekly UP/DOWN markets with empirically-anchored exit discipline. Enters on CEX momentum divergence; exits automatically on time cap, volume spike, or target capture. Use when the user wants to trade BTC direction markets (hours/days duration), not fast 5-minute markets.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.1"
+  version: "1.0.2"
   displayName: Polymarket BTC Up-Down Trader
   difficulty: intermediate
 ---

--- a/skills/polymarket-btc-up-down-trader/SKILL.md
+++ b/skills/polymarket-btc-up-down-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-btc-up-down-trader
 description: Trade Polymarket BTC daily and weekly UP/DOWN markets with empirically-anchored exit discipline. Enters on CEX momentum divergence; exits automatically on time cap, volume spike, or target capture. Use when the user wants to trade BTC direction markets (hours/days duration), not fast 5-minute markets.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.2"
+  version: "1.1.0"
   displayName: Polymarket BTC Up-Down Trader
   difficulty: intermediate
 ---

--- a/skills/polymarket-btc-up-down-trader/clawhub.json
+++ b/skills/polymarket-btc-up-down-trader/clawhub.json
@@ -6,7 +6,7 @@
       "SIMMER_API_KEY"
     ],
     "pip": [
-      "simmer-sdk>=0.16.0"
+      "simmer-sdk>=0.17.32"
     ]
   },
   "envVars": [

--- a/skills/polymarket-btc-up-down-trader/strategy.py
+++ b/skills/polymarket-btc-up-down-trader/strategy.py
@@ -298,11 +298,42 @@ def fetch_btc_updown_markets():
 # Price signals
 # =============================================================================
 
+def _is_replay():
+    """True inside the Simmer replay harness (SIMMER_REPLAY=1). Decision data
+    must then come ONLY from the Simmer API — a direct-vendor fetch would be
+    future data relative to the frozen tick."""
+    return os.environ.get("SIMMER_REPLAY") == "1"
+
+
 def fetch_btc_momentum(lookback_minutes):
     """
-    Fetch BTC momentum from Binance BTCUSDT klines.
+    BTC momentum over the last `lookback_minutes` of CLOSED 1m candles.
+
+    Primary source: Simmer's data plane (client.get_candles — closed candles
+    only, one code path live and under replay; current_price becomes the last
+    CLOSED close, <=60s behind the old intra-candle read). Legacy direct
+    Binance is a LIVE-ONLY fallback for servers without the data plane; under
+    replay it never fires.
+
     Returns (momentum_pct, direction, current_price) or (None, None, None).
     """
+    try:
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(minutes=max(lookback_minutes + 1, 5))
+        candles = get_client().get_candles("BTCUSDT", start.isoformat(), end.isoformat())
+        if candles and len(candles) >= 2:
+            open_price = float(candles[0]["open"])
+            close_price = float(candles[-1]["close"])
+            momentum_pct = (close_price - open_price) / open_price * 100
+            direction = "up" if momentum_pct > 0 else "down"
+            return abs(momentum_pct), direction, close_price
+        if _is_replay():
+            return None, None, None  # honest no-signal — never fall back under replay
+    except Exception:  # noqa: BLE001 — branch on environment below
+        if _is_replay():
+            return None, None, None
+
+    # ---- legacy LIVE-ONLY direct path (never reached under replay) ----
     interval = "1m"
     limit = max(lookback_minutes + 1, 5)
     url = f"https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval={interval}&limit={limit}"

--- a/skills/polymarket-btc-up-down-trader/strategy.py
+++ b/skills/polymarket-btc-up-down-trader/strategy.py
@@ -661,11 +661,14 @@ def run_exit_monitor(client, live=False, quiet=False):
             print(f"  🚪 EXIT triggered: {exit_reason} | {details}")
             if live:
                 try:
-                    result = client.sell(
+                    result = client.trade(
                         market_id=market_id,
-                        side=side,
-                        quantity=quantity,
+                        side=side.lower(),
+                        action="sell",
+                        shares=quantity,
+                        venue="polymarket",
                         source=TRADE_SOURCE,
+                        skill_slug=SKILL_SLUG,
                     )
                     log_trade(
                         market_id=market_id,
@@ -779,11 +782,14 @@ def run_entry_scan(client, live=False, quiet=False):
 
         if live:
             try:
-                result = client.buy(
+                result = client.trade(
                     market_id=market_id,
-                    side=side,
-                    amount_usd=trade_size,
+                    side=side.lower(),
+                    action="buy",
+                    amount=trade_size,
+                    venue="polymarket",
                     source=TRADE_SOURCE,
+                    skill_slug=SKILL_SLUG,
                 )
                 log_trade(
                     market_id=market_id,

--- a/skills/polymarket-btc-up-down-trader/strategy.py
+++ b/skills/polymarket-btc-up-down-trader/strategy.py
@@ -317,21 +317,26 @@ def fetch_btc_momentum(lookback_minutes):
 
     Returns (momentum_pct, direction, current_price) or (None, None, None).
     """
-    try:
-        end = datetime.now(timezone.utc)
-        start = end - timedelta(minutes=max(lookback_minutes + 1, 5))
-        candles = get_client().get_candles("BTCUSDT", start.isoformat(), end.isoformat())
-        if candles and len(candles) >= 2:
-            open_price = float(candles[0]["open"])
-            close_price = float(candles[-1]["close"])
-            momentum_pct = (close_price - open_price) / open_price * 100
-            direction = "up" if momentum_pct > 0 else "down"
-            return abs(momentum_pct), direction, close_price
-        if _is_replay():
-            return None, None, None  # honest no-signal — never fall back under replay
-    except Exception:  # noqa: BLE001 — branch on environment below
-        if _is_replay():
-            return None, None, None
+    # No API key → no client (get_client() sys.exits). Checked up-front so the
+    # sys.exit never fires inside the signal fetch.
+    if os.environ.get("SIMMER_API_KEY"):
+        try:
+            end = datetime.now(timezone.utc)
+            start = end - timedelta(minutes=max(lookback_minutes + 1, 5))
+            candles = get_client().get_candles("BTCUSDT", start.isoformat(), end.isoformat())
+            if candles and len(candles) >= 2:
+                open_price = float(candles[0]["open"])
+                close_price = float(candles[-1]["close"])
+                momentum_pct = (close_price - open_price) / open_price * 100
+                direction = "up" if momentum_pct > 0 else "down"
+                return abs(momentum_pct), direction, close_price
+            if _is_replay():
+                return None, None, None  # honest no-signal — never fall back under replay
+        except Exception:  # noqa: BLE001 — branch on environment below
+            if _is_replay():
+                return None, None, None
+    elif _is_replay():
+        return None, None, None  # can't reach the plane under replay → no-signal
 
     # ---- legacy LIVE-ONLY direct path (never reached under replay) ----
     interval = "1m"

--- a/skills/polymarket-btc-up-down-trader/tests/test_exits.py
+++ b/skills/polymarket-btc-up-down-trader/tests/test_exits.py
@@ -435,5 +435,87 @@ class TestEntryEdgeSemantics(unittest.TestCase):
         self.assertGreater(self._edge_down(0.60), threshold)  # YES at 0.60, down momentum
 
 
+class TestLiveTradeCalls(unittest.TestCase):
+    """Regression coverage for live execution using SimmerClient.trade()."""
+
+    def setUp(self):
+        strat.DAILY_BUDGET = 50.0
+        strat.MAX_POSITION_USD = 10.0
+        strat.MIN_MOMENTUM_PCT = 0.3
+        strat.MIN_HOURS_TO_RESOLUTION = 4.0
+        strat.ENTRY_THRESHOLD = 0.05
+
+    def test_exit_monitor_sells_with_client_trade(self):
+        class ClientWithoutSell:
+            def __init__(self):
+                self.trade = MagicMock(return_value={"success": True})
+
+            def get_positions(self):
+                return [
+                    {
+                        "marketId": "mkt_exit",
+                        "side": "YES",
+                        "quantity": 3.25,
+                        "source": strat.TRADE_SOURCE,
+                    }
+                ]
+
+        client = ClientWithoutSell()
+        market_data = {
+            "question": "Bitcoin up or down?",
+            "endDate": (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat(),
+            "clobTokenIds": ["yes_token", "no_token"],
+        }
+
+        with patch.object(strat, "_api_request", return_value=market_data), \
+             patch.object(strat, "evaluate_exit_triggers", return_value=(True, "time_cap", {"hours": 2})), \
+             patch.object(strat, "log_trade"):
+            closed = strat.run_exit_monitor(client, live=True, quiet=True)
+
+        self.assertEqual(closed, 1)
+        client.trade.assert_called_once_with(
+            market_id="mkt_exit",
+            side="yes",
+            action="sell",
+            shares=3.25,
+            venue="polymarket",
+            source=strat.TRADE_SOURCE,
+            skill_slug=strat.SKILL_SLUG,
+        )
+
+    def test_entry_scan_buys_with_client_trade(self):
+        class ClientWithoutBuy:
+            def __init__(self):
+                self.trade = MagicMock(return_value={"success": True})
+
+        client = ClientWithoutBuy()
+        market = {
+            "conditionId": "mkt_entry",
+            "question": "Bitcoin up or down?",
+            "clobTokenIds": ["yes_token", "no_token"],
+            "_hours_to_resolution": 8.0,
+            "_end_dt": datetime.now(timezone.utc) + timedelta(hours=8),
+        }
+
+        with patch.object(strat, "_load_daily_spend", return_value={"spent": 0.0, "trades": 0}), \
+             patch.object(strat, "_save_daily_spend"), \
+             patch.object(strat, "fetch_btc_momentum", return_value=(0.8, "up", 100000.0)), \
+             patch.object(strat, "fetch_btc_updown_markets", return_value=[market]), \
+             patch.object(strat, "fetch_live_midpoint", return_value=0.40), \
+             patch.object(strat, "log_trade"):
+            entered = strat.run_entry_scan(client, live=True, quiet=True)
+
+        self.assertEqual(entered, 1)
+        client.trade.assert_called_once_with(
+            market_id="mkt_entry",
+            side="yes",
+            action="buy",
+            amount=10.0,
+            venue="polymarket",
+            source=strat.TRADE_SOURCE,
+            skill_slug=strat.SKILL_SLUG,
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.6.6"
+  version: "1.7.0"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/clawhub.json
+++ b/skills/polymarket-fast-loop/clawhub.json
@@ -6,7 +6,7 @@
       "SIMMER_API_KEY"
     ],
     "pip": [
-      "simmer-sdk>=0.11.1"
+      "simmer-sdk>=0.17.32"
     ]
   },
   "envVars": [

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -502,11 +502,86 @@ def find_best_fast_market(markets):
 # CEX Price Signal
 # =============================================================================
 
+def _is_replay():
+    """True inside the Simmer replay harness (SIMMER_REPLAY=1). Decision data
+    must then come ONLY from the Simmer API — any direct-vendor fetch would be
+    future data relative to the frozen tick."""
+    return os.environ.get("SIMMER_REPLAY") == "1"
+
+
+def fetch_candles_via_simmer(symbol, lookback_minutes, interval="1m"):
+    """CLOSED 1m candles for the last `lookback_minutes` via Simmer's data
+    plane (client.get_candles — one code path live and under replay; the
+    server never serves an in-progress candle). Returns a list of candle
+    dicts ascending, or raises SignalFetchError.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    end = datetime.now(timezone.utc)
+    # +1 interval of slack: closed-candle semantics mean "now" excludes the
+    # in-progress candle, so the window must reach one interval further back
+    # to still contain `lookback` closed candles.
+    start = end - timedelta(minutes=lookback_minutes + 1)
+    try:
+        return get_client().get_candles(
+            symbol, start.isoformat(), end.isoformat(), interval=interval,
+        )
+    except Exception as exc:  # noqa: BLE001 — branch on environment below
+        if _is_replay():
+            raise SignalFetchError(
+                f"Simmer candles plane unavailable under replay: {exc}",
+                [{"endpoint": "simmer-data-plane", "error": str(exc)[:240]}],
+            ) from exc
+        return None  # live: caller may use the legacy direct path
+
+
 def get_binance_momentum(symbol="BTCUSDT", lookback_minutes=5):
-    """Get price momentum from Binance public API.
+    """Price momentum over the last `lookback_minutes` of CLOSED 1m candles.
+
+    Primary source: Simmer's data plane (replay-deterministic — the
+    fast-scaler 89.4% retraction came from exactly the in-progress-candle
+    class this avoids; live now matches what a backtest can verify, at the
+    cost of <=60s signal lag vs the old intra-candle price). Legacy direct
+    Binance path remains as a LIVE-ONLY fallback for older/self-hosted
+    servers without the data plane; under replay it never fires.
+
     Returns: {momentum_pct, direction, price_now, price_then, avg_volume, candles}
     """
     failures = []
+
+    plane = fetch_candles_via_simmer(symbol, lookback_minutes)
+    if plane is not None and len(plane) >= 2:
+        candles = plane
+        price_then = float(candles[0]["open"])
+        price_now = float(candles[-1]["close"])
+        momentum_pct = ((price_now - price_then) / price_then) * 100
+        volumes = [float(c["volume"]) for c in candles]
+        avg_volume = sum(volumes) / len(volumes)
+        latest_volume = volumes[-1]
+        return {
+            "momentum_pct": momentum_pct,
+            "direction": "up" if momentum_pct > 0 else "down",
+            "price_now": price_now,
+            "price_then": price_then,
+            "avg_volume": avg_volume,
+            "latest_volume": latest_volume,
+            "volume_ratio": latest_volume / avg_volume if avg_volume > 0 else 1.0,
+            "candles": len(candles),
+            "endpoint": "simmer-data-plane",
+            "fallback_attempts": [],
+        }
+    if plane is not None:
+        # Data plane answered but with <2 closed candles in the window.
+        if _is_replay():
+            raise SignalFetchError(
+                f"data plane returned {len(plane)} candles; need at least 2",
+                [{"endpoint": "simmer-data-plane", "error": "insufficient_candles",
+                  "candles": len(plane)}],
+            )
+        failures.append({"endpoint": "simmer-data-plane",
+                         "error": "insufficient_candles", "candles": len(plane)})
+
+    # ---- legacy LIVE-ONLY direct path (never reached under replay) ----
     result = None
     endpoint = None
     for base_url in BINANCE_BASE_URLS:
@@ -599,8 +674,25 @@ def _norm_cdf(x):
 
 
 def get_binance_price_at(symbol, start_ms):
-    """Get BTC close price of the 1-minute candle starting at start_ms (unix ms).
-    Used to fetch the reference price at market open for the N(d) model."""
+    """Close price of the 1-minute candle starting at start_ms (unix ms).
+    Used to fetch the reference price at market open for the N(d) model.
+
+    Simmer data plane first (deterministic under replay); legacy direct
+    Binance is LIVE-ONLY — under replay a missing plane returns None and the
+    caller's no-reference path handles it (never future data)."""
+    from datetime import datetime, timedelta, timezone
+
+    start = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc)
+    try:
+        candles = get_client().get_candles(
+            symbol, start.isoformat(), (start + timedelta(minutes=2)).isoformat(),
+        )
+        if candles:
+            return float(candles[0]["close"])
+    except Exception:  # noqa: BLE001 — branch on environment below
+        pass
+    if _is_replay():
+        return None
     url = (
         f"https://api.binance.com/api/v3/klines"
         f"?symbol={symbol}&interval=1m&startTime={start_ms}&limit=1"

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -593,6 +593,19 @@ def get_binance_momentum(symbol="BTCUSDT", lookback_minutes=5):
         failures.append({"endpoint": "simmer-data-plane",
                          "error": "insufficient_candles", "candles": len(plane)})
 
+    # Structural look-ahead backstop: the legacy direct-Binance path below is
+    # future data relative to the frozen tick. The branches above already
+    # raise under replay for every CURRENT data-plane outcome, but this guard
+    # makes the invariant independent of get_candles' return contract — a
+    # future SDK change that returned None (falsy, not raising) would
+    # otherwise slip past `plane is not None` and reach legacy. Never rely on
+    # an upstream return shape to enforce a money-correctness property.
+    if _is_replay():
+        raise SignalFetchError(
+            "no usable data-plane candles under replay (legacy fetch blocked)",
+            failures or [{"endpoint": "simmer-data-plane", "error": "no_candles"}],
+        )
+
     # ---- legacy LIVE-ONLY direct path (never reached under replay) ----
     result = None
     endpoint = None

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -517,6 +517,18 @@ def fetch_candles_via_simmer(symbol, lookback_minutes, interval="1m"):
     """
     from datetime import datetime, timedelta, timezone
 
+    # No API key → no client (get_client() sys.exits). Treat as "plane
+    # unreachable from here": live falls back to the legacy path, replay
+    # raises. Checked up-front so get_client()'s sys.exit never fires inside
+    # the signal fetch.
+    if not os.environ.get("SIMMER_API_KEY"):
+        if _is_replay():
+            raise SignalFetchError(
+                "Simmer candles plane unavailable under replay: SIMMER_API_KEY unset",
+                [{"endpoint": "simmer-data-plane", "error": "no_api_key"}],
+            )
+        return None
+
     end = datetime.now(timezone.utc)
     # +1 interval of slack: closed-candle semantics mean "now" excludes the
     # in-progress candle, so the window must reach one interval further back
@@ -683,14 +695,15 @@ def get_binance_price_at(symbol, start_ms):
     from datetime import datetime, timedelta, timezone
 
     start = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc)
-    try:
-        candles = get_client().get_candles(
-            symbol, start.isoformat(), (start + timedelta(minutes=2)).isoformat(),
-        )
-        if candles:
-            return float(candles[0]["close"])
-    except Exception:  # noqa: BLE001 — branch on environment below
-        pass
+    if os.environ.get("SIMMER_API_KEY"):
+        try:
+            candles = get_client().get_candles(
+                symbol, start.isoformat(), (start + timedelta(minutes=2)).isoformat(),
+            )
+            if candles:
+                return float(candles[0]["close"])
+        except Exception:  # noqa: BLE001 — branch on environment below
+            pass
     if _is_replay():
         return None
     url = (

--- a/skills/polymarket-fast-scaler/SKILL.md
+++ b/skills/polymarket-fast-scaler/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-scaler
 description: Trade Polymarket BTC 5-minute fast markets using a magnitude-gated conviction-ladder strategy. Only fires when |1m BTC momentum| >= 0.10%, the magnitude threshold the strategy is built around. Position size scales with signal strength (3 conviction tiers). Reference template for gate-filtered BTC fast-market trading; the original performance claim was retracted (see below).
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.1.0"
+  version: "1.2.0"
   displayName: Polymarket FastScaler
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-scaler/clawhub.json
+++ b/skills/polymarket-fast-scaler/clawhub.json
@@ -6,7 +6,7 @@
       "SIMMER_API_KEY"
     ],
     "pip": [
-      "simmer-sdk>=0.17.0"
+      "simmer-sdk>=0.17.32"
     ]
   },
   "envVars": [

--- a/skills/polymarket-fast-scaler/fast_scaler.py
+++ b/skills/polymarket-fast-scaler/fast_scaler.py
@@ -475,16 +475,69 @@ def find_best_fast_market(markets):
 # Signal — Binance 1m Momentum
 # =============================================================================
 
-def get_binance_1m_momentum(asset="BTC"):
-    """Fetch the most recent 1-minute Binance candle and return momentum %.
+def _is_replay():
+    """True inside the Simmer replay harness (SIMMER_REPLAY=1). Decision data
+    must then come ONLY from the Simmer API — a direct-vendor fetch would be
+    future data relative to the frozen tick (the exact class behind this
+    skill's 89.4% backtest retraction)."""
+    return os.environ.get("SIMMER_REPLAY") == "1"
 
-    Returns dict with: momentum_pct, direction, price_now, price_open, volume_ratio
-    or None on failure.
+
+def _momentum_from_closed_candles(candles):
+    """Momentum dict from the LAST CLOSED candle, volume context from the
+    rest. Same semantics as the legacy index -2 rule: a settled signal,
+    never the in-progress candle."""
+    if not candles or len(candles) < 1:
+        return None
+    candle = candles[-1]
+    price_open = float(candle["open"])
+    price_close = float(candle["close"])
+    volume = float(candle["volume"])
+    avg_volume = sum(float(c["volume"]) for c in candles) / len(candles)
+    momentum_pct = (price_close - price_open) / price_open * 100
+    return {
+        "momentum_pct": momentum_pct,
+        "abs_momentum_pct": abs(momentum_pct),
+        # momentum_pct == 0 → "down" is unreachable; magnitude gate filters |mom| > 0
+        "direction": "up" if momentum_pct > 0 else "down",
+        "price_now": price_close,
+        "price_open": price_open,
+        "volume": volume,
+        "volume_ratio": volume / avg_volume if avg_volume > 0 else 1.0,
+    }
+
+
+def get_binance_1m_momentum(asset="BTC"):
+    """Momentum % from the last CLOSED 1-minute candle.
+
+    Primary source: Simmer's data plane (client.get_candles — closed candles
+    only, one code path live and under replay). Legacy direct Binance is a
+    LIVE-ONLY fallback for servers without the data plane; under replay it
+    never fires (returns None → no signal this tick).
 
     Using 1m lookback (window-open candle) is the backtested signal source.
     Do not increase lookback without re-running the backtest.
+
+    Returns dict with: momentum_pct, direction, price_now, price_open,
+    volume_ratio — or None on failure.
     """
     symbol = ASSET_SYMBOLS.get(asset, "BTCUSDT")
+
+    try:
+        from datetime import datetime, timedelta, timezone
+
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(minutes=4)  # ≥3 closed candles for volume context
+        plane = get_client().get_candles(symbol, start.isoformat(), end.isoformat())
+        if plane:
+            return _momentum_from_closed_candles(plane)
+        if _is_replay():
+            return None  # empty tape window — honest no-signal, never fall back
+    except Exception:  # noqa: BLE001 — branch on environment below
+        if _is_replay():
+            return None
+
+    # ---- legacy LIVE-ONLY direct path (never reached under replay) ----
     # Try global endpoint first; fall back to US endpoint for geo-restricted deployments (HTTP 451)
     result = None
     for base in ("https://api.binance.com", "https://api.binance.us"):

--- a/skills/polymarket-fast-scaler/fast_scaler.py
+++ b/skills/polymarket-fast-scaler/fast_scaler.py
@@ -523,19 +523,25 @@ def get_binance_1m_momentum(asset="BTC"):
     """
     symbol = ASSET_SYMBOLS.get(asset, "BTCUSDT")
 
-    try:
-        from datetime import datetime, timedelta, timezone
+    # No API key → no client (get_client() sys.exits). Checked up-front so the
+    # sys.exit never fires inside the signal fetch; live falls back to legacy,
+    # replay yields no-signal.
+    if os.environ.get("SIMMER_API_KEY"):
+        try:
+            from datetime import datetime, timedelta, timezone
 
-        end = datetime.now(timezone.utc)
-        start = end - timedelta(minutes=4)  # ≥3 closed candles for volume context
-        plane = get_client().get_candles(symbol, start.isoformat(), end.isoformat())
-        if plane:
-            return _momentum_from_closed_candles(plane)
-        if _is_replay():
-            return None  # empty tape window — honest no-signal, never fall back
-    except Exception:  # noqa: BLE001 — branch on environment below
-        if _is_replay():
-            return None
+            end = datetime.now(timezone.utc)
+            start = end - timedelta(minutes=4)  # ≥3 closed candles for volume context
+            plane = get_client().get_candles(symbol, start.isoformat(), end.isoformat())
+            if plane:
+                return _momentum_from_closed_candles(plane)
+            if _is_replay():
+                return None  # empty tape window — honest no-signal, never fall back
+        except Exception:  # noqa: BLE001 — branch on environment below
+            if _is_replay():
+                return None
+    elif _is_replay():
+        return None  # can't reach the plane under replay → no-signal, never legacy
 
     # ---- legacy LIVE-ONLY direct path (never reached under replay) ----
     # Try global endpoint first; fall back to US endpoint for geo-restricted deployments (HTTP 451)

--- a/tests/test_skills_replay_gate.py
+++ b/tests/test_skills_replay_gate.py
@@ -1,0 +1,77 @@
+"""Binance-trio replay gate: under SIMMER_REPLAY=1, a failing/absent data
+plane must produce an honest no-signal — NEVER a direct Binance call (that
+would be future data relative to the frozen tick). Refs SIM-3070 1.5C."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SKILLS = Path(__file__).parent.parent / "skills"
+
+
+def _load(slug, module_file, name):
+    spec = importlib.util.spec_from_file_location(name, SKILLS / slug / module_file)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def replay_env(monkeypatch):
+    monkeypatch.setenv("SIMMER_REPLAY", "1")
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_replay")
+
+
+def test_fastloop_replay_no_plane_raises_never_binance(replay_env):
+    m = _load("polymarket-fast-loop", "fastloop_trader.py", "_fl_gate")
+    m.get_client = MagicMock(side_effect=RuntimeError("no plane"))
+    m._api_request = MagicMock()
+    with pytest.raises(m.SignalFetchError):
+        m.get_binance_momentum("BTCUSDT", 5)
+    m._api_request.assert_not_called()
+
+
+def test_fastscaler_replay_no_plane_returns_none_never_binance(replay_env):
+    m = _load("polymarket-fast-scaler", "fast_scaler.py", "_fs_gate")
+    m.get_client = MagicMock(side_effect=RuntimeError("no plane"))
+    m._api_request = MagicMock()
+    assert m.get_binance_1m_momentum("BTC") is None
+    m._api_request.assert_not_called()
+
+
+def test_btcupdown_replay_no_plane_returns_none_never_binance(replay_env):
+    m = _load("polymarket-btc-up-down-trader", "strategy.py", "_bud_gate")
+    m.get_client = MagicMock(side_effect=RuntimeError("no plane"))
+    m._api_request = MagicMock()
+    assert m.fetch_btc_momentum(30) == (None, None, None)
+    m._api_request.assert_not_called()
+
+
+def test_fastloop_live_falls_back_when_plane_missing(monkeypatch):
+    monkeypatch.delenv("SIMMER_REPLAY", raising=False)
+    m = _load("polymarket-fast-loop", "fastloop_trader.py", "_fl_live")
+    m.get_client = MagicMock(side_effect=RuntimeError("old server"))
+    # legacy path runs: 5 fake klines [open_time, open, high, low, close, volume, ...]
+    klines = [[0, "100", "101", "99", "100.5", "10", 0]] * 5
+    m._api_request = MagicMock(return_value=klines)
+    out = m.get_binance_momentum("BTCUSDT", 5)
+    assert out["endpoint"].startswith("https://api.binance")
+    m._api_request.assert_called()
+
+
+def test_plane_used_when_available(monkeypatch):
+    monkeypatch.delenv("SIMMER_REPLAY", raising=False)
+    m = _load("polymarket-fast-scaler", "fast_scaler.py", "_fs_plane")
+    candles = [{"open": 100.0, "close": 100.3, "volume": 5.0},
+               {"open": 100.3, "close": 100.1, "volume": 7.0}]
+    client = MagicMock()
+    client.get_candles.return_value = candles
+    m.get_client = MagicMock(return_value=client)
+    m._api_request = MagicMock()
+    out = m.get_binance_1m_momentum("BTC")
+    assert out["price_now"] == 100.1  # LAST CLOSED candle, not index -2
+    m._api_request.assert_not_called()

--- a/tests/test_skills_replay_gate.py
+++ b/tests/test_skills_replay_gate.py
@@ -76,3 +76,16 @@ def test_plane_used_when_available(monkeypatch):
     out = m.get_binance_1m_momentum("BTC")
     assert out["price_now"] == 100.1  # LAST CLOSED candle, not index -2
     m._api_request.assert_not_called()
+
+
+def test_fastloop_replay_none_candles_still_blocks_binance(replay_env):
+    """Self-review backstop: even if get_candles returns None (falsy, not
+    raising) under replay, the legacy Binance path must not run."""
+    m = _load("polymarket-fast-loop", "fastloop_trader.py", "_fl_none")
+    client = MagicMock()
+    client.get_candles.return_value = None
+    m.get_client = MagicMock(return_value=client)
+    m._api_request = MagicMock()
+    with pytest.raises(m.SignalFetchError):
+        m.get_binance_momentum("BTCUSDT", 5)
+    m._api_request.assert_not_called()

--- a/tests/test_skills_replay_gate.py
+++ b/tests/test_skills_replay_gate.py
@@ -65,6 +65,7 @@ def test_fastloop_live_falls_back_when_plane_missing(monkeypatch):
 
 def test_plane_used_when_available(monkeypatch):
     monkeypatch.delenv("SIMMER_REPLAY", raising=False)
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_test")  # guard: no key → plane skipped
     m = _load("polymarket-fast-scaler", "fast_scaler.py", "_fs_plane")
     candles = [{"open": 100.0, "close": 100.3, "volume": 5.0},
                {"open": 100.3, "close": 100.1, "volume": 7.0}]


### PR DESCRIPTION
## Summary
The daytime half of Phase 1.5C: fast-loop (1.7.0), fast-scaler (1.2.0), btc-up-down (1.1.0) switch their momentum signals to `client.get_candles` — mert-pattern, one code path live and under replay.

- **Replay gate**: legacy direct-Binance paths are now LIVE-ONLY, hard-gated on `SIMMER_REPLAY` (exported by the harness since simmer #1295). Under replay, a missing/failing data plane = honest no-signal — structurally never a future-data fetch.
- **Deliberate semantic change**: "current price" = last CLOSED candle's close (≤60s lag vs the old intra-candle read). Live now matches what a backtest can verify; the intra-candle read is the exact class behind fast-scaler's 89.4% retraction. fast-scaler keeps its settled-signal rule.
- **btc-up-down repo was BEHIND published** (1.0.1 vs 1.0.2 — the `client.trade` modernization never got backported): synced verbatim from the published bundle first (separate commit), then patched.
- SDK → **0.17.32** (`get_candles` from #201 ships in it); skill pip floors → `>=0.17.32`.

## Tests
5 new in `test_skills_replay_gate.py`: never-falls-back-under-replay for all three (asserting zero `_api_request` calls), live fallback works on old servers, plane-preferred path uses the last CLOSED candle. Full suite: 427 passed (4 pre-existing OWS-constructor failures unchanged).

## After merge (the approval batch)
1. Publish simmer-sdk 0.17.32 to PyPI
2. Republish the three skills to ClawHub
3. Seed runs → registry/result SQL for badge candidates #3-5

Refs SIM-3070

🤖 Generated with [Claude Code](https://claude.com/claude-code)