### PR TITLE
fix(trade): round amount/shares to venue precision instead of rejecting (SIM-3272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.2] - 2026-06-16
+
+### Fixed
+
+- **`trade()` now rounds `amount`/`shares` to venue precision instead of rejecting full-precision floats (SIM-3272).** Previously `client.trade()` raised `ValueError` when the USDC `amount` had more than 2 decimals (or `shares` more than 5), forcing every skill to re-implement a `round(cost, 2)` workaround. Planner / Kelly sizing routinely produces values like `16.489550245148255`, which silently dropped trades on live runs (the World Cup copytrader lost 3/10 trades to this alone). `trade()` now quantizes `amount` to 2 decimals and `shares` to 5 before submission, logging at debug when it rounds. Sub-precision values that quantize to `0` are still rejected (can't place a `$0` order). This is input-precision quantization only — tick-aware rounding of the on-chain maker/taker amounts is unchanged and stays in `signing.py` (`round_price_to_tick` + py-clob-client `ROUNDING_CONFIG`); the two layers round different quantities and never double-round.
+
 ## [0.19.1] - 2026-06-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.19.1"
+version = "0.19.2"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1877,19 +1877,37 @@ class SimmerClient:
         if not is_sell and amount <= 0:
             raise ValueError("amount required for buy orders")
 
-        # Validate decimal precision before submission.
-        # Maker (USDC) supports max 2 decimals; shares support max 5.
+        # Quantize to the venue's input precision before submission. Maker
+        # (USDC) accepts max 2 decimals; shares accept max 5. Planner / Kelly
+        # sizing produces full-precision floats (e.g. 16.489550245148255), so
+        # round here rather than rejecting — every skill would otherwise have
+        # to re-implement the same round() workaround (SIM-3272).
+        #
+        # This is INPUT quantization only. Tick-aware rounding of the on-chain
+        # maker/taker amounts stays in signing.py (round_price_to_tick +
+        # py-clob-client ROUNDING_CONFIG); the two layers are orthogonal and
+        # round different quantities, so this never double-rounds the order.
         if not is_sell:
-            if round(amount, 2) != amount:
+            quantized = round(amount, 2)
+            if quantized != amount:
+                logger.debug(
+                    "Rounding amount %s -> %s (USDC max 2 decimals)", amount, quantized
+                )
+                amount = quantized
+            if amount <= 0:
                 raise ValueError(
-                    f"amount {amount} has too many decimal places (max 2). "
-                    f"Use {round(amount, 2)} instead."
+                    f"amount rounds to {amount} (below $0.01) — too small to place an order"
                 )
         else:
-            if round(shares, 5) != shares:
+            quantized = round(shares, 5)
+            if quantized != shares:
+                logger.debug(
+                    "Rounding shares %s -> %s (max 5 decimals)", shares, quantized
+                )
+                shares = quantized
+            if shares <= 0:
                 raise ValueError(
-                    f"shares {shares} has too many decimal places (max 5). "
-                    f"Use {round(shares, 5)} instead."
+                    f"shares rounds to {shares} — too small to place an order"
                 )
 
         # Paper trading: simulate with real prices (no live API calls)

--- a/tests/test_decimal_validation.py
+++ b/tests/test_decimal_validation.py
@@ -1,4 +1,11 @@
-"""Tests for pre-submission decimal validation in SimmerClient.trade()."""
+"""Tests for pre-submission decimal quantization in SimmerClient.trade().
+
+The client rounds amount (USDC maker, max 2 decimals) and shares (taker, max 5
+decimals) to the venue's input precision instead of rejecting full-precision
+floats, so skills can pass raw planner/Kelly outputs without re-implementing the
+round() workaround (SIM-3272). Tick-aware rounding of the on-chain order amounts
+stays in signing.py — this layer only quantizes the human-facing inputs.
+"""
 
 import pytest
 
@@ -6,7 +13,11 @@ from simmer_sdk.client import SimmerClient
 
 
 def _make_client():
-    """Return a live-mode client with network calls stubbed out."""
+    """Return a live-mode client with network calls stubbed out.
+
+    The stubbed ``_request`` records the last payload so tests can assert what
+    amount/shares actually reached the wire after quantization.
+    """
     client = SimmerClient.__new__(SimmerClient)
     client.live = True
     client.venue = "polymarket"
@@ -17,69 +28,80 @@ def _make_client():
     client._approvals_warned = False
     client.ORDER_TYPES = {"FAK", "FOK", "GTC", "GTD"}
     client.VENUES = {"sim", "polymarket", "kalshi", "simmer"}
+
+    client.sent_payloads = []
+
+    def _fake_request(method, path, **kwargs):
+        if kwargs.get("json") is not None:
+            client.sent_payloads.append(kwargs["json"])
+        return {
+            "success": True, "trade_id": "t1", "market_id": "m1",
+            "side": "yes", "shares_bought": 10, "shares_requested": 10,
+            "order_status": "MATCHED", "cost": 10.00, "new_price": 0.5,
+            "position": {},
+        }
+
+    client._request = _fake_request
     return client
 
 
-def _fake_request(method, path, **kwargs):
-    return {
-        "success": True, "trade_id": "t1", "market_id": "m1",
-        "side": "yes", "shares_bought": 10, "shares_requested": 10,
-        "order_status": "MATCHED", "cost": 10.00, "new_price": 0.5,
-        "position": {},
-    }
-
-
-class TestAmountDecimalValidation:
-    """amount (maker USDC) must have max 2 decimal places."""
+class TestAmountDecimalQuantization:
+    """amount (maker USDC) is rounded to max 2 decimal places."""
 
     def test_exact_two_decimals_accepted(self):
         client = _make_client()
-        client._request = _fake_request
         result = client.trade("m1", "yes", amount=10.12)
         assert result.success
+        assert client.sent_payloads[-1]["amount"] == 10.12
 
     def test_integer_amount_accepted(self):
         client = _make_client()
-        client._request = _fake_request
         result = client.trade("m1", "yes", amount=10.0)
         assert result.success
+        assert client.sent_payloads[-1]["amount"] == 10.0
 
-    def test_three_decimals_rejected(self):
+    def test_three_decimals_rounded(self):
         client = _make_client()
-        client._request = _fake_request
-        with pytest.raises(ValueError, match="too many decimal places.*max 2"):
-            client.trade("m1", "yes", amount=10.123)
+        result = client.trade("m1", "yes", amount=10.123)
+        assert result.success
+        assert client.sent_payloads[-1]["amount"] == 10.12
 
-    def test_many_decimals_rejected(self):
+    def test_many_decimals_rounded(self):
+        """The exact value from the SIM-3265 live run."""
         client = _make_client()
-        client._request = _fake_request
-        with pytest.raises(ValueError, match="too many decimal places.*max 2"):
-            client.trade("m1", "yes", amount=5.333333333)
+        result = client.trade("m1", "yes", amount=16.489550245148255)
+        assert result.success
+        assert client.sent_payloads[-1]["amount"] == 16.49
 
-    def test_error_suggests_rounded_value(self):
+    def test_amount_rounding_to_zero_rejected(self):
+        """A sub-cent amount that quantizes to 0 must not place a $0 order."""
         client = _make_client()
-        client._request = _fake_request
-        with pytest.raises(ValueError, match="Use 10.12 instead"):
-            client.trade("m1", "yes", amount=10.123)
+        with pytest.raises(ValueError, match="too small to place an order"):
+            client.trade("m1", "yes", amount=0.004)
 
 
-class TestSharesDecimalValidation:
-    """shares (taker) must have max 5 decimal places."""
+class TestSharesDecimalQuantization:
+    """shares (taker) are rounded to max 5 decimal places."""
 
     def test_exact_five_decimals_accepted(self):
         client = _make_client()
-        client._request = _fake_request
         result = client.trade("m1", "yes", shares=1.23456, action="sell")
         assert result.success
+        assert client.sent_payloads[-1]["shares"] == 1.23456
 
-    def test_six_decimals_rejected(self):
+    def test_six_decimals_rounded(self):
         client = _make_client()
-        client._request = _fake_request
-        with pytest.raises(ValueError, match="too many decimal places.*max 5"):
-            client.trade("m1", "yes", shares=1.234567, action="sell")
+        result = client.trade("m1", "yes", shares=1.234567, action="sell")
+        assert result.success
+        assert client.sent_payloads[-1]["shares"] == 1.23457
 
     def test_integer_shares_accepted(self):
         client = _make_client()
-        client._request = _fake_request
         result = client.trade("m1", "yes", shares=5.0, action="sell")
         assert result.success
+        assert client.sent_payloads[-1]["shares"] == 5.0
+
+    def test_shares_rounding_to_zero_rejected(self):
+        client = _make_client()
+        with pytest.raises(ValueError, match="too small to place an order"):
+            client.trade("m1", "yes", shares=0.000004, action="sell")


### PR DESCRIPTION
## Problem
`client.trade()` raised `ValueError` when the USDC `amount` had >2 decimals (or `shares` >5):
```
amount 16.489550245148255 has too many decimal places (max 2). Use 16.49 instead.
```
Planner / Kelly sizing routinely produces such floats, so every skill had to re-implement `round(cost, 2)`. When they don't, live trades drop silently — the WC copytrader lost 3/10 trades to this (SIM-3265, which fixed it skill-side as a workaround).

## Fix
Quantize at the trade boundary instead of rejecting: `amount → 2dp`, `shares → 5dp`, with a debug log when rounding actually happens. Sub-precision values that quantize to `0` are still rejected (no `$0` orders).

## Why this is safe (no conflict with signing-time precision)
This is **input-precision quantization only**. Tick-aware rounding of the on-chain maker/taker amounts is unchanged and stays in `signing.py` (`round_price_to_tick` + py-clob-client `ROUNDING_CONFIG`, from the `_sdk-signing-precision` / `_polymarket-rounding-precision` work). The two layers round **different quantities** at **different stages**:
- this layer: human-facing USD `amount` → cents, share count → 5dp
- signing layer: price → tick, derived maker/taker base-unit integers → tick-aware

The old guard already forced callers to pass ≤2dp amounts, so the signing layer receives byte-identical input — this just relocates the round() the error message already prescribed.

## Tests
`tests/test_decimal_validation.py` rewritten: asserts >2dp amount and >5dp shares are rounded and the quantized value reaches the wire payload; sub-precision→0 still raises. 9 passed. Full suite green (the 4 `test_client_constructors` failures are pre-existing — `open-wallet-standard` not installed in this env — and unrelated).

## Release
Patch bump `0.19.1 → 0.19.2` + CHANGELOG. Backward-compatible (rounding is strictly more permissive than raising). PyPI publish is a separate, human-gated step. Skills benefit once on `>=0.19.2`; SIM-3265's skill-side rounding stays as harmless belt-and-braces.

Closes SIM-3272

🤖 Generated with [Claude Code](https://claude.com/claude-code)