### PR TITLE
docs(skills): flip-invariant market-discovery guidance

### DIFF
--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-skill-builder
 description: Generate complete, installable OpenClaw trading skills from natural language strategy descriptions. Use when your human wants to create a new trading strategy, build a bot, generate a skill, automate a trade idea, turn a tweet into a strategy, or asks "build me a skill that...". Produces a full skill folder (SKILL.md + Python script + config) ready to install and run.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.7"
+  version: "1.3.8"
   displayName: Simmer Skill Builder
   difficulty: beginner
 ---
@@ -266,8 +266,13 @@ Customize:
 - `TRADE_SOURCE` — unique tag like `"sdk:<skillname>"`
 - `SKILL_SLUG` — must match the ClawHub slug exactly (e.g., `"polymarket-weather-trader"`)
 - Signal logic — your human's strategy
-- Market fetching/filtering — how to find relevant markets
+- Market fetching/filtering — how to find relevant markets (see **Market discovery** below)
 - Main strategy function — the core loop
+
+**Market discovery — the #1 cause of "0 markets" skills.** Unfiltered `get_markets()` returns a **windowed slice** (~1,000 of ~21k active markets), not the full catalog — so filtering an unfiltered call client-side reads as "0 markets found" when the markets are actually live and tradeable. Rules:
+- To reach a **specific** market, filter **server-side**: `get_markets(tags="world-cup", limit=50)` or `get_markets(q="netherlands japan", limit=20)`. `tags=`/`q=` apply *before* the window; filtering an unfiltered list in Python does not.
+- For "what's liquid to trade right now," use `sort="volume"`.
+- **Never hardcode market IDs** in the skill or its config. Markets import on a rolling basis, and the same matchup can re-import under a new ID — so a pinned ID 404s later. Resolve IDs at runtime from `get_markets(...)` and read each market's `id`.
 
 ### Step 5: Validate
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.5"
+  version: "1.24.6"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -111,7 +111,7 @@ Documentation references — open when the situation matches.
 ```python
 client.get_briefing()              # portfolio + risk + opportunities (one call)
 client.find_markets(query)         # text-search markets
-client.get_markets(status=, limit=) # list markets by status
+client.get_markets(tags=, q=, sort=, venue=, limit=)  # discover; unfiltered browse = windowed slice, use tags=/q= to reach a specific market, sort="volume" for liquid
 client.get_market_context(id)      # warnings, position info before trading
 client.trade(id, side, usd, ...)   # execute (always with reasoning=)
 client.cancel_order(order_id)      # or cancel_market_orders / cancel_all_orders


### PR DESCRIPTION
## Why

Two independent skill builders hit the same **"0 active markets"** wall this week. Root cause is the recurring SDK discovery-window footgun, **not** an import gap: unfiltered `get_markets()` returns a windowed slice (~1k of ~21k active), so a client-side filter silently returns nothing and reads as "not imported."

The guidance that prevents this was thin/absent exactly where builders read first.

## What

- **`skills/simmer/SKILL.md`** (overview — what every builder installs): API-surface line now teaches `get_markets(tags=, q=, sort=, venue=, limit=)` instead of the bare `(status, limit)` form that pointed straight at the trap.
- **`skills/simmer-skill-builder/SKILL.md`**: new **Market discovery** rule — unfiltered browse is a windowed slice; filter server-side with `tags=`/`q=` to reach a specific market; use `sort="volume"` for liquid; **never hardcode market IDs** (rolling import re-mints IDs, so pinned IDs 404 later).

## Flip-safe

Worded to survive the **SIM-3124** default-sort flip (grace window ends Jun 19) — no current-default value is stated, so it stays correct before and after the flip. One edit, no re-update needed.

Version bumps: `simmer` 1.24.5→1.24.6, `simmer-skill-builder` 1.3.7→1.3.8. Will republish both to ClawHub on merge + resync the website-served `skill.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)