### PR TITLE
docs(neh): warn auto stop-loss can't protect against gap-resolution

### DIFF
--- a/skills/polymarket-nothing-ever-happens/DISCLAIMER.md
+++ b/skills/polymarket-nothing-ever-happens/DISCLAIMER.md
@@ -28,8 +28,16 @@ exceeding any specific position size.
 
 Stop-loss and take-profit monitors run on a fixed schedule. Markets that
 resolve faster than the monitor cycle cannot be exited automatically.
-Position sizing is the only risk control on these markets — set it
-conservatively.
+
+Some markets also resolve by gapping rather than decaying. Weather
+temperature buckets are the clearest case: the losing side can sit near
+your entry, then jump straight to about 0 at resolution, with no
+intermediate price for a percentage stop to trigger on and no liquidity
+to exit into. On these markets a stop-loss cannot cap your loss
+regardless of the monitor cycle.
+
+Position sizing is the only reliable risk control on these markets. Set
+it conservatively, assuming the full position can go to zero.
 
 ## Use of this skill is at your own risk
 

--- a/skills/polymarket-nothing-ever-happens/SKILL.md
+++ b/skills/polymarket-nothing-ever-happens/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-nothing-ever-happens
 description: Buy NO on standalone non-sports yes/no Polymarket markets priced below a configurable cap. Based on the "nothing-ever-happens" thesis — binary markets often resolve NO, and cheap NO shares offer asymmetric value. Scans for candidates via Gamma API, filters out sports and grouped markets, checks fees, and executes.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.4"
+  version: "1.0.5"
   displayName: Polymarket Nothing-Ever-Happens
   difficulty: beginner
 ---
@@ -20,6 +20,8 @@ Buy NO on standalone yes/no Polymarket markets priced below a configurable cap.
 ## The Thesis
 
 On most standalone binary prediction markets, the event resolves NO — nothing dramatic happens. Markets systematically overprice dramatic YES outcomes. When NO is trading at 3¢–5¢, you're getting 20–33x payout if you're right, and the base rate of "nothing happens" is often much higher than the implied 3–5%.
+
+> ⚠️ **Automated stop-losses cannot protect against gap-resolution.** Many NO-fade targets, weather temperature buckets especially, do not decay toward their losing outcome. They gap: the price sits near your entry, then jumps straight to about 0 at resolution. A percentage stop has no intermediate price to trigger on and no liquidity to exit into once it is near zero, so it cannot cap your downside on these markets. Size every position for the full loss, not for the stop. See [DISCLAIMER.md](./DISCLAIMER.md).
 
 ## What It Does
 


### PR DESCRIPTION
## What
- `SKILL.md`: ⚠️ warning that automated stop-losses can't protect against gap-resolution markets, placed right after the asymmetric-payoff thesis. Version 1.0.4 -> 1.0.5.
- `DISCLAIMER.md`: extends 'Risk monitoring may not apply to all market types' with the gap-resolution case.

## Why
The NEH NO-fade strategy is exactly the one a weather trader (clawdeus) runs. Weather NO buckets gap straight to ~0 at resolution, so a percentage stop has no level to trigger on and no liquidity to exit into. The skill sells 20-33x asymmetry without flagging that the auto stop can't cap the downside. Mirrors the existing sub-15min warning in polymarket-fast-loop/SKILL.md.

## Note
Version bumped; **ClawHub republish is a separate step** (needs Adrian) for installed users to receive it. Repo + ClawHub will drift until republished.

Refs SIM-3172

🤖 Generated with [Claude Code](https://claude.com/claude-code)