### PR TITLE
fix(sdk): find_markets() reaches the full catalogue via server q filter (SIM-3241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-06-15
+
+### Fixed
+
+- **`find_markets()` now reaches the full active catalogue, not just the most-recent browse slice (SIM-3241).** `find_markets(query)` previously fetched an *unfiltered* `get_markets(limit=100)` window and filtered client-side, so any market outside the newest-N server window was invisible to it — most visibly a large portion of live World Cup markets that an agent could see on the dashboard but not via `find_markets()`. It now pushes `query` to the server-side `q` filter, which is applied **before** the window, so older-but-active markets are found. Queries shorter than 2 chars fall back to the previous windowed scan (the server `q` filter requires >= 2 chars). Trading was never affected — this is a discovery-only fix, and `get_markets(tags=..., q=..., sort="volume")` already reached these markets. Companion MCP `simmer_get_markets` (simmer-mcp 3.4.3) gains a tool-description note that unfiltered browse is windowed and to pass `tags`/`q`/`sort` to reach a full category. The default unfiltered browse ordering is tracked separately (SIM-3126) and intentionally unchanged here.
+
 ## [0.19.0] - 2026-06-14
 
 ### Added

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -734,6 +734,11 @@ if (simmer) {
     description: [
       "List or search markets available for trading.",
       "Use 'q' for text search. Results include price, volume, and venue.",
+      "Unfiltered browse is windowed to the most-recent slice of the catalogue,",
+      "so to reach the full set for a category (e.g. World Cup) pass a filter:",
+      "tags (e.g. tags='world-cup'), a 'q' query, or sort='volume'. Filters are",
+      "applied server-side BEFORE the window, so they reach older-but-active",
+      "markets a plain browse would miss.",
       "Default limit is 50; max is 500.",
     ],
     schema: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.19.0"
+version = "0.19.1"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2567,14 +2567,24 @@ class SimmerClient:
         """
         Search markets by question text.
 
+        Uses the server-side keyword filter (``q``), which is applied BEFORE the
+        result window, so matches are found across the full active catalogue --
+        not just the most-recent browse slice. This matters for older-but-active
+        markets (e.g. World Cup markets outside the newest-N window): a plain
+        windowed browse would silently miss them. Queries shorter than 2 chars
+        fall back to a windowed client-side scan (the server filter needs >= 2).
+
         Args:
             query: Search string
 
         Returns:
             List of matching markets
         """
-        markets = self.get_markets(limit=100)
         query_lower = query.lower()
+        if len(query.strip()) >= 2:
+            markets = self.get_markets(q=query, limit=100)
+        else:
+            markets = self.get_markets(limit=100)
         return [m for m in markets if query_lower in m.question.lower()]
 
     def get_open_orders(self) -> Dict[str, Any]:

--- a/tests/test_find_markets_server_query.py
+++ b/tests/test_find_markets_server_query.py
@@ -1,0 +1,59 @@
+"""Tests for find_markets server-side keyword filtering (SIM-3241).
+
+find_markets must push the query to the server ``q`` filter, which is applied
+BEFORE the result window, so matches are found across the full active
+catalogue -- not just the most-recent browse slice. Previously it fetched an
+unfiltered window and filtered client-side, silently missing older-but-active
+markets (e.g. World Cup markets outside the newest-N window).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+
+
+def _client() -> SimmerClient:
+    return SimmerClient.__new__(SimmerClient)
+
+
+def _market(question: str):
+    return SimpleNamespace(question=question)
+
+
+def test_find_markets_pushes_query_to_server_q():
+    """A >=2-char query is forwarded as the server-side ``q`` filter."""
+    client = _client()
+    client.get_markets = MagicMock(
+        return_value=[_market("Will Brazil win the World Cup?")]
+    )
+
+    results = client.find_markets("world cup")
+
+    client.get_markets.assert_called_once_with(q="world cup", limit=100)
+    assert len(results) == 1
+
+
+def test_find_markets_still_filters_client_side():
+    """The client-side substring filter still narrows the server result set."""
+    client = _client()
+    client.get_markets = MagicMock(
+        return_value=[
+            _market("Will Brazil win the World Cup?"),
+            _market("Will it rain in Dallas?"),
+        ]
+    )
+
+    results = client.find_markets("world cup")
+
+    assert [m.question for m in results] == ["Will Brazil win the World Cup?"]
+
+
+def test_find_markets_short_query_falls_back_to_unfiltered():
+    """Server ``q`` needs >= 2 chars; a 1-char query must not be pushed as ``q``."""
+    client = _client()
+    client.get_markets = MagicMock(return_value=[_market("A market")])
+
+    client.find_markets("a")
+
+    client.get_markets.assert_called_once_with(limit=100)


### PR DESCRIPTION
## Problem (SIM-3241)

`SimmerClient.find_markets(query)` and the unfiltered MCP `simmer_get_markets` browse missed a large portion of World Cup markets that were visible on the dashboard.

Root cause: `find_markets` fetched an **unfiltered** `get_markets(limit=100)` window and filtered client-side:

```python
markets = self.get_markets(limit=100)        # newest-N slice of ~21k active markets
return [m for m in markets if query_lower in m.question.lower()]
```

The server windows unfiltered browse to the most-recent slice, so any older-but-active market (e.g. WC markets outside the newest-N window) was never in the candidate set — even though `get_markets` already exposes a server-side `q`/`tags`/`sort` filter applied **before** the window.

**This is a discovery-only bug. Trading was never affected** — agents with a `market_id` could always trade, and `get_markets(tags="world-cup")` / `q=...` / `sort="volume"` already reached the full set on the shipped SDK/MCP. The fix just makes the convenience search paths work without the agent knowing the filter trick.

## Changes

- **`find_markets()`** now forwards `query` as the server-side `q` filter (applied before the window). Sub-2-char queries fall back to the old windowed scan (server `q` requires ≥ 2 chars). Client-side substring filter retained for exactness.
- **MCP `simmer_get_markets`** tool description now states that unfiltered browse is windowed and to pass `tags`/`q`/`sort` to reach a full category. No behavior change — it already forwarded those params.
- New tests lock the fix (forwards `q`, still filters client-side, short-query fallback).
- `simmer-sdk` 0.19.0 → 0.19.1; `simmer-mcp` 3.4.2 → 3.4.3 (description only).

## Out of scope (deliberately)

The default *unfiltered* browse ordering (window/sort default → liquidity-first) is tracked as **SIM-3126** and intentionally left untouched here — this PR does not change defaults, only fixes the keyword-search path and documents the MCP browse.

## Test

```
pytest tests/test_find_markets_server_query.py -q   # 3 passed
tsc --noEmit -p mcp                                  # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)