### PR TITLE
chore(publish): prune nested __pycache__ before bundling

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -117,8 +117,12 @@ TMP_DIR="/tmp/$NAME"
 rm -rf "$TMP_DIR"
 cp -r "$SKILL_DIR" "$TMP_DIR"
 
-# Clean up unwanted files
-rm -rf "$TMP_DIR/__pycache__" "$TMP_DIR"/.* 2>/dev/null || true
+# Clean up unwanted files. The old top-level-only rm missed NESTED caches
+# (e.g. tests/__pycache__), so a stale 90KB .pyc shipped in the copytrader
+# 0.1.1 bundle. Prune every __pycache__ dir + loose .pyc/.pyo recursively.
+find "$TMP_DIR" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+find "$TMP_DIR" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete 2>/dev/null || true
+rm -rf "$TMP_DIR"/.* 2>/dev/null || true
 
 FILE_COUNT=$(find "$TMP_DIR" -type f | wc -l)
 echo "   Files: $FILE_COUNT"


### PR DESCRIPTION
The skill-publish cleanup removed only the top-level `__pycache__`, so nested caches (`tests/__pycache__`) shipped in the bundle — a stale 90KB `.pyc` went out in the copytrader 0.1.1 publish. Now prunes every `__pycache__` dir + loose `.pyc`/`.pyo` recursively.

Verified on a temp tree: nested + top-level caches and a stray `.pyc` removed, real source/test files kept. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)