### PR TITLE
fix(test): skip missing-bundle backtest test without [backtest] extra (main red)

### DIFF
--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -86,6 +86,10 @@ def test_resolve_sdk_path_explicit_wins():
 # -- validation errors (CI-safe; fail before the engine import is needed) -----
 
 def test_run_backtest_rejects_missing_bundle(tmp_path):
+    # run_backtest checks for the [backtest] extra before it reaches the
+    # bundle-dir validation, so skip cleanly when the extra isn't installed —
+    # mirrors test_run_backtest_rejects_missing_{entrypoint,tape} below.
+    pytest.importorskip("duckdb", reason="requires the [backtest] extra")
     with pytest.raises(BacktestError, match="bundle dir not found"):
         run_backtest(str(tmp_path / "nope"), entrypoint="x.py",
                      tape=str(tmp_path), t0="2026-03-01", t1="2026-03-02")


### PR DESCRIPTION
## Problem
SDK `main` CI has been **red** since the 0.18.0 backtest merges (#207/#208/#210).

`tests/test_backtest_run.py::test_run_backtest_rejects_missing_bundle` asserts a `"bundle dir not found"` error, but `run_backtest` checks for the `[backtest]` extra (duckdb/fastapi/uvicorn) **before** bundle-dir validation. `ci.yml` installs `pip install -e .` (no extra), so the test receives `"the backtest engine needs extra dependencies…"` instead and fails.

## Fix
Add `pytest.importorskip("duckdb", reason="requires the [backtest] extra")` — the exact guard its two siblings (`..._missing_entrypoint`, `..._missing_tape`) already use. One line; matches the file's established pattern.

## Impact
Unblocks all SDK merges (surfaced while merging #188 worldcup-parlay-roller — main-red was masking that PR's own green status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)