### PR TITLE
feat(backtest): run_backtest() wrapper (SIM-3070 slice 3)

### DIFF
--- a/simmer_sdk/backtest/__init__.py
+++ b/simmer_sdk/backtest/__init__.py
@@ -4,13 +4,257 @@ Backtest an UNMODIFIED skill bundle against historical prediction-market data
 before risking capital — the missing "test before capital" leg alongside the
 sim-venue, dry-run, and paper-trade modes (which are all live-forward).
 
-The engine substrate under ``backtest.replay`` is vendored from the simmer
-backend (see ``scripts/sync_replay_engine.py``); the same code path powers the
-internal ``scripts/replay_run.py run-bundle``.
+``run_backtest`` is the programmatic entrypoint; ``simmer_sdk.cli`` wraps it as
+``simmer backtest``. Both run the SAME engine substrate (vendored under
+``backtest.replay`` from the simmer backend) that powers the internal
+``scripts/replay_run.py run-bundle`` — so a given (bundle, tape, window,
+cadence, args) reproduces an identical ``reproducibility.config_hash`` and
+therefore identical pnl / hit_rate across the two paths.
 
 Requires the optional extra::
 
     pip install 'simmer-sdk[backtest]'
-
-The public entrypoint ``run_backtest`` is added in slice 3.
 """
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Union
+
+__all__ = ["run_backtest", "resolve_sdk_path", "BacktestError"]
+
+_DEFAULT_ARGS = ["--live", "--quiet"]
+_CADENCE_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+class BacktestError(RuntimeError):
+    """Raised for user-facing backtest setup errors (bad paths, missing extra)."""
+
+
+# -- input parsing (mirrors scripts/replay_run.py so config_hash matches) -----
+
+def _parse_dt(value: Union[str, datetime]) -> datetime:
+    """ISO string or datetime -> tz-aware UTC.
+
+    Mirrors the internal CLI's ``_dt``: a naive value is pinned to UTC (NOT
+    converted), so the same ``--t0 2026-03-01`` produces a byte-identical
+    isoformat in ``config_hash`` on both the SDK and internal paths.
+    """
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        dt = datetime.fromisoformat(str(value))
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_cadence(value: Union[str, int, float, timedelta]) -> timedelta:
+    """Accept a timedelta, a bare number of minutes, or a ``<n><unit>`` string
+    (``90s``, ``15m``, ``12h``, ``30d``)."""
+    if isinstance(value, timedelta):
+        return value
+    if isinstance(value, (int, float)):
+        return timedelta(minutes=value)
+    s = str(value).strip().lower()
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([smhd]?)", s)
+    if not m:
+        raise BacktestError(
+            f"cadence {value!r} not understood — use e.g. 15m, 12h, 30d, or minutes"
+        )
+    qty = float(m.group(1))
+    unit = m.group(2) or "m"  # bare number = minutes
+    return timedelta(seconds=qty * _CADENCE_UNITS[unit])
+
+
+def _normalize_args(args: Union[str, list, tuple, None]) -> Optional[list]:
+    """Entrypoint CLI args as a list (or None -> harness default --live --quiet).
+
+    A string is split on whitespace, matching the internal ``--args`` contract.
+    """
+    if args is None:
+        return None
+    if isinstance(args, str):
+        return args.split() or None
+    return list(args)
+
+
+def resolve_sdk_path(explicit: Optional[str] = None) -> str:
+    """Directory to put on the skill subprocess's PYTHONPATH so it can
+    ``import simmer_sdk``.
+
+    The replay harness builds the subprocess env from a strict allowlist and
+    sets ``PYTHONPATH=sdk_path`` explicitly — it does NOT inherit the parent's
+    sys.path — so this must point at the dir CONTAINING ``simmer_sdk/``. For an
+    installed wheel that's site-packages; for an editable/source checkout it's
+    the repo root. Auto-resolved from this package's own location.
+    """
+    if explicit:
+        return os.path.abspath(explicit)
+    import simmer_sdk
+
+    return os.path.dirname(os.path.dirname(os.path.abspath(simmer_sdk.__file__)))
+
+
+def _bundle_skill_version(bundle_dir: str) -> str:
+    """metadata.version from the bundle's SKILL.md frontmatter.
+
+    Byte-for-byte the same regex as ``scripts/replay_run.py._bundle_skill_version``
+    — it feeds ``skill_version`` into ``config_hash``, so any divergence here
+    would break SDK/internal reproducibility.
+    """
+    path = os.path.join(bundle_dir, "SKILL.md")
+    try:
+        with open(path) as fh:
+            head = fh.read(4096)
+        m = re.search(r"^\s*version:\s*['\"]?([0-9][^'\"#\s]*)", head, re.MULTILINE)
+        return m.group(1) if m else "unknown"
+    except OSError:
+        return "unknown"
+
+
+def _dataset_rev(tape_dir: str) -> str:
+    """``hf-slice:<t0>..<t1>:<n>mk`` from the tape manifest, matching the
+    internal CLI so ``config_hash`` lines up."""
+    import json
+
+    manifest_path = os.path.join(tape_dir, "manifest.json")
+    if os.path.exists(manifest_path):
+        with open(manifest_path) as fh:
+            m = json.load(fh)
+        return f"hf-slice:{m.get('t0')}..{m.get('t1')}:{m.get('markets')}mk"
+    return "unknown"
+
+
+# -- public entrypoint --------------------------------------------------------
+
+def run_backtest(
+    bundle: str,
+    *,
+    entrypoint: str,
+    tape: str,
+    t0: Union[str, datetime],
+    t1: Union[str, datetime],
+    cadence: Union[str, int, float, timedelta] = "15m",
+    balance: float = 1000.0,
+    fee_rate: float = 0.0,
+    seed: int = 0,
+    max_evaluations: int = 50_000,
+    args: Union[str, list, tuple, None] = None,
+    coverage_ok: bool = False,
+    candles: bool = True,
+    offline_klines: bool = False,
+    sdk_path: Optional[str] = None,
+) -> dict:
+    """Replay an UNMODIFIED skill bundle over a local historical tape slice.
+
+    Args:
+        bundle: path to the skill bundle dir (the thing a user installs).
+        entrypoint: script filename inside the bundle to run each tick
+            (e.g. ``nothing_ever_happens.py``).
+        tape: local dir holding ``markets.parquet`` + ``quant.parquet``
+            (+ optional ``manifest.json``) — as produced by
+            ``scripts/replay_run.py extract``. Remote/window download is slice 5.
+        t0, t1: window bounds (ISO string or datetime; naive => UTC).
+        cadence: tick spacing — ``15m`` / ``12h`` / ``30d``, minutes, or timedelta.
+        balance: starting balance.
+        fee_rate: per-fill fee rate (0 = none; baselines ignore fees in v0).
+        seed: RNG seed for the random baseline.
+        max_evaluations: hard ticks×markets budget (engine truncates past it).
+        args: entrypoint CLI args (string split on whitespace, or list).
+            ``None`` => the harness default ``--live --quiet``.
+        coverage_ok: assert this window/cadence fits the skill's signal horizon,
+            so a 0-trade result is a *verified* no-signal outcome.
+        candles: wire the Binance candles plane (needed by crypto-signal skills;
+            absent => ``/api/replay-data/candles`` 404s and the skill reads
+            "no signal" honestly).
+        offline_klines: candles plane uses only pre-cached months (no network).
+        sdk_path: dir containing ``simmer_sdk/`` for the subprocess PYTHONPATH;
+            auto-resolved to the installed package when omitted.
+
+    Returns:
+        The engine report dict (``summary`` / ``baselines`` / ``decisions`` /
+        ``fills`` / ``equity_curve`` / ``realism_gaps`` / ``data_plane`` /
+        ``reproducibility`` / ``bundle`` / ``coverage_ok`` / ``replay_job``).
+    """
+    try:
+        from .replay.candles_service import build_kline_store
+        from .replay.duckdb_store import DuckDBStore
+        from .replay.engine import ReplayConfig
+        from .replay.harness import bundle_digest, replay_bundle
+    except ImportError as exc:  # missing duckdb/fastapi/uvicorn
+        raise BacktestError(
+            "the backtest engine needs extra dependencies — install with:\n"
+            "    pip install 'simmer-sdk[backtest]'"
+        ) from exc
+
+    bundle = os.path.abspath(bundle)
+    if not os.path.isdir(bundle):
+        raise BacktestError(f"bundle dir not found: {bundle}")
+    if not os.path.exists(os.path.join(bundle, entrypoint)):
+        raise BacktestError(f"entrypoint {entrypoint!r} not found in bundle {bundle}")
+
+    markets_pq = os.path.join(tape, "markets.parquet")
+    quant_pq = os.path.join(tape, "quant.parquet")
+    for p in (markets_pq, quant_pq):
+        if not os.path.exists(p):
+            raise BacktestError(
+                f"missing tape file: {p}\n"
+                "expected a local slice dir with markets.parquet + quant.parquet "
+                "(produce one with scripts/replay_run.py extract)"
+            )
+
+    t0_dt, t1_dt = _parse_dt(t0), _parse_dt(t1)
+    if t1_dt <= t0_dt:
+        raise BacktestError(f"t1 ({t1_dt}) must be after t0 ({t0_dt})")
+    cadence_td = _parse_cadence(cadence)
+    extra_args = _normalize_args(args)
+    sdk_path = resolve_sdk_path(sdk_path)
+
+    store = DuckDBStore(markets_pq, quant_pq)
+    config = ReplayConfig(
+        t0=t0_dt,
+        t1=t1_dt,
+        cadence=cadence_td,
+        starting_balance=balance,
+        fee_rate=fee_rate,
+        skill_slug=os.path.basename(bundle.rstrip("/")),
+        skill_version=_bundle_skill_version(bundle),
+        dataset_rev=_dataset_rev(tape),
+        seed=seed,
+        max_evaluations=max_evaluations,
+        # bundle content + invocation change results -> must change config_hash
+        params={
+            "entrypoint": entrypoint,
+            "args": extra_args or _DEFAULT_ARGS,
+            "bundle_digest": bundle_digest(bundle),
+        },
+    )
+    kline_store = build_kline_store(offline=offline_klines) if candles else None
+    try:
+        report = replay_bundle(
+            store, bundle, entrypoint, config, sdk_path,
+            extra_args=extra_args, kline_store=kline_store,
+        )
+    finally:
+        if kline_store is not None:
+            kline_store.close()
+        store.close()
+
+    # Runner-asserted coverage: lets a 0-trade result read as verified
+    # no-signal. Default False keeps 0-trade results inconclusive.
+    report["coverage_ok"] = bool(coverage_ok)
+    report["replay_job"] = {
+        "slug": config.skill_slug,
+        "version": None,
+        "t0": t0_dt.isoformat(),
+        "t1": t1_dt.isoformat(),
+        "cadence_seconds": int(cadence_td.total_seconds()),
+        "args": " ".join(extra_args) if extra_args else None,
+        "coverage_ok": bool(coverage_ok),
+        "tape_url": None,
+        "entrypoint": entrypoint,
+    }
+    return report

--- a/simmer_sdk/backtest/__init__.py
+++ b/simmer_sdk/backtest/__init__.py
@@ -38,17 +38,20 @@ class BacktestError(RuntimeError):
 def _parse_dt(value: Union[str, datetime]) -> datetime:
     """ISO string or datetime -> tz-aware UTC.
 
