### PR TITLE
feat(backtest): rebase wall-clock candle windows under replay (SIM-3070)

### DIFF
--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ 2c909730b34a
+# vendored from simmer_v3/replay/candles_service.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/candles_service.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ 2c909730b34a
+# vendored from simmer_v3/replay/duckdb_store.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/duckdb_store.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ 2c909730b34a
+# vendored from simmer_v3/replay/engine.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/engine.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/feeds/binance.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ 2c909730b34a
+# vendored from simmer_v3/replay/feeds/binance.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ 2c909730b34a
+# vendored from simmer_v3/replay/harness.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/harness.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 
@@ -106,7 +106,7 @@ _ENV_ALLOWLIST = ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR", "TZ",
                   "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE")
 
 
-def _subprocess_env(base_url: str, sdk_path: str) -> dict:
+def _subprocess_env(base_url: str, sdk_path: str, now: datetime) -> dict:
     env = {k: os.environ[k] for k in _ENV_ALLOWLIST if k in os.environ}
     env.update({
         "SIMMER_API_URL": base_url,
@@ -115,6 +115,13 @@ def _subprocess_env(base_url: str, sdk_path: str) -> dict:
         # fallbacks (e.g. api.binance.com when the candles plane is absent)
         # on this — a fallback firing under replay would be look-ahead.
         "SIMMER_REPLAY": "1",
+        # The frozen tick (SIM-3070): candle-signal skills window candles by
+        # datetime.now() (wall clock), which under replay is the REAL present —
+        # after the tick — so the server clamps the request to nothing. The SDK's
+        # get_candles rebases a "last N minutes ending now" request to end at this
+        # tick instead. Set ONLY here (per tick); production never sets it, so the
+        # rebase is a strict no-op for live trading.
+        "SIMMER_REPLAY_NOW": now.isoformat(),
         "PYTHONPATH": sdk_path,
         "TRADING_VENUE": "polymarket",
         "PYTHONUNBUFFERED": "1",
@@ -202,7 +209,7 @@ class BundleStrategy:
         self.tick_logs: list[dict] = []
 
     def on_tick(self, api, now: datetime) -> None:
-        env = _subprocess_env(self.base_url, self.sdk_path)
+        env = _subprocess_env(self.base_url, self.sdk_path, now)
         proc = subprocess.run(
             [sys.executable, str(self.entry), *self.extra_args],
             cwd=str(self.entry.parent), env=env,

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ 2c909730b34a
+# vendored from simmer_v3/replay/server.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/server.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/simstate.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ 2c909730b34a
+# vendored from simmer_v3/replay/simstate.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ 2c909730b34a
+# vendored from simmer_v3/replay/store.py @ a759c3089aa2
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ 96544b0f6a6c
+# vendored from simmer_v3/replay/store.py @ 2c909730b34a
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1594,6 +1594,13 @@ class SimmerClient:
             List of candle dicts: open_time, close_time (ISO), open, high,
             low, close, volume — ascending by open_time.
         """
+        # Under replay, a wall-clock-windowed skill (e.g. "last N minutes ending
+        # datetime.now()") asks for a window ending in the REAL present — after
+        # the frozen tick — so the server clamps it to nothing and the skill reads
+        # "no signal". Rebase such a request to end at the frozen tick, preserving
+        # the requested duration. SIMMER_REPLAY_NOW is set ONLY by the replay
+        # harness; live trading never sets it, so this is a strict no-op in prod.
+        start, end = self._replay_rebase_window(start, end)
         data = self._request(
             "GET", "/api/replay-data/candles",
             params={"symbol": symbol, "interval": interval, "start": start, "end": end},
@@ -1607,6 +1614,34 @@ class SimmerClient:
             data.get("served_through") or start, end,
         )
         return candles + tail
+
+    @staticmethod
+    def _replay_rebase_window(start: str, end: str):
+        """Shift a wall-clock candle window to end at the frozen replay tick.
+
+        Returns ``(start, end)`` unchanged unless ``SIMMER_REPLAY_NOW`` is set
+        (only the replay harness sets it) AND the requested window ends AFTER the
+        tick. A window that already ends at/before the tick is a valid historical
+        request and is served as-is. Preserves the requested duration so "the
+        last N minutes" stays N minutes, just ending at the tick.
+        """
+        tick_iso = os.environ.get("SIMMER_REPLAY_NOW")
+        if not tick_iso:
+            return start, end
+
+        def _iso(value):
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+        try:
+            tick = _iso(tick_iso)
+            s, e = _iso(start), _iso(end)
+        except (ValueError, TypeError):
+            return start, end
+        if e <= tick:
+            return start, end
+        offset = e - tick
+        return (s - offset).isoformat(), tick.isoformat()
 
     @staticmethod
     def _live_binance_tail(symbol: str, interval: str, start: str, end: str) -> List[dict]:

--- a/tests/test_candle_rebase.py
+++ b/tests/test_candle_rebase.py
@@ -1,0 +1,53 @@
+"""Unit tests for the replay candle-window rebase (SIM-3070).
+
+Candle-signal skills window candles by datetime.now(); under replay that's the
+real present (after the frozen tick), so the server clamps the request to
+nothing. get_candles rebases such a request to end at the frozen tick — but ONLY
+when SIMMER_REPLAY_NOW is set (the replay harness sets it; production never does).
+"""
+
+from datetime import datetime, timezone
+
+from simmer_sdk.client import SimmerClient
+
+rebase = SimmerClient._replay_rebase_window
+
+
+def test_no_op_when_env_unset(monkeypatch):
+    monkeypatch.delenv("SIMMER_REPLAY_NOW", raising=False)
+    assert rebase("2026-06-13T10:00:00+00:00", "2026-06-13T11:00:00+00:00") == (
+        "2026-06-13T10:00:00+00:00", "2026-06-13T11:00:00+00:00")
+
+
+def test_rebases_future_window_to_tick(monkeypatch):
+    # tick is April; skill asks for a 1h window ending "now" in June
+    monkeypatch.setenv("SIMMER_REPLAY_NOW", "2026-04-10T00:00:00+00:00")
+    s, e = rebase("2026-06-13T10:00:00+00:00", "2026-06-13T11:00:00+00:00")
+    # window now ends at the tick, duration preserved (1h)
+    assert e == "2026-04-10T00:00:00+00:00"
+    assert s == "2026-04-09T23:00:00+00:00"
+
+
+def test_past_window_served_as_is(monkeypatch):
+    # a window already ending at/before the tick is a valid historical request
+    monkeypatch.setenv("SIMMER_REPLAY_NOW", "2026-04-10T00:00:00+00:00")
+    assert rebase("2026-04-08T00:00:00+00:00", "2026-04-09T00:00:00+00:00") == (
+        "2026-04-08T00:00:00+00:00", "2026-04-09T00:00:00+00:00")
+
+
+def test_window_ending_exactly_at_tick_unchanged(monkeypatch):
+    monkeypatch.setenv("SIMMER_REPLAY_NOW", "2026-04-10T00:00:00+00:00")
+    assert rebase("2026-04-09T23:00:00+00:00", "2026-04-10T00:00:00+00:00") == (
+        "2026-04-09T23:00:00+00:00", "2026-04-10T00:00:00+00:00")
+
+
+def test_handles_z_suffix_and_naive(monkeypatch):
+    monkeypatch.setenv("SIMMER_REPLAY_NOW", "2026-04-10T00:00:00Z")
+    s, e = rebase("2026-06-13T10:00:00", "2026-06-13T11:00:00")  # naive => UTC
+    assert e == datetime(2026, 4, 10, tzinfo=timezone.utc).isoformat()
+
+
+def test_unparseable_input_is_no_op(monkeypatch):
+    monkeypatch.setenv("SIMMER_REPLAY_NOW", "not-a-date")
+    assert rebase("2026-06-13T10:00:00+00:00", "2026-06-13T11:00:00+00:00") == (
+        "2026-06-13T10:00:00+00:00", "2026-06-13T11:00:00+00:00")


### PR DESCRIPTION
**SDK half of the crypto-skill candle fix (SIM-3070).** Pairs with simmer `#1310` (the harness exports `SIMMER_REPLAY_NOW`) — both ship together. Lands in the next SDK release (post-0.18.0).

## Problem
Crypto-signal skills (the Binance trio) window candles by `datetime.now()` → under replay that's after the frozen tick → server clamps to nothing → `candles_served=0`, skill reads "no signal". The trio were un-backtestable despite the candle plane working.

## Fix (SDK-side, zero live-trading risk)
`get_candles` rebases a window that ends **after** the frozen tick to end **at** the tick, preserving the requested duration — gated entirely on `SIMMER_REPLAY_NOW`, which **only the replay harness sets** (per tick). Production never sets it, so the rebase is a **strict no-op for live trading**. A window already ending at/before the tick (a genuine historical request) is served as-is.

Also re-vendors the harness to export `SIMMER_REPLAY_NOW`.

## Verification
- **End-to-end:** btc-up-down over `/tmp/btcud-tape` (2026-04-06..13, 6h) now serves **899 candles (was 0)**; the skill computes real momentum from historical candles (`BTC: $69,034 | Momentum: +0.27% (up) — below 0.30% threshold, no entry`) instead of `Could not fetch BTC momentum`.
- **No regression:** demo + NEH unchanged (non-candle skills never call `get_candles`; `config_hash 4995db6204207cda` holds).
- `tests/test_candle_rebase.py` — 6 cases (no-op when env unset, rebase future window, past window as-is, Z/naive parsing, unparseable no-op). 29 backtest/cli/rebase tests pass.

> Vendored harness pins the backend **branch** sha (`2c909730`). After #1310 merges I'll re-sync to main's sha (`sync_replay_engine.py --check` flags the drift until then).

Refs SIM-3070

🤖 Generated with [Claude Code](https://claude.com/claude-code)