### PR TITLE
feat(backtest): self-serve tape download via the backend tape service (SIM-3070 slice 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-06-14
+
+### Added
+
+- **`simmer backtest` self-serve tape download — `--window` / `--t0`/`--t1` without a local tape (SIM-3070 slice 5).** Omit `--tape` and the window slice is fetched from Simmer's backend tape service (`POST /api/backtest/tape`), which slices the canonical Polymarket dataset server-side and returns a small per-window tape (tens of MB), cached under `~/.simmer/tapes/`. No more hunting for data or downloading the 21GB public dump:
+  ```
+  simmer backtest ./my-skill --entrypoint run.py --t0 2026-03-01 --t1 2026-03-08
+  simmer backtest ./my-skill --entrypoint run.py --window 30d   # by duration
+  ```
+  New flags `--max-markets` / `--min-volume` (clamp the slice; server caps at 1000 markets) and `--base-url` (defaults to `SIMMER_API_URL` env or production). `run_backtest(...)` now accepts `tape=None` (fetch) plus `max_markets` / `min_volume` / `base_url`. `--tape <local>` stays as a BYO escape hatch. Why server-side slicing: the public HF dump's CDN serves the 21GB file at ~0.44 MB/s, so client-side window slicing over httpfs is impractical; the backend stages the dataset into fast object storage once and slices intra-datacenter. Data coverage currently ends ~2026-05-05 (a freshness fetcher is the next follow-up).
+
 ## [0.18.0] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,9 +152,13 @@ pip install 'simmer-sdk[backtest]'
 # Try it offline — bundled 10-market demo slice, no data download:
 simmer backtest --demo
 
-# Backtest your own skill over a local tape slice:
-simmer backtest ./my-skill --entrypoint run.py --tape ./slice \
+# Backtest your own skill over a window — the tape is fetched + cached for you:
+simmer backtest ./my-skill --entrypoint run.py \
     --t0 2026-03-01 --t1 2026-03-08 --cadence 12h --out report.json
+
+# ...or by duration, and with your own local slice (BYO):
+simmer backtest ./my-skill --entrypoint run.py --window 30d
+simmer backtest ./my-skill --entrypoint run.py --tape ./slice --t0 2026-03-01 --t1 2026-03-08
 ```
 
 The engine replays your **unmodified** skill against a frozen, look-ahead-safe
@@ -165,15 +169,16 @@ trades, baselines (buy-and-hold-YES / random), realism gaps, and a reproducible
 ```python
 from simmer_sdk.backtest import run_backtest
 
-report = run_backtest("./my-skill", entrypoint="run.py", tape="./slice",
+# tape omitted => the window slice is fetched from the tape service and cached.
+report = run_backtest("./my-skill", entrypoint="run.py",
                       t0="2026-03-01", t1="2026-03-08", cadence="12h")
 print(report["summary"]["pnl"], report["summary"]["hit_rate"])
 ```
 
 > Backtests use trade-tape prices (no orderbook), so they model decision quality,
-> not execution realism — every report lists its `realism_gaps`. Self-serve
-> `--window` (auto-download a historical slice) is coming; for now pass a local
-> `--tape` directory or use `--demo`.
+> not execution realism — every report lists its `realism_gaps`. The window slice
+> is fetched from Simmer's tape service and cached under `~/.simmer/tapes/`; pass
+> `--tape <dir>` to use your own. Data coverage currently ends ~2026-05-05.
 
 ## Key Methods
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.18.0"
+version = "0.19.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/backtest/__init__.py
+++ b/simmer_sdk/backtest/__init__.py
@@ -143,6 +143,7 @@ def run_backtest(
     max_markets: int = 300,
     min_volume: float = 1000.0,
     base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
     cadence: Union[str, int, float, timedelta] = "15m",
     balance: float = 1000.0,
     fee_rate: float = 0.0,
@@ -171,6 +172,8 @@ def run_backtest(
         min_volume: min market volume for a fetched slice. Ignored for a local tape.
         base_url: tape-service base URL (default: ``SIMMER_API_URL`` env or
             production). Ignored when ``tape`` is an explicit local dir.
+        api_key: Simmer API key for the tape fetch (default: ``SIMMER_API_KEY``
+            env — the same key you trade with). Ignored for a local ``tape``.
         cadence: tick spacing — ``15m`` / ``12h`` / ``30d``, minutes, or timedelta.
         balance: starting balance.
         fee_rate: per-fill fee rate (0 = none; baselines ignore fees in v0).
@@ -215,7 +218,8 @@ def run_backtest(
 
         try:
             tape = fetch_tape(
-                t0, t1, max_markets=max_markets, min_volume=min_volume, base_url=base_url
+                t0, t1, max_markets=max_markets, min_volume=min_volume,
+                base_url=base_url, api_key=api_key,
             )
         except TapeFetchError as exc:
             raise BacktestError(str(exc)) from exc

--- a/simmer_sdk/backtest/__init__.py
+++ b/simmer_sdk/backtest/__init__.py
@@ -137,9 +137,12 @@ def run_backtest(
     bundle: str,
     *,
     entrypoint: str,
-    tape: str,
+    tape: Optional[str] = None,
     t0: Union[str, datetime],
     t1: Union[str, datetime],
+    max_markets: int = 300,
+    min_volume: float = 1000.0,
+    base_url: Optional[str] = None,
     cadence: Union[str, int, float, timedelta] = "15m",
     balance: float = 1000.0,
     fee_rate: float = 0.0,
@@ -158,9 +161,16 @@ def run_backtest(
         entrypoint: script filename inside the bundle to run each tick
             (e.g. ``nothing_ever_happens.py``).
         tape: local dir holding ``markets.parquet`` + ``quant.parquet``
-            (+ optional ``manifest.json``) — as produced by
-            ``scripts/replay_run.py extract``. Remote/window download is slice 5.
+            (+ optional ``manifest.json``). When omitted, the slice for
+            ``[t0, t1]`` is fetched from the backend tape service and cached
+            under ``~/.simmer/tapes/`` (``POST /api/backtest/tape``); pass an
+            explicit dir to use your own local slice (BYO escape hatch).
         t0, t1: window bounds (ISO string or datetime; naive => UTC).
+        max_markets: cap on markets in a fetched slice (server clamps to 1000).
+            Ignored when ``tape`` is an explicit local dir.
+        min_volume: min market volume for a fetched slice. Ignored for a local tape.
+        base_url: tape-service base URL (default: ``SIMMER_API_URL`` env or
+            production). Ignored when ``tape`` is an explicit local dir.
         cadence: tick spacing — ``15m`` / ``12h`` / ``30d``, minutes, or timedelta.
         balance: starting balance.
         fee_rate: per-fill fee rate (0 = none; baselines ignore fees in v0).
@@ -198,6 +208,17 @@ def run_backtest(
         raise BacktestError(f"bundle dir not found: {bundle}")
     if not os.path.exists(os.path.join(bundle, entrypoint)):
         raise BacktestError(f"entrypoint {entrypoint!r} not found in bundle {bundle}")
+
+    # No local tape => fetch (and cache) the slice for [t0, t1] from the backend.
+    if tape is None:
+        from .tape import TapeFetchError, fetch_tape
+
+        try:
+            tape = fetch_tape(
+                t0, t1, max_markets=max_markets, min_volume=min_volume, base_url=base_url
+            )
+        except TapeFetchError as exc:
+            raise BacktestError(str(exc)) from exc
 
     markets_pq = os.path.join(tape, "markets.parquet")
     quant_pq = os.path.join(tape, "quant.parquet")

--- a/simmer_sdk/backtest/tape.py
+++ b/simmer_sdk/backtest/tape.py
@@ -79,6 +79,7 @@ def fetch_tape(
     max_markets: int = 300,
     min_volume: float = 1000.0,
     base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
     cache_dir: Optional[str] = None,
     refresh: bool = False,
     timeout: int = 300,
@@ -86,12 +87,20 @@ def fetch_tape(
 ) -> str:
     """Fetch (or reuse a cached) tape slice for ``[t0, t1]``; return its local dir.
 
-    Calls ``POST {base_url}/api/backtest/tape``; downloads the presigned
+    Calls ``POST {base_url}/api/backtest/tape`` (Simmer API key required — the
+    same ``SIMMER_API_KEY`` you trade with); downloads the presigned
     markets.parquet + quant.parquet + manifest.json into ``~/.simmer/tapes/<key>/``.
     The server keys the slice by (dataset_rev, window, max_markets, min_volume),
     so the cache key is stable across callers.
     """
     base = _resolve_base_url(base_url)
+    key = api_key or os.getenv("SIMMER_API_KEY")
+    if not key:
+        raise TapeFetchError(
+            "a Simmer API key is required to fetch a tape — set SIMMER_API_KEY "
+            "(the same key you trade with) or pass api_key=..., or use --tape "
+            "<local-dir> / --demo to skip the download."
+        )
     payload = {
         "t0": _iso_date(t0),
         "t1": _iso_date(t1),
@@ -101,10 +110,18 @@ def fetch_tape(
     log(f"requesting tape slice {payload['t0']}..{payload['t1']} "
         f"(max {max_markets} markets, min volume {min_volume:,.0f}) from {base}...")
     try:
-        resp = requests.post(base + _TAPE_ENDPOINT, json=payload, timeout=60)
+        resp = requests.post(
+            base + _TAPE_ENDPOINT, json=payload,
+            headers={"Authorization": f"Bearer {key}"}, timeout=60,
+        )
     except requests.RequestException as exc:
         raise TapeFetchError(f"could not reach the tape service at {base}: {exc}") from exc
 
+    if resp.status_code in (401, 403):
+        raise TapeFetchError(_detail(resp, "tape request rejected — check SIMMER_API_KEY"))
+    if resp.status_code == 429:
+        raise TapeFetchError(_detail(resp, "backtest tape rate limit reached — wait a minute "
+                                           "(cached windows are free)"))
     if resp.status_code == 422:
         raise TapeFetchError(_detail(resp, "invalid backtest window"))
     if resp.status_code == 503:

--- a/simmer_sdk/backtest/tape.py
+++ b/simmer_sdk/backtest/tape.py
@@ -1,0 +1,159 @@
+"""Self-serve tape download for `simmer backtest` (SIM-3070 slice 5).
+
+`simmer backtest` needs a *tape* — a local dir of ``markets.parquet`` +
+``quant.parquet`` for the window under test. This module fetches one from
+Simmer's backend (``POST /api/backtest/tape``), which slices the canonical
+Polymarket dataset server-side and returns presigned URLs to a small per-window
+slice (tens of MB). The slice is cached under ``~/.simmer/tapes/`` so a repeat
+window is instant.
+
+Why not fetch from HuggingFace directly: the public dump's CDN serves the 21GB
+``quant.parquet`` at ~0.44 MB/s, so client-side window slicing over httpfs times
+out. The backend stages the dataset into fast object storage once and slices
+intra-datacenter (SIM-3070, 2026-06-14). ``--tape <local>`` stays as a BYO
+escape hatch for power users who have their own slice.
+
+No ``[backtest]`` extra needed here — fetching is plain HTTP (only the engine,
+which runs the tape, needs duckdb).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional, Union
+from datetime import datetime
+
+import requests
+
+# Last day the canonical dataset covers, until the freshness fetcher (slice 6)
+# grows it. A window starting past this errors server-side too, but checking
+# locally gives a clearer message without a round-trip.
+DATASET_END = "2026-05-05"
+_TAPE_ENDPOINT = "/api/backtest/tape"
+
+
+class TapeFetchError(RuntimeError):
+    """Raised when a tape window can't be fetched (bad window, network, server)."""
+
+
+def cache_root() -> Path:
+    root = os.environ.get("SIMMER_TAPE_CACHE") or os.path.join(
+        os.path.expanduser("~"), ".simmer", "tapes"
+    )
+    p = Path(root)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _resolve_base_url(base_url: Optional[str]) -> str:
+    url = base_url or os.getenv("SIMMER_API_URL") or "https://api.simmer.markets"
+    return url.rstrip("/")
+
+
+def _iso_date(value: Union[str, datetime]) -> str:
+    """ISO date string for the request body (accepts str or datetime)."""
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    return str(value)
+
+
+def _download(url: str, dest: Path, *, timeout: int = 300) -> None:
+    tmp = Path(tempfile.mkstemp(dir=str(dest.parent), suffix=".part")[1])
+    try:
+        with requests.get(url, stream=True, timeout=timeout) as r:
+            r.raise_for_status()
+            with open(tmp, "wb") as fh:
+                for chunk in r.iter_content(chunk_size=1 << 20):
+                    fh.write(chunk)
+        os.replace(tmp, dest)  # atomic
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def fetch_tape(
+    t0: Union[str, datetime],
+    t1: Union[str, datetime],
+    *,
+    max_markets: int = 300,
+    min_volume: float = 1000.0,
+    base_url: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    refresh: bool = False,
+    timeout: int = 300,
+    log=print,
+) -> str:
+    """Fetch (or reuse a cached) tape slice for ``[t0, t1]``; return its local dir.
+
+    Calls ``POST {base_url}/api/backtest/tape``; downloads the presigned
+    markets.parquet + quant.parquet + manifest.json into ``~/.simmer/tapes/<key>/``.
+    The server keys the slice by (dataset_rev, window, max_markets, min_volume),
+    so the cache key is stable across callers.
+    """
+    base = _resolve_base_url(base_url)
+    payload = {
+        "t0": _iso_date(t0),
+        "t1": _iso_date(t1),
+        "max_markets": int(max_markets),
+        "min_volume": float(min_volume),
+    }
+    log(f"requesting tape slice {payload['t0']}..{payload['t1']} "
+        f"(max {max_markets} markets, min volume {min_volume:,.0f}) from {base}...")
+    try:
+        resp = requests.post(base + _TAPE_ENDPOINT, json=payload, timeout=60)
+    except requests.RequestException as exc:
+        raise TapeFetchError(f"could not reach the tape service at {base}: {exc}") from exc
+
+    if resp.status_code == 422:
+        raise TapeFetchError(_detail(resp, "invalid backtest window"))
+    if resp.status_code == 503:
+        raise TapeFetchError(_detail(resp, "the backtest tape service is unavailable"))
+    if not resp.ok:
+        raise TapeFetchError(_detail(resp, f"tape request failed ({resp.status_code})"))
+
+    body = resp.json()
+    key = body.get("key")
+    urls = body.get("urls") or {}
+    if not key or not urls.get("markets") or not urls.get("quant"):
+        raise TapeFetchError(f"malformed tape response from {base}: {body!r}")
+
+    root = Path(cache_dir) if cache_dir else cache_root()
+    root.mkdir(parents=True, exist_ok=True)
+    slice_dir = root / key
+    markets_pq = slice_dir / "markets.parquet"
+    quant_pq = slice_dir / "quant.parquet"
+    if markets_pq.exists() and quant_pq.exists() and not refresh:
+        log(f"using cached tape: {slice_dir}")
+        return str(slice_dir)
+
+    slice_dir.mkdir(parents=True, exist_ok=True)
+    n_markets = body.get("markets")
+    n_quant = body.get("quant_rows")
+    log(f"downloading slice ({n_markets} markets, "
+        f"{f'{n_quant:,}' if isinstance(n_quant, int) else '?'} prints)"
+        f"{' [server cache hit]' if body.get('cached') else ''}...")
+    try:
+        _download(urls["markets"], markets_pq, timeout=timeout)
+        _download(urls["quant"], quant_pq, timeout=timeout)
+        if urls.get("manifest"):
+            try:
+                _download(urls["manifest"], slice_dir / "manifest.json", timeout=timeout)
+            except Exception:
+                pass  # manifest is best-effort (only feeds dataset_rev labeling)
+    except requests.RequestException as exc:
+        # don't leave a half-downloaded slice that a later run would treat as cached
+        import shutil
+
+        shutil.rmtree(slice_dir, ignore_errors=True)
+        raise TapeFetchError(f"failed downloading the tape slice: {exc}") from exc
+
+    log(f"tape ready → {slice_dir}")
+    return str(slice_dir)
+
+
+def _detail(resp, fallback: str) -> str:
+    try:
+        return resp.json().get("detail") or fallback
+    except Exception:
+        return fallback

--- a/simmer_sdk/cli.py
+++ b/simmer_sdk/cli.py
@@ -3,9 +3,12 @@
 
 Currently one subcommand:
 
-    simmer backtest <bundle> --entrypoint run.py --tape ./slice \
+    # fetch + cache the window slice from the tape service (no local tape needed)
+    simmer backtest <bundle> --entrypoint run.py \
         --t0 2026-03-01 --t1 2026-03-08 [--cadence 12h] [--out report.json]
 
+    simmer backtest <bundle> --entrypoint run.py --window 30d   # window by duration
+    simmer backtest <bundle> --entrypoint run.py --tape ./slice --t0 ... --t1 ...  # BYO slice
     simmer backtest --demo        # bundled offline demo, no tape needed
 
 Backtest an UNMODIFIED skill bundle against historical prediction-market data
@@ -105,18 +108,41 @@ def _print_summary(report: dict, *, balance: float) -> None:
 
 # -- backtest subcommand ------------------------------------------------------
 
+_WINDOW_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def _resolve_window(args: argparse.Namespace) -> tuple[str, str]:
+    """Return (t0, t1) ISO dates from explicit --t0/--t1 or a --window duration.
+
+    --window <Nd/Nh/...> anchors to --t1 (or the dataset end until the freshness
+    fetcher lands) and walks back. Explicit --t0/--t1 take precedence.
+    """
+    import re
+    from datetime import datetime, timedelta, timezone
+
+    from simmer_sdk.backtest.tape import DATASET_END
+
+    if args.t0 and args.t1:
+        return args.t0, args.t1
+    if args.window:
+        m = re.fullmatch(r"(\d+(?:\.\d+)?)\s*([smhd]?)", str(args.window).strip().lower())
+        if not m:
+            raise ValueError(f"--window {args.window!r} not understood — use e.g. 30d, 12h, 90d")
+        span = timedelta(seconds=float(m.group(1)) * _WINDOW_UNITS[m.group(2) or "d"])
+        t1 = datetime.fromisoformat(args.t1) if args.t1 else datetime.fromisoformat(DATASET_END)
+        t1 = t1.replace(tzinfo=timezone.utc)
+        t0 = t1 - span
+        return t0.date().isoformat(), t1.date().isoformat()
+    raise ValueError("a window is required — pass --t0 and --t1, or --window 30d "
+                     "(or --demo for the bundled offline demo)")
+
+
 def _cmd_backtest(args: argparse.Namespace) -> int:
     try:
         from simmer_sdk.backtest import BacktestError, run_backtest
     except ImportError as exc:
         print(f"error: could not import the backtest engine ({exc})\n"
               "install it with:  pip install 'simmer-sdk[backtest]'", file=sys.stderr)
-        return 2
-
-    if args.window:
-        print("error: --window (self-serve tape download) is not available yet "
-              "(SIM-3070 slice 5).\nFor now pass --tape <dir> with a local slice, "
-              "or --demo for the bundled offline demo.", file=sys.stderr)
         return 2
 
     if args.demo:
@@ -128,16 +154,21 @@ def _cmd_backtest(args: argparse.Namespace) -> int:
         # the demo skill reads no candles — keep the run hermetic + fast.
         candles = False
     else:
+        # tape is now OPTIONAL — omit it and the window slice is fetched from the
+        # backend tape service and cached. --window derives [t0,t1] for convenience.
+        try:
+            t0, t1 = _resolve_window(args)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
         missing = [n for n, v in (("bundle", args.bundle),
-                                  ("--entrypoint", args.entrypoint),
-                                  ("--tape", args.tape),
-                                  ("--t0", args.t0), ("--t1", args.t1)) if not v]
+                                  ("--entrypoint", args.entrypoint)) if not v]
         if missing:
             print("error: " + ", ".join(missing) + " required "
                   "(or pass --demo for the bundled offline demo)", file=sys.stderr)
             return 2
         bundle, entrypoint, tape = args.bundle, args.entrypoint, args.tape
-        t0, t1, cadence = args.t0, args.t1, args.cadence
+        cadence = args.cadence
         candles = not args.no_candles
 
     try:
@@ -147,6 +178,9 @@ def _cmd_backtest(args: argparse.Namespace) -> int:
             tape=tape,
             t0=t0,
             t1=t1,
+            max_markets=args.max_markets,
+            min_volume=args.min_volume,
+            base_url=args.base_url,
             cadence=cadence,
             balance=args.balance,
             fee_rate=args.fee_rate,
@@ -193,9 +227,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     bt.add_argument("bundle", nargs="?", help="path to the skill bundle dir")
     bt.add_argument("--entrypoint", help="script filename inside the bundle to run each tick")
-    bt.add_argument("--tape", help="local tape slice dir (markets.parquet + quant.parquet)")
+    bt.add_argument("--tape", help="local tape slice dir (markets.parquet + quant.parquet); "
+                                   "omit to fetch + cache the window from the tape service")
     bt.add_argument("--t0", help="window start (ISO, e.g. 2026-03-01)")
     bt.add_argument("--t1", help="window end (ISO)")
+    bt.add_argument("--max-markets", type=int, default=300, dest="max_markets",
+                    help="cap on markets in a fetched slice (default 300; server clamps to 1000)")
+    bt.add_argument("--min-volume", type=float, default=1000.0, dest="min_volume",
+                    help="min market volume for a fetched slice (default 1000)")
+    bt.add_argument("--base-url", default=None, dest="base_url",
+                    help="tape-service base URL (default: SIMMER_API_URL env or production)")
     bt.add_argument("--cadence", default="15m", help="tick spacing: 15m / 12h / 30d / minutes (default 15m)")
     bt.add_argument("--balance", type=float, default=1000.0, help="starting balance (default 1000)")
     bt.add_argument("--fee-rate", type=float, default=0.0, dest="fee_rate", help="per-fill fee rate (default 0)")
@@ -216,7 +257,8 @@ def _build_parser() -> argparse.ArgumentParser:
     bt.add_argument("--out", default=None, help="write the full report JSON here")
     bt.add_argument("--demo", action="store_true", help="run the bundled offline demo (no tape needed)")
     bt.add_argument("--window", default=None,
-                    help="(coming in slice 5) self-serve tape download, e.g. 30d — use --tape for now")
+                    help="window duration to fetch, e.g. 30d / 12h — anchored to --t1 "
+                         "or the dataset end. Alternative to explicit --t0/--t1.")
     bt.set_defaults(fn=_cmd_backtest)
     return p
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,11 +20,28 @@ def test_backtest_requires_inputs_or_demo(capsys):
     assert "required" in capsys.readouterr().err
 
 
-def test_window_flag_is_not_yet_supported(capsys):
-    rc = cli.main(["backtest", "./b", "--entrypoint", "r.py", "--tape", "./t",
-                   "--t0", "2026-03-01", "--t1", "2026-03-02", "--window", "30d"])
-    assert rc == 2
-    assert "slice 5" in capsys.readouterr().err
+def test_resolve_window_from_duration():
+    import argparse
+
+    # --window anchors to the dataset end when --t1 is absent and walks back.
+    a = argparse.Namespace(t0=None, t1=None, window="30d")
+    t0, t1 = cli._resolve_window(a)
+    assert t1 == "2026-05-05" and t0 == "2026-04-05"
+
+
+def test_resolve_window_explicit_takes_precedence():
+    import argparse
+
+    a = argparse.Namespace(t0="2026-03-01", t1="2026-03-08", window="30d")
+    assert cli._resolve_window(a) == ("2026-03-01", "2026-03-08")
+
+
+def test_resolve_window_requires_a_window():
+    import argparse
+
+    a = argparse.Namespace(t0=None, t1=None, window=None)
+    with pytest.raises(ValueError, match="window is required"):
+        cli._resolve_window(a)
 
 
 def test_version_exits_zero(capsys):

--- a/tests/test_tape_endpoint.py
+++ b/tests/test_tape_endpoint.py
@@ -1,0 +1,121 @@
+"""Tests for the endpoint-backed tape fetcher (SIM-3070 slice 5).
+
+Mocks the backend tape service (POST /api/backtest/tape) + the presigned
+downloads — no network, no bucket. Verifies request shape, caching, and error
+mapping.
+"""
+
+import json
+import os
+
+import pytest
+
+from simmer_sdk.backtest import tape as tp
+
+
+class _Resp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.ok = 200 <= status_code < 300
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise AssertionError("raise_for_status on error")
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("SIMMER_TAPE_CACHE", str(tmp_path))
+    return tmp_path
+
+
+def _ok_body(key="abc123"):
+    return {
+        "key": key,
+        "dataset_rev": "rev1",
+        "t0": "2026-03-01", "t1": "2026-03-08",
+        "markets": 12, "quant_rows": 3456,
+        "expires_in": 3600, "cached": False,
+        "urls": {
+            "markets": "https://bucket/slices/%s/markets.parquet" % key,
+            "quant": "https://bucket/slices/%s/quant.parquet" % key,
+            "manifest": "https://bucket/slices/%s/manifest.json" % key,
+        },
+    }
+
+
+def _patch_download(monkeypatch):
+    """_download just writes a stub file so cache/existence logic is exercised."""
+    def fake(url, dest, timeout=300):
+        with open(dest, "wb") as fh:
+            fh.write(b"PAR1")
+    monkeypatch.setattr(tp, "_download", fake)
+
+
+def test_fetch_tape_success_and_request_shape(cache, monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _Resp(200, _ok_body())
+
+    monkeypatch.setattr(tp.requests, "post", fake_post)
+    _patch_download(monkeypatch)
+
+    out = tp.fetch_tape("2026-03-01", "2026-03-08", max_markets=50, min_volume=2000,
+                        base_url="http://localhost:8000")
+    assert captured["url"] == "http://localhost:8000/api/backtest/tape"
+    assert captured["json"] == {"t0": "2026-03-01", "t1": "2026-03-08",
+                                "max_markets": 50, "min_volume": 2000.0}
+    assert os.path.exists(os.path.join(out, "markets.parquet"))
+    assert os.path.exists(os.path.join(out, "quant.parquet"))
+
+
+def test_fetch_tape_cache_hit_skips_redownload(cache, monkeypatch):
+    monkeypatch.setattr(tp.requests, "post", lambda *a, **k: _Resp(200, _ok_body()))
+    calls = {"n": 0}
+
+    def fake(url, dest, timeout=300):
+        calls["n"] += 1
+        with open(dest, "wb") as fh:
+            fh.write(b"PAR1")
+    monkeypatch.setattr(tp, "_download", fake)
+
+    tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
+    first = calls["n"]
+    assert first >= 2  # markets + quant downloaded
+    tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
+    assert calls["n"] == first  # cached → no further downloads
+
+
+def test_fetch_tape_maps_422(cache, monkeypatch):
+    monkeypatch.setattr(tp.requests, "post",
+                        lambda *a, **k: _Resp(422, {"detail": "window exceeds the 365-day ceiling"}))
+    with pytest.raises(tp.TapeFetchError, match="365-day"):
+        tp.fetch_tape("2024-01-01", "2026-01-01", base_url="http://x")
+
+
+def test_fetch_tape_maps_503(cache, monkeypatch):
+    monkeypatch.setattr(tp.requests, "post",
+                        lambda *a, **k: _Resp(503, {"detail": "tape service is not configured"}))
+    with pytest.raises(tp.TapeFetchError, match="not configured"):
+        tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
+
+
+def test_fetch_tape_malformed_response(cache, monkeypatch):
+    monkeypatch.setattr(tp.requests, "post", lambda *a, **k: _Resp(200, {"key": "x"}))  # no urls
+    with pytest.raises(tp.TapeFetchError, match="malformed"):
+        tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
+
+
+def test_base_url_resolution_prefers_env(monkeypatch):
+    monkeypatch.delenv("SIMMER_API_URL", raising=False)
+    assert tp._resolve_base_url(None) == "https://api.simmer.markets"
+    monkeypatch.setenv("SIMMER_API_URL", "http://localhost:9000/")
+    assert tp._resolve_base_url(None) == "http://localhost:9000"
+    assert tp._resolve_base_url("http://explicit:1/") == "http://explicit:1"

--- a/tests/test_tape_endpoint.py
+++ b/tests/test_tape_endpoint.py
@@ -30,6 +30,7 @@ class _Resp:
 @pytest.fixture
 def cache(tmp_path, monkeypatch):
     monkeypatch.setenv("SIMMER_TAPE_CACHE", str(tmp_path))
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_live_test")
     return tmp_path
 
 
@@ -59,9 +60,10 @@ def _patch_download(monkeypatch):
 def test_fetch_tape_success_and_request_shape(cache, monkeypatch):
     captured = {}
 
-    def fake_post(url, json=None, timeout=None):
+    def fake_post(url, json=None, headers=None, timeout=None):
         captured["url"] = url
         captured["json"] = json
+        captured["headers"] = headers
         return _Resp(200, _ok_body())
 
     monkeypatch.setattr(tp.requests, "post", fake_post)
@@ -72,8 +74,30 @@ def test_fetch_tape_success_and_request_shape(cache, monkeypatch):
     assert captured["url"] == "http://localhost:8000/api/backtest/tape"
     assert captured["json"] == {"t0": "2026-03-01", "t1": "2026-03-08",
                                 "max_markets": 50, "min_volume": 2000.0}
+    assert captured["headers"]["Authorization"] == "Bearer sk_live_test"
     assert os.path.exists(os.path.join(out, "markets.parquet"))
     assert os.path.exists(os.path.join(out, "quant.parquet"))
+
+
+def test_fetch_tape_requires_api_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("SIMMER_TAPE_CACHE", str(tmp_path))
+    monkeypatch.delenv("SIMMER_API_KEY", raising=False)
+    with pytest.raises(tp.TapeFetchError, match="API key"):
+        tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
+
+
+def test_fetch_tape_maps_401(cache, monkeypatch):
+    monkeypatch.setattr(tp.requests, "post",
+                        lambda *a, **k: _Resp(401, {"detail": "invalid api key"}))
+    with pytest.raises(tp.TapeFetchError, match="SIMMER_API_KEY|api key"):
+        tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
+
+
+def test_fetch_tape_maps_429(cache, monkeypatch):
+    monkeypatch.setattr(tp.requests, "post",
+                        lambda *a, **k: _Resp(429, {"detail": "rate limit reached"}))
+    with pytest.raises(tp.TapeFetchError, match="rate limit"):
+        tp.fetch_tape("2026-03-01", "2026-03-08", base_url="http://x")
 
 
 def test_fetch_tape_cache_hit_skips_redownload(cache, monkeypatch):


### PR DESCRIPTION
## What
SDK half of SIM-3070 slice 5. `simmer backtest` no longer needs a local tape: omit `--tape` (or pass `--window 30d`) and the window slice is fetched from `POST /api/backtest/tape`, cached under `~/.simmer/tapes/`.

## Changes
- `simmer_sdk/backtest/tape.py` — `fetch_tape()`: POST window+limits, download presigned markets/quant parquet, cache by server slice key; maps 422/503 to clear errors. No `[backtest]` extra needed (plain HTTP).
- `run_backtest(tape=None)` fetches; new `max_markets` / `min_volume` / `base_url` params.
- `cli.py` — `--window` resolves `[t0,t1]` (anchored to dataset end); `--t0/--t1` without `--tape` fetches; new `--max-markets`/`--min-volume`/`--base-url`; `--tape` stays as BYO escape hatch. Replaces the shelved client-side HF-httpfs auto-fetch.
- 0.19.0; CHANGELOG + README.

## Tests
- 6 mocked tape-fetch tests (request shape, cache hit, 422/503/malformed, base-url resolution).
- `--window` CLI resolution tests; `--demo` end-to-end still passes. 14 backtest/cli/tape tests green.

## Sequencing
Depends on the backend endpoint (simmer #1325) being live before publish.

SIM-3070

🤖 Generated with [Claude Code](https://claude.com/claude-code)