### PR TITLE
chore(security): CODEOWNERS money-path red fence (SIM-3220)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Money-path code owners — SDK red fence (SIM-3220, mirrors the main simmer repo).
+#
+# Any PR touching SDK signing / redemption code requires a human (code-owner)
+# review before merge, regardless of author (agent or human). The SDK signs
+# REAL orders and transactions, so these are the highest-risk money paths in
+# the package — and until now they had no fence (weaker than the main repo,
+# which is backwards from the risk).
+#
+# Requires branch protection on `main`: "Require review from Code Owners".
+#
+# Known gap: client.py orchestrates trade execution + signing but is too broad
+# to require review wholesale (it changes on most SDK PRs). Fence it explicitly
+# if SDK velocity allows, or as signing concentrates out of it. The dedicated
+# signing modules below are the focused money-correctness surface.
+
+/simmer_sdk/signing.py              @adlai88
+/simmer_sdk/ows_utils.py            @adlai88
+/simmer_sdk/solana_signing.py       @adlai88
+/simmer_sdk/hyperliquid_signing.py  @adlai88
+/simmer_sdk/dw_redeem.py            @adlai88


### PR DESCRIPTION
Mirrors the main simmer repo's red fence onto the SDK. The SDK signs **real orders + transactions** but had **no** money-path review fence — weaker protection than the main repo, backwards from the risk.

Adds `.github/CODEOWNERS` requiring a human (code-owner) review before any PR touching the SDK signing/redemption modules can merge: `signing.py`, `ows_utils.py`, `solana_signing.py`, `hyperliquid_signing.py`, `dw_redeem.py`.

Activates once branch protection enables **Require review from Code Owners** (enabling that next, same as main). Known gap noted in-file: `client.py` is too broad to fence wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)