### PR TITLE
fix(ci): unbreak publish-mcp workflow YAML (unquoted colon in deprecate message)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Set npm deprecation notice on simmer-autoresearch
         if: ${{ !inputs.dry_run }}
-        run: npm deprecate simmer-autoresearch "This package has been renamed to simmer-mcp. Run: npm install -g simmer-mcp"
+        run: >-
+          npm deprecate simmer-autoresearch "This package has been renamed to simmer-mcp. Run: npm install -g simmer-mcp"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

`publish-mcp.yml` line 61 had a colon-space inside an unquoted `run:` scalar:

```yaml
run: npm deprecate simmer-autoresearch "This package has been renamed to simmer-mcp. Run: npm install -g simmer-mcp"
```

The `Run: ` made YAML treat it as a nested mapping → `mapping values are not allowed here`. GitHub could not parse the file, so:
- every push to `main` logged a phantom 0s "workflow file issue" failure, and
- `workflow_dispatch` was never exposed (`gh workflow run` → HTTP 422 "Workflow does not have 'workflow_dispatch' trigger").

The MCP npm publish path has been non-functional (the `force re-registration` commits in history were earlier attempts to work around this).

## Fix

Fold the command into a `>-` block scalar so the inner colon is literal. No behavior change to the published command.

```yaml
run: >-
  npm deprecate simmer-autoresearch "This package has been renamed to simmer-mcp. Run: npm install -g simmer-mcp"
```

Validated with `python3 -c "import yaml; yaml.safe_load(...)"` → VALID.

Unblocks publishing simmer-mcp 3.4.3 (the SIM-3241 tool-description note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)