### PR TITLE
chore(release): cut 0.18.0 — simmer backtest + hyperliquid P1; fix [backtest] pytz dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-06-13
+
+### Added
+
+- **`simmer backtest` — local historical backtesting for trading skills (SIM-3070).** Backtest an UNMODIFIED skill bundle against historical prediction-market data before risking capital — the missing *historical* leg alongside the existing live-forward modes (sim-venue, dry-run, paper-trade). New optional extra `pip install 'simmer-sdk[backtest]'` (pulls duckdb/fastapi/uvicorn). New `simmer` console command:
+  ```
+  simmer backtest ./my-skill --entrypoint run.py --tape ./slice \
+      --t0 2026-03-01 --t1 2026-03-08 [--cadence 12h] [--out report.json]
+  simmer backtest --demo        # bundled offline demo, no tape needed
+  ```
+  Programmatic mirror: `simmer_sdk.backtest.run_backtest(...) -> report dict`. The engine runs locally and replays the real skill subprocess against a frozen, look-ahead-safe replay server, returning pnl, hit_rate, drawdown, trades, decisions, baselines (buy-and-hold-YES / random), realism gaps, and a reproducible `config_hash`. The engine substrate is vendored from the Simmer backend and runs the identical code path as the internal seed runner (same inputs → identical `config_hash` → identical results). `--window` (self-serve tape download) lands in a follow-up; for now pass `--tape <local-slice>` or `--demo`.
+- **Hyperliquid HIP-4 outcome-market signing + venue adapter (SIM-3151, P1 slice 1).** New optional extra `pip install 'simmer-sdk[hyperliquid]'`. Adds a `HyperliquidVenue` adapter behind a `VenueAdapter` Protocol (`client.hyperliquid`), with a dual signer (raw-key and OWS) producing byte-identical signatures, reusing the official SDK's validated EIP-712 wire-building / action-hash / float-formatting primitives. Signing is validated offline (26 tests, bit-identical raw≡OWS); end-to-end funded validation is pending — opt-in only, no change to default trading behavior.
+
+## [0.17.32] - 2026-06-12
+
+### Added
+
+- **Binance trio (`polymarket-fast-loop` / `polymarket-fast-scaler` / `polymarket-btc-up-down-trader`) read momentum signal from Simmer's data plane (`client.get_candles`) instead of hardcoding `urlopen(api.binance.com)` (SIM-3070 1.5C, #202).** Closed candles only; under replay the same endpoint is clamped to the frozen tick so the skills become backtestable rather than silently fetching live (future) data.
+
 ## [0.17.31] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,6 +142,39 @@ print(f"Balance: ${summary['balance']:.2f}, P&L: ${summary['total_pnl']:.2f}")
 
 **Graduation path:** `sim` (instant fills, no spread) → `polymarket` + `live=False` (real prices, spread modeled) → `polymarket` live (real USDC).
 
+## Backtesting
+
+The three modes above are all *live-forward*. To test a strategy on **historical** data before risking capital, backtest the skill bundle:
+
+```bash
+pip install 'simmer-sdk[backtest]'
+
+# Try it offline — bundled 10-market demo slice, no data download:
+simmer backtest --demo
+
+# Backtest your own skill over a local tape slice:
+simmer backtest ./my-skill --entrypoint run.py --tape ./slice \
+    --t0 2026-03-01 --t1 2026-03-08 --cadence 12h --out report.json
+```
+
+The engine replays your **unmodified** skill against a frozen, look-ahead-safe
+replay server (one subprocess per tick) and reports pnl, hit rate, max drawdown,
+trades, baselines (buy-and-hold-YES / random), realism gaps, and a reproducible
+`config_hash`. Programmatic equivalent:
+
+```python
+from simmer_sdk.backtest import run_backtest
+
+report = run_backtest("./my-skill", entrypoint="run.py", tape="./slice",
+                      t0="2026-03-01", t1="2026-03-08", cadence="12h")
+print(report["summary"]["pnl"], report["summary"]["hit_rate"])
+```
+
+> Backtests use trade-tape prices (no orderbook), so they model decision quality,
+> not execution realism — every report lists its `realism_gaps`. Self-serve
+> `--window` (auto-download a historical slice) is coming; for now pass a local
+> `--tape` directory or use `--demo`.
+
 ## Key Methods
 
 | Method | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.17.32"
+version = "0.18.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [
@@ -86,6 +86,11 @@ backtest = [
     "duckdb>=0.10.0",
     "fastapi>=0.110.0",
     "uvicorn>=0.27.0",
+    # duckdb binds the tape's tz-aware TIMESTAMPTZ columns via pytz; without it
+    # every market/price query raises "Required module 'pytz' failed to import"
+    # → the replay server 500s and every backtest fails on a fresh install. Not
+    # pulled in transitively by duckdb/fastapi/uvicorn, so pin it explicitly.
+    "pytz>=2023.3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Prepares the **0.18.0** release. Publish to PyPI is gated on you.

## Why 0.18.0 (and a heads-up)
`main` has been labeled **0.17.32** through 4 feature PRs, but PyPI's published 0.17.32 was cut at #202 (the Binance trio). So the unreleased delta on `main` is **two features**, and any release ships both:
- **`simmer backtest`** (SIM-3070, slices 2–4) — `[backtest]` extra + `simmer` CLI + `run_backtest()` + offline `--demo`.
- **Hyperliquid HIP-4 signing + venue adapter** (SIM-3151 P1 slice 1, #205) — `[hyperliquid]` extra.

Both are **opt-in extras with no change to default behavior**, so shipping them together is low-risk. ⚠️ **Decision for you:** hyperliquid's signing is validated offline (26 tests, bit-identical raw≡OWS) but **not yet funded-validated end-to-end** — confirm you're OK releasing it (gated behind the extra + explicit `client.hyperliquid`), or hold 0.18.0 until its funded leg lands.

## Release-blocking bug found (and fixed)
A clean-venv install smoke (`pip install 'simmer-sdk[backtest]'` in a fresh venv) caught that the `[backtest]` extra was **missing `pytz`**. duckdb binds the tape's tz-aware `TIMESTAMPTZ` columns through pytz, so on a fresh install every market/price query raised `Required module 'pytz' failed to import` → the replay server 500'd and **every backtest failed** (the demo returned 0 trades / 12 failed ticks). The source dev env had pytz transitively, which masked it. Pinned `pytz>=2023.3` explicitly.

## Changes
- `pyproject.toml`: version → 0.18.0; `pytz>=2023.3` added to `[backtest]`.
- `CHANGELOG.md`: 0.18.0 (backtest + hyperliquid) + a backfilled 0.17.32 (Binance trio) entry.
- `README.md`: new **Backtesting** section (CLI + programmatic + realism caveat).

## Verification
- Wheel builds; `simmer = simmer_sdk.cli:main` console-script + demo data (skill + tape) + 10 vendored replay modules all ship.
- **Fresh venv** `pip install '<wheel>[backtest]'` → `simmer --version` = 0.18.0, pytz auto-installed, `simmer backtest --demo` runs clean (50% hit, 10 settled, exit 0, `config_hash 4995db6204207cda`).

Refs SIM-3070, SIM-3151

🤖 Generated with [Claude Code](https://claude.com/claude-code)