### PR TITLE
feat(wc-copytrader): pass market_ids to scope the server plan (SIM-3273)

### DIFF
--- a/skills/polymarket-worldcup-copytrader/SKILL.md
+++ b/skills/polymarket-worldcup-copytrader/SKILL.md
@@ -8,7 +8,7 @@ tags:
   - copytrading
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.0"
+  version: "0.1.1"
   displayName: World Cup Copytrader
   difficulty: beginner
   sensitivity: sensitive

--- a/skills/polymarket-worldcup-copytrader/copytrader.py
+++ b/skills/polymarket-worldcup-copytrader/copytrader.py
@@ -439,6 +439,28 @@ def run(dry_run: bool = True, venue: str = None) -> None:
             except Exception:
                 pass
 
+    # --- WC scope allowlist ---
+    # Fetch the WC market set up front: it scopes the server-side plan so the
+    # leaders' non-WC positions don't consume plan slots (SIM-3273), AND gates
+    # client-side execution below. A live run fails closed if the allowlist is
+    # unavailable (a WC-only skill must not trade unscoped); a dry-run
+    # continues unscoped since nothing is spent.
+    wc_market_ids = None
+    try:
+        wc_market_ids = fetch_wc_market_ids()
+    except Exception as e:
+        if not dry_run:
+            print(f"\n❌ WC market allowlist unavailable ({e}) — aborting live run (fail-closed).")
+            print("   A WC-only skill must not execute unscoped trades. Retry next run.")
+            if os.environ.get("AUTOMATON_MANAGED"):
+                print(json.dumps({"automaton": {
+                    "signals": 0, "trades_attempted": 0, "trades_executed": 0,
+                    "skip_reason": "wc_scope_unavailable",
+                }}))
+                _automaton_reported = True
+            return
+        print(f"\n⚠️  WC market allowlist unavailable ({e}); dry-run continues unscoped.")
+
     # --- build trade plan (server-side copytrading engine) ---
     print("\n📡 Requesting trade plan…")
     payload = {
@@ -455,6 +477,11 @@ def run(dry_run: bool = True, venue: str = None) -> None:
         "max_trades": MAX_TRADES,
         "venue": effective_venue,
     }
+    # Scope the plan server-side to WC markets so non-WC leader positions never
+    # consume plan slots (SIM-3273). Older servers ignore the param; the
+    # client-side filter below stays as belt-and-braces either way.
+    if wc_market_ids:
+        payload["market_ids"] = sorted(wc_market_ids)
     try:
         plan = client._request("POST", "/api/sdk/copytrading/execute", json=payload, timeout=60)
     except Exception as e:
@@ -493,27 +520,12 @@ def run(dry_run: bool = True, venue: str = None) -> None:
         _emit_automaton(plan, 0)
         return
 
-    # --- WC scope allowlist (live only) ---
-    # Leaders are WC-curated but their books are not: a leader can hold
-    # non-WC positions and the plan endpoint has no scope param, so a
-    # WC-only skill must filter client-side before spending anything.
-    try:
-        wc_market_ids = fetch_wc_market_ids()
-    except Exception as e:
-        print(f"\n❌ WC market allowlist unavailable ({e}) — aborting live run (fail-closed).")
-        print("   A WC-only skill must not execute unscoped trades. Retry next run.")
-        if os.environ.get("AUTOMATON_MANAGED"):
-            print(json.dumps({"automaton": {
-                "signals": plan.get("positions_found", 0),
-                "trades_attempted": 0, "trades_executed": 0,
-                "skip_reason": "wc_scope_unavailable",
-            }}))
-            _automaton_reported = True
-        return
-
     # --- execute trades client-side ---