-    Mirrors the internal CLI's ``_dt``: a naive value is pinned to UTC (NOT
-    converted), so the same ``--t0 2026-03-01`` produces a byte-identical
-    isoformat in ``config_hash`` on both the SDK and internal paths.
+    STRING inputs mirror the internal CLI's ``_dt`` EXACTLY — it does
+    ``datetime.fromisoformat(s).replace(tzinfo=utc)``, which FORCES UTC and does
+    NOT convert an offset, so an offset-bearing ISO string keeps its wall-clock
+    time. We must match byte-for-byte (incl. that quirk) or ``config_hash``
+    desyncs from ``scripts/replay_run.py`` for the same ``--t0``/``--t1``.
+
+    DATETIME inputs (programmatic; no internal counterpart) get the sane
+    treatment: a naive value is pinned to UTC, an aware value is converted.
     """
-    if isinstance(value, datetime):
-        dt = value
-    else:
-        dt = datetime.fromisoformat(str(value))
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+    if not isinstance(value, datetime):
+        return datetime.fromisoformat(str(value)).replace(tzinfo=timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _parse_cadence(value: Union[str, int, float, timedelta]) -> timedelta:
@@ -213,27 +216,33 @@ def run_backtest(
     extra_args = _normalize_args(args)
     sdk_path = resolve_sdk_path(sdk_path)
 
-    store = DuckDBStore(markets_pq, quant_pq)
-    config = ReplayConfig(
-        t0=t0_dt,
-        t1=t1_dt,
-        cadence=cadence_td,
-        starting_balance=balance,
-        fee_rate=fee_rate,
-        skill_slug=os.path.basename(bundle.rstrip("/")),
-        skill_version=_bundle_skill_version(bundle),
-        dataset_rev=_dataset_rev(tape),
-        seed=seed,
-        max_evaluations=max_evaluations,
-        # bundle content + invocation change results -> must change config_hash
-        params={
-            "entrypoint": entrypoint,
-            "args": extra_args or _DEFAULT_ARGS,
-            "bundle_digest": bundle_digest(bundle),
-        },
-    )
-    kline_store = build_kline_store(offline=offline_klines) if candles else None
+    # store + kline_store both hold OS resources (a DuckDB connection / FD); build
+    # them INSIDE the try so the finally closes whatever was opened even if a later
+    # constructor throws (e.g. build_kline_store on a bad cache dir would otherwise
+    # leak the already-open DuckDB connection).
+    store = None
+    kline_store = None
     try:
+        store = DuckDBStore(markets_pq, quant_pq)
+        config = ReplayConfig(
+            t0=t0_dt,
+            t1=t1_dt,
+            cadence=cadence_td,
+            starting_balance=balance,
+            fee_rate=fee_rate,
+            skill_slug=os.path.basename(bundle.rstrip("/")),
+            skill_version=_bundle_skill_version(bundle),
+            dataset_rev=_dataset_rev(tape),
+            seed=seed,
+            max_evaluations=max_evaluations,
+            # bundle content + invocation change results -> must change config_hash
+            params={
+                "entrypoint": entrypoint,
+                "args": extra_args or _DEFAULT_ARGS,
+                "bundle_digest": bundle_digest(bundle),
+            },
+        )
+        kline_store = build_kline_store(offline=offline_klines) if candles else None
         report = replay_bundle(
             store, bundle, entrypoint, config, sdk_path,
             extra_args=extra_args, kline_store=kline_store,
@@ -241,7 +250,8 @@ def run_backtest(
     finally:
         if kline_store is not None:
             kline_store.close()
-        store.close()
+        if store is not None:
+            store.close()
 
     # Runner-asserted coverage: lets a 0-trade result read as verified
     # no-signal. Default False keeps 0-trade results inconclusive.

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -1,0 +1,140 @@
+"""Unit tests for simmer_sdk.backtest.run_backtest (SIM-3070 slice 3).
+
+Two tiers:
+
+* Pure input-parsing + sdk-path resolution — always run in CI (no extra, no
+  network, no fixtures).
+* End-to-end replay of a real bundle over a local tape slice — gated on
+  SIMMER_BACKTEST_TAPE + SIMMER_BACKTEST_BUNDLE (the tape parquets are 100MB+
+  and not in the repo). Locally:
+
+      SIMMER_BACKTEST_TAPE=/tmp/seed-tape-neh-fresh \
+      SIMMER_BACKTEST_BUNDLE=skills/polymarket-nothing-ever-happens \
+      SIMMER_BACKTEST_ENTRYPOINT=nothing_ever_happens.py \
+      python -m pytest tests/test_backtest_run.py -v
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import simmer_sdk.backtest as bt
+from simmer_sdk.backtest import (
+    BacktestError,
+    resolve_sdk_path,
+    run_backtest,
+)
+
+
+# -- pure parsing (CI-safe) ---------------------------------------------------
+
+def test_parse_dt_naive_string_pins_utc():
+    dt = bt._parse_dt("2026-03-01")
+    assert dt == datetime(2026, 3, 1, tzinfo=timezone.utc)
+    # byte-identical isoformat to the internal CLI's _dt — config_hash depends on it
+    assert dt.isoformat() == "2026-03-01T00:00:00+00:00"
+
+
+def test_parse_dt_passthrough_datetime_and_tz_convert():
+    aware = datetime(2026, 3, 1, 12, tzinfo=timezone(timedelta(hours=8)))
+    assert bt._parse_dt(aware) == datetime(2026, 3, 1, 4, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("value,seconds", [
+    ("90s", 90),
+    ("15m", 900),
+    ("12h", 43200),
+    ("30d", 2592000),
+    ("720", 43200),          # bare number = minutes
+    (720, 43200),            # int minutes
+    (timedelta(hours=2), 7200),
+])
+def test_parse_cadence(value, seconds):
+    assert bt._parse_cadence(value).total_seconds() == seconds
+
+
+def test_parse_cadence_rejects_garbage():
+    with pytest.raises(BacktestError):
+        bt._parse_cadence("soon")
+
+
+def test_normalize_args():
+    assert bt._normalize_args(None) is None
+    assert bt._normalize_args("--live --quiet") == ["--live", "--quiet"]
+    assert bt._normalize_args(["--live"]) == ["--live"]
+    assert bt._normalize_args("") is None
+
+
+def test_resolve_sdk_path_points_at_dir_containing_package():
+    sdk_path = resolve_sdk_path()
+    # the subprocess does `import simmer_sdk` with PYTHONPATH=sdk_path
+    assert os.path.isdir(os.path.join(sdk_path, "simmer_sdk"))
+
+
+def test_resolve_sdk_path_explicit_wins():
+    assert resolve_sdk_path("/some/where") == os.path.abspath("/some/where")
+
+
+# -- validation errors (CI-safe; fail before the engine import is needed) -----
+
+def test_run_backtest_rejects_missing_bundle(tmp_path):
+    with pytest.raises(BacktestError, match="bundle dir not found"):
+        run_backtest(str(tmp_path / "nope"), entrypoint="x.py",
+                     tape=str(tmp_path), t0="2026-03-01", t1="2026-03-02")
+
+
+def test_run_backtest_rejects_missing_entrypoint(tmp_path):
+    # the [backtest] extra must be present for run_backtest to reach the
+    # bundle-validation branch; skip cleanly if it isn't.
+    pytest.importorskip("duckdb", reason="requires the [backtest] extra")
+    (tmp_path / "SKILL.md").write_text("---\nversion: 1.0.0\n---\n")
+    with pytest.raises(BacktestError, match="entrypoint"):
+        run_backtest(str(tmp_path), entrypoint="ghost.py",
+                     tape=str(tmp_path), t0="2026-03-01", t1="2026-03-02")
+
+
+def test_run_backtest_rejects_missing_tape(tmp_path):
+    pytest.importorskip("duckdb", reason="requires the [backtest] extra")
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "run.py").write_text("print('hi')\n")
+    with pytest.raises(BacktestError, match="missing tape file"):
+        run_backtest(str(bundle), entrypoint="run.py",
+                     tape=str(tmp_path / "empty"), t0="2026-03-01", t1="2026-03-02")
+
+
+# -- end-to-end (gated on local fixtures) -------------------------------------
+
+_TAPE = os.environ.get("SIMMER_BACKTEST_TAPE")
+_BUNDLE = os.environ.get("SIMMER_BACKTEST_BUNDLE")
+_ENTRY = os.environ.get("SIMMER_BACKTEST_ENTRYPOINT", "nothing_ever_happens.py")
+_T0 = os.environ.get("SIMMER_BACKTEST_T0", "2026-04-28")
+_T1 = os.environ.get("SIMMER_BACKTEST_T1", "2026-05-05")
+
+
+@pytest.mark.skipif(
+    not (_TAPE and _BUNDLE),
+    reason="set SIMMER_BACKTEST_TAPE + SIMMER_BACKTEST_BUNDLE for the e2e run",
+)
+def test_run_backtest_end_to_end():
+    pytest.importorskip("duckdb", reason="requires the [backtest] extra")
+    report = run_backtest(
+        _BUNDLE, entrypoint=_ENTRY, tape=_TAPE,
+        t0=_T0, t1=_T1, cadence="12h",
+        # NEH reads no candles; skip the plane so the test is hermetic + fast.
+        candles=False,
+    )
+    # shape contract
+    for key in ("summary", "baselines", "decisions", "fills", "equity_curve",
+                "realism_gaps", "data_plane", "reproducibility", "bundle",
+                "coverage_ok", "replay_job"):
+        assert key in report, f"missing report key {key}"
+    assert report["bundle"]["clean"] is True, "bundle had failed ticks"
+    assert report["summary"]["ticks"] > 0
+    # config_hash is deterministic for the same inputs
+    again = run_backtest(_BUNDLE, entrypoint=_ENTRY, tape=_TAPE,
+                         t0=_T0, t1=_T1, cadence="12h", candles=False)
+    assert (report["reproducibility"]["config_hash"]
+            == again["reproducibility"]["config_hash"])
+    assert report["summary"]["pnl"] == again["summary"]["pnl"]

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -41,6 +41,13 @@ def test_parse_dt_passthrough_datetime_and_tz_convert():
     assert bt._parse_dt(aware) == datetime(2026, 3, 1, 4, tzinfo=timezone.utc)
 
 
