### PR TITLE
docs(weather): disclose stops can't catch gap-resolution (published weather skills)

### DIFF
--- a/skills/kalshi-weather-trader/DISCLAIMER.md
+++ b/skills/kalshi-weather-trader/DISCLAIMER.md
@@ -28,8 +28,16 @@ exceeding any specific position size.
 
 Stop-loss and take-profit monitors run on a fixed schedule. Markets that
 resolve faster than the monitor cycle cannot be exited automatically.
-Position sizing is the only risk control on these markets — set it
-conservatively.
+
+Some markets also resolve by gapping rather than decaying. Weather
+temperature buckets are the clearest case: the losing side can sit near
+your entry, then jump straight to about 0 at resolution, with no
+intermediate price for a percentage stop to trigger on and no liquidity
+to exit into. On these markets a stop-loss cannot cap your loss
+regardless of the monitor cycle.
+
+Position sizing is the only reliable risk control on these markets. Set
+it conservatively, assuming the full position can go to zero.
 
 ## Use of this skill is at your own risk
 

--- a/skills/kalshi-weather-trader/SKILL.md
+++ b/skills/kalshi-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: kalshi-weather-trader
 description: Trade Kalshi weather markets using NOAA forecasts via Simmer SDK and DFlow on Solana. Port of the popular polymarket-weather-trader. Use when user wants to trade temperature markets on Kalshi, automate weather bets, or check NOAA forecasts.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.9"
+  version: "1.0.10"
   displayName: Kalshi Weather Trader
   difficulty: intermediate
   attribution: Strategy inspired by gopfan2, powered by DFlow

--- a/skills/polymarket-weather-trader/DISCLAIMER.md
+++ b/skills/polymarket-weather-trader/DISCLAIMER.md
@@ -28,8 +28,16 @@ exceeding any specific position size.
 
 Stop-loss and take-profit monitors run on a fixed schedule. Markets that
 resolve faster than the monitor cycle cannot be exited automatically.
-Position sizing is the only risk control on these markets — set it
-conservatively.
+
+Some markets also resolve by gapping rather than decaying. Weather
+temperature buckets are the clearest case: the losing side can sit near
+your entry, then jump straight to about 0 at resolution, with no
+intermediate price for a percentage stop to trigger on and no liquidity
+to exit into. On these markets a stop-loss cannot cap your loss
+regardless of the monitor cycle.
+
+Position sizing is the only reliable risk control on these markets. Set
+it conservatively, assuming the full position can go to zero.
 
 ## Use of this skill is at your own risk
 

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.0"
+  version: "1.23.1"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).
@@ -25,7 +25,7 @@ This skill executes real-money trades on Polymarket only when the `--live` flag 
 - **Real-money trading requires explicit human verification.** A wallet must be linked at [simmer.markets/dashboard](https://simmer.markets/dashboard) before any real trade lands. Without a linked wallet the SDK rejects real-money order construction.
 - **Per-trade cap.** `SIMMER_WEATHER_MAX_POSITION_USD` defaults to `$2.00` per trade. Configurable via env var, capped at the user's dashboard-set platform per-trade limit.
 - **Daily caps.** Platform-level daily caps apply (max trades/day, max USD/day). Set at [simmer.markets/dashboard](https://simmer.markets/dashboard) → SDK settings.
-- **Auto stop-loss is ON by default.** Server-side risk monitor watches every buy. Threshold is configurable per user at simmer.markets/dashboard → Settings → Auto Risk Monitor.
+- **Auto stop-loss is ON by default.** Server-side risk monitor watches every buy. Threshold is configurable per user at simmer.markets/dashboard → Settings → Auto Risk Monitor. **It cannot protect against gap-resolution, though:** weather temperature buckets jump straight to about 0 at resolution rather than decaying through your stop, so a percentage stop has no price to trigger on and no liquidity to exit into. Size for the full loss, not for the stop. See [DISCLAIMER.md](./DISCLAIMER.md).
 - **Strategy-side safeguards.** Beyond platform risk monitors, this skill checks flip-flop, slippage (`SIMMER_WEATHER_SLIPPAGE_MAX`, default 15%), time-decay, and resolved-market status before every order. Disable only with `--no-safeguards` (not recommended).
 - **Reversibility.** Open positions exit automatically when price > `SIMMER_WEATHER_EXIT_THRESHOLD` (default `0.45`), or via `client.cancel_order()` / a manual sell.
 


### PR DESCRIPTION
## What
Adds the gap-to-zero stop-loss disclosure to the **published** weather skills:
- `polymarket-weather-trader` (1.23.0 → 1.23.1): SKILL.md 'Auto stop-loss is ON' bullet caveat + DISCLAIMER.md extension.
- `kalshi-weather-trader` (1.0.9 → 1.0.10): DISCLAIMER.md extension.

## Why
Follow-up to the disclosure in PR #203. That PR targeted `polymarket-nothing-ever-happens`, which is `publish: false` (SDK reference/example, not on ClawHub) — so it never reaches installed users. These two ARE the published weather skills users run, and their DISCLAIMERs only had the generic 'fixed schedule' note. Weather temp buckets gap straight to ~0 at resolution; a percentage stop can't catch that.

Will ClawHub-republish both after merge.

Refs SIM-3172

🤖 Generated with [Claude Code](https://claude.com/claude-code)