### PR TITLE
chore(mcp): bump simmer-mcp 3.4.4 — rebundle WC copytrader 0.1.1

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Refreshes `bundled-skills/` so the MCP execution path carries the WC copytrader fixes (SIM-3265 rounding, SIM-3273 `market_ids` scoping). Bundle regenerates at publish via the `prepack` hook; `npm test` 147/147 green; `npm pack --dry-run` clean (0 .pyc, copytrader 0.1.1 / `72dcabf`). Recurring bundle-drift class → SIM-3275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)