### PR TITLE
docs(readme): warn that unfiltered get_markets() is windowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ def get_client():
 def run(live: bool = False):
     client = get_client()
 
-    # Find markets
-    markets = client.get_markets(status="active", limit=20)
+    # Find markets. Unfiltered browse is windowed to the newest ~1,000 active
+    # markets — filter with sort="volume", q="...", or tags="..." to reach the rest.
+    markets = client.get_markets(status="active", sort="volume", limit=20)
 
     # Get trading context (safeguards, slippage, conflict detection)
     ctx = client.get_market_context(markets[0].id)
@@ -82,8 +83,9 @@ from simmer_sdk import SimmerClient
 
 client = SimmerClient(api_key="sk_live_...")
 
-# Browse markets
-markets = client.get_markets(limit=10)
+# Browse markets (unfiltered browse is windowed to the newest ~1,000 active
+# markets — use sort="volume", q="...", or tags="..." for discovery)
+markets = client.get_markets(sort="volume", limit=10)
 for m in markets:
     print(f"{m.question}: {m.current_probability:.1%}")
 


### PR DESCRIPTION
## What

Both `get_markets()` examples in the README now use filtered discovery (`sort="volume"`) and carry an inline note that an **unfiltered** browse is windowed to roughly the newest ~1,000 active markets (out of 20k+).

## Why

An intern building the World Cup group-repricer skill reported "0 active group-winner legs" and concluded Simmer hadn't imported them. In fact all 60 legs *were* active and tradeable — they'd just fallen outside the unfiltered `get_markets()` recency window (~12k markets are newer). `q=`/`tags=`/`sort=` are applied server-side *before* the window, so filtering reaches the full catalog.

The README is the canonical copy-paste source for skill authors, so the examples themselves should model the correct pattern. Companion change in simmer-docs adds a dedicated "Discovering markets already in Simmer" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)