-    # Belt-and-braces: server-side params already request these limits, but
-    # enforce them client-side too so a server bug can't oversize the run.
+    # Belt-and-braces: the server already scoped the plan to wc_market_ids
+    # (SIM-3273) and applied the size limits, but re-enforce both client-side
+    # so a server bug (or an older server that ignores market_ids) can't push
+    # a non-WC or oversized trade. wc_market_ids is guaranteed set here: a live
+    # run with no allowlist aborted fail-closed above.
     if len(trades) > MAX_TRADES:
         print(f"\n⚠️  Plan has {len(trades)} trades > max_trades={MAX_TRADES} — truncating.")
         trades = trades[:MAX_TRADES]

--- a/skills/polymarket-worldcup-copytrader/tests/test_copytrader.py
+++ b/skills/polymarket-worldcup-copytrader/tests/test_copytrader.py
@@ -1158,5 +1158,37 @@ class TestDecimalPrecisionQuantize(unittest.TestCase):
         self.assertEqual(round(sells[0]["shares"], 5), sells[0]["shares"])
 
 
+class TestServerSideScopeParam(unittest.TestCase):
+    """The skill passes its WC allowlist as market_ids so the server scopes the
+    plan to WC markets BEFORE Top N, instead of relying only on the client-side
+    filter that discards already-planned slots (SIM-3273)."""
+
+    def test_market_ids_sent_to_plan(self):
+        mod, mock_client = _make_skill_module(leaders_response=_leaders_response())
+        mod.run(dry_run=True, venue="sim")
+        execute_calls = [c for c in mock_client._request.call_args_list
+                         if "copytrading/execute" in str(c)]
+        self.assertTrue(execute_calls, "plan endpoint was not called")
+        payload = execute_calls[0][1].get("json", {})
+        self.assertIn("market_ids", payload)
+        # default markets_response covers the plan's markets → allowlist non-empty
+        self.assertIn("mkt-abc", payload["market_ids"])
+
+    def test_dry_run_continues_unscoped_when_allowlist_unavailable(self):
+        """A dry-run must still produce a plan (unscoped) if the WC allowlist
+        fetch fails — nothing is spent, so don't fail closed."""
+        mod, mock_client = _make_skill_module(
+            leaders_response=_leaders_response(),
+            markets_response=RuntimeError("markets endpoint down"),
+        )
+        mod.run(dry_run=True, venue="sim")
+        execute_calls = [c for c in mock_client._request.call_args_list
+                         if "copytrading/execute" in str(c)]
+        self.assertTrue(execute_calls, "dry-run should still request a plan")
+        payload = execute_calls[0][1].get("json", {})
+        # no allowlist → no scope param sent; server returns unscoped plan
+        self.assertNotIn("market_ids", payload)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
The WC copytrader now passes its auto-curated WC allowlist as `market_ids` on the `POST /api/sdk/copytrading/execute` call, so the server scopes the plan to WC markets **before** Top N (the consumer side of SIM-3273).

Previously the leaders' non-WC positions consumed Top-N slots that the skill discarded client-side — 40% of plan capacity wasted in the last live run.

## Changes
- Fetch the WC allowlist up front (it now scopes the plan *and* gates client-side execution).
  - **Live** run with no allowlist → aborts fail-closed (unchanged invariant: a WC-only skill must not trade unscoped).
  - **Dry-run** with no allowlist → continues unscoped (nothing is spent), prints a warning.
- Pass `market_ids=sorted(wc_market_ids)` on the plan request.
- Keep the client-side non-WC filter as belt-and-braces (an older server that ignores the param still yields correct plans).
- Remove the now-duplicate live-only allowlist fetch.
- Skill `0.1.0 → 0.1.1` (ClawHub republish).

## Dependency
Requires the server `market_ids` param (simmer PR for SIM-3273, #1382) deployed. Backward-compatible until then — the param is ignored and the client-side filter holds.

## Tests
`73 passed`. Added: `market_ids` is sent on the plan call; dry-run continues unscoped (no `market_ids`) when the allowlist fetch fails.

Refs SIM-3273

🤖 Generated with [Claude Code](https://claude.com/claude-code)