+def test_parse_dt_offset_string_forces_utc_for_config_hash_parity():
+    # an offset-bearing STRING must mirror the internal _dt EXACTLY: force the
+    # tz to UTC (keep wall-clock), do NOT convert — else config_hash desyncs from
+    # scripts/replay_run.py. (Contrast the aware-DATETIME case above, which converts.)
+    assert bt._parse_dt("2026-03-01T00:00:00+05:00") == datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+
 @pytest.mark.parametrize("value,seconds", [
     ("90s", 90),
     ("15m", 900),


### PR DESCRIPTION
**SIM-3070 slice 3 of 4.** Stacks on #206 (slice 2) — base is the slice-2 branch, so the diff shows only slice-3 files. Retarget to `main` once #206 merges.

## What
`simmer_sdk.backtest.run_backtest(...) -> report dict` — the programmatic entrypoint that replays an **unmodified** skill bundle over a local tape slice via the vendored engine. Slice 4 wraps this as `simmer backtest`.

## How it stays reproducible
Mirrors `scripts/replay_run.py cmd_run_bundle` byte-for-byte everywhere it feeds `config_hash`:
- same `params` dict (`entrypoint` / `args` / `bundle_digest`)
- `skill_slug` = bundle basename, `skill_version` via the **identical** SKILL.md regex
- `dataset_rev` from the tape manifest, default `max_evaluations = 50_000`
- `_parse_dt` pins naive values to UTC (not convert), matching the internal `_dt`

`sdk_path` is auto-resolved to the installed package: the harness builds the subprocess env from a strict allowlist and sets `PYTHONPATH` explicitly (no parent sys.path inheritance), so it must point at the dir containing `simmer_sdk/`.

Flexible inputs: `t0/t1` as ISO string or datetime; `cadence` as `15m`/`12h`/`30d`/minutes/timedelta; `args` as string or list. Missing `[backtest]` extra → `BacktestError` pointing at the install command.

## Verification
- `tests/test_backtest_run.py`: 16 CI-safe tests (parsers, sdk-path resolution, validation errors) + 1 env-gated end-to-end replay (tape parquets are 100MB+, out of repo).
- **Cross-path reproducibility** (the key check): NEH bundle @ `/tmp/seed-tape-neh-fresh`, window `2026-04-28..05-05`, 12h cadence — internal `run-bundle` and SDK `run_backtest` both produce `config_hash=676a97508d1f339b`, pnl 0.0, 15 ticks, 436 evals, `bundle.clean=true`. **Identical.**

Refs SIM-3070

🤖 Generated with [Claude Code](https://claude.com/claude-code)