### PR TITLE
fix(copytrader): quantize stake amount/shares to SDK precision (SIM-3265)

### DIFF
--- a/skills/polymarket-worldcup-copytrader/copytrader.py
+++ b/skills/polymarket-worldcup-copytrader/copytrader.py
@@ -565,6 +565,14 @@ def run(dry_run: bool = True, venue: str = None) -> None:
                 t["success"] = False
                 t["error"] = "no_price_bound"
                 continue
+        # Quantize to the SDK's precision contract before submitting. The
+        # server plan returns full-precision floats (e.g. estimated_cost
+        # 16.489550245148255); the SDK rejects buys whose USDC amount has >2
+        # decimals and sells whose share count has >5 (client.trade decimal
+        # guard). Round at the trade boundary, not on `cost`/`shares` upstream,
+        # so the per-position cap check above keeps full-precision estimates.
+        amount_q = round(cost, 2) if action == "buy" else 0
+        shares_q = round(shares, 5) if action == "sell" else 0
         source_wallet = t.get("whale_wallet") or t.get("source_wallet") or ""
         signal_data = {
             "signal_source": "wc_copytrader",
@@ -578,8 +586,8 @@ def run(dry_run: bool = True, venue: str = None) -> None:
                 market_id=market_id,
                 side=side,
                 action=action,
-                amount=cost if action == "buy" else 0,
-                shares=shares if action == "sell" else 0,
+                amount=amount_q,
+                shares=shares_q,
                 venue=effective_venue,
                 # FAK (fill-and-kill): fill what's available now, cancel the
                 # rest. A once-daily fire-and-forget run must never leave

--- a/skills/polymarket-worldcup-copytrader/tests/test_copytrader.py
+++ b/skills/polymarket-worldcup-copytrader/tests/test_copytrader.py
@@ -1115,5 +1115,48 @@ class TestSensitivityManifest(unittest.TestCase):
             self.assertNotIn(phrase, content, f"SKILL.md must not contain: {phrase}")
 
 
+class TestDecimalPrecisionQuantize(unittest.TestCase):
+    """Stake amounts/share counts from the server plan are full-precision
+    floats; the SDK rejects buys with >2 USDC decimals and sells with >5
+    share decimals (client.trade decimal guard). The skill must quantize at
+    the trade boundary so live runs don't drop trades (SIM-3265)."""
+
+    def _hiprec_plan(self):
+        return {"trades": [
+            {"market_id": "mkt-wc-1", "action": "buy", "side": "yes",
+             "shares": 27.0, "estimated_price": 0.6,
+             "estimated_cost": 16.489550245148255,  # >2 decimals
+             "market_title": "WC buy hiprec"},
+            {"market_id": "mkt-wc-2", "action": "sell", "side": "yes",
+             "shares": 4.123456789,  # >5 decimals
+             "estimated_price": 0.7, "estimated_cost": 2.886419752,
+             "market_title": "WC sell hiprec"},
+        ]}
+
+    def test_buy_amount_rounded_to_2dp(self):
+        plan = self._hiprec_plan()
+        mod, mock_client = _make_skill_module(
+            leaders_response=_leaders_response(), plan_response=plan)
+        mod.run(dry_run=False, venue="sim")
+        buys = [c[1] for c in mock_client.trade.call_args_list
+                if c[1].get("action") == "buy"]
+        self.assertEqual(len(buys), 1)
+        self.assertEqual(buys[0]["amount"], 16.49)
+        # never ship a value the SDK would reject
+        self.assertEqual(round(buys[0]["amount"], 2), buys[0]["amount"])
+
+    def test_sell_shares_rounded_to_5dp(self):
+        plan = self._hiprec_plan()
+        mod, mock_client = _make_skill_module(
+            leaders_response=_leaders_response(), plan_response=plan)
+        mod._config["buy_only"] = "false"
+        mod.run(dry_run=False, venue="sim")
+        sells = [c[1] for c in mock_client.trade.call_args_list
+                 if c[1].get("action") == "sell"]
+        self.assertEqual(len(sells), 1)
+        self.assertEqual(sells[0]["shares"], 4.12346)
+        self.assertEqual(round(sells[0]["shares"], 5), sells[0]["shares"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
`polymarket-worldcup-copytrader` passed full-precision floats from the server plan straight to `client.trade()`. The SDK's decimal guard (`client.py:1883/1889`) rejects buys whose USDC `amount` has >2 decimals and sells whose `shares` count has >5. On the first live run 3/10 trades were silently dropped:

```
amount 16.489550245148255 has too many decimal places (max 2). Use 16.49 instead.
```

## Fix
Quantize at the `client.trade()` boundary:
- buys: `amount=round(cost, 2)`
- sells: `shares=round(shares, 5)`

Rounding at the call site (not on `cost`/`shares` upstream) keeps the per-position cap check operating on full-precision estimates. Fixes the reported buy-path failure **and** the symmetric sell-path case (`shares` max 5) the live run hadn't yet surfaced.

The bundled copy under `mcp/bundled-skills/` is gitignored/generated, so only the canonical `skills/` source is edited.

## Tests
Added `TestDecimalPrecisionQuantize` — asserts a >2dp `estimated_cost` and a >5dp `shares` are quantized before reaching `client.trade()`. Full suite: 73 passed.

Closes SIM-3265

🤖 Generated with [Claude Code](https://claude.com/claude-code)