### PR TITLE
feat(signing): default V2 orders to Simmer's builder code (attribution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-06-16
+
+### Changed
+
+- **V2 orders now default to Simmer's builder code for attribution (was zero bytes32).** Volume routed through the Simmer SDK is now attributed to Simmer's Polymarket builder profile by default (builder-program revenue share + leaderboard standing). Previously the `builder` field defaulted to zero unless the operator set `POLY_BUILDER_CODE`, so external/self-custody operators — roughly half of all SDK volume — shipped **unattributed** orders (attribution gap found 2026-06-16). The server (managed-wallet) path was already attributed; this closes the external cohort. Precedence is unchanged: explicit `builder_code` arg > `POLY_BUILDER_CODE` env > **Simmer default** (`SIMMER_BUILDER_CODE`, the new fallback). To attribute to your own builder profile, pass `builder_code` or set `POLY_BUILDER_CODE`; pass `ZERO_BYTES32` to opt out entirely. The builder code is a public on-chain attribution identifier, not a secret. Maker/Taker fee rates on Simmer's builder profile are **0%**, so attribution adds no cost to operators' trades. Takes effect as operators upgrade the SDK (orders are signed client-side, so old installs keep current behavior until upgraded).
+
 ## [0.19.2] - 2026-06-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.19.2"
+version = "0.20.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -4445,7 +4445,7 @@ class SimmerClient:
                     neg_risk=neg_risk,
                     tick_size=tick_size,
                     order_type=order_type,
-                    builder_code=None,  # picks up POLY_BUILDER_CODE env
+                    builder_code=None,  # None -> POLY_BUILDER_CODE env -> Simmer default (see signing.py)
                     metadata=None,
                     amount_usdc=amount_usdc,
                 )

--- a/simmer_sdk/signing.py
+++ b/simmer_sdk/signing.py
@@ -56,8 +56,20 @@ MIN_ORDER_SIZE_SHARES = 5
 # Zero address for open orders (anyone can fill)
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
-# Zero bytes32 — V2 default for metadata / builder when unset
+# Zero bytes32 — V2 default for metadata, and the opt-out value for builder.
 ZERO_BYTES32 = "0x" + "00" * 32
+
+# Simmer's public Polymarket builder-attribution code (bytes32). This is the
+# DEFAULT `builder` on every V2 order this SDK signs, so volume routed through
+# the Simmer SDK is attributed to Simmer's builder profile (builder-program
+# revenue share + leaderboard standing). It is NOT a secret: it is serialized
+# on-chain in every order, shown at polymarket.com/settings?tab=builder, and
+# published on Polymarket's builder leaderboard. Override per-order via the
+# `builder_code` argument or globally via the POLY_BUILDER_CODE env var; pass
+# ZERO_BYTES32 explicitly to opt out of attribution entirely.
+SIMMER_BUILDER_CODE = (
+    "0xed9222e433d100f617b2d2b125fd36f055ee6ebf792e44d2c522ed33e55697f8"
+)
 
 
 @dataclass
@@ -161,9 +173,12 @@ def build_and_sign_order(
         signature_type: Signature type (0=EOA default)
         tick_size: Market tick size (e.g., 0.01 or 0.001)
         fee_rate_bps: V1 only. Ignored on V2 (fees are match-time, not signed).
-        builder_code: V2 only. bytes32 hex for builder attribution. Reads env
-            `POLY_BUILDER_CODE` if None; defaults to zero bytes32 if unset.
-            Mint yours at polymarket.com/settings?tab=builder.
+        builder_code: V2 only. bytes32 hex for builder attribution. Resolution
+            order: this arg > `POLY_BUILDER_CODE` env > Simmer's default builder
+            code (`SIMMER_BUILDER_CODE`). So SDK-routed volume is attributed to
+            Simmer by default. To attribute to your own builder profile, mint a
+            code at polymarket.com/settings?tab=builder and pass it here or set
+            `POLY_BUILDER_CODE`; pass ZERO_BYTES32 to opt out of attribution.
         metadata: V2 only. bytes32 hex, default zero bytes32.
         amount_usdc: V2 FAK/FOK BUY only. Original USDC dollar amount. If
             provided, the V2 path routes through `build_market_order` with
@@ -443,9 +458,9 @@ def _build_and_sign_order_v2(
             f"Invalid order_type '{order_type}'. Must be FAK, FOK, GTC, or GTD."
         )
 
-    # Resolve builder_code: explicit arg > env > zero bytes32
+    # Resolve builder_code: explicit arg > env > Simmer default attribution
     if builder_code is None:
-        builder_code = os.getenv("POLY_BUILDER_CODE", "").strip() or ZERO_BYTES32
+        builder_code = os.getenv("POLY_BUILDER_CODE", "").strip() or SIMMER_BUILDER_CODE
     if not builder_code.startswith("0x"):
         builder_code = "0x" + builder_code
     if metadata is None:
@@ -1021,7 +1036,7 @@ def _build_and_sign_order_v2_dw(
     _builder_code = (
         builder_code
         or os.getenv("POLY_BUILDER_CODE", "").strip()
-        or ZERO_BYTES32
+        or SIMMER_BUILDER_CODE
     )
     if not _builder_code.startswith("0x"):
         _builder_code = "0x" + _builder_code
@@ -1387,7 +1402,7 @@ def build_and_sign_order_v2_dw_ows(
     _builder_code = (
         builder_code
         or os.getenv("POLY_BUILDER_CODE", "").strip()
-        or ZERO_BYTES32
+        or SIMMER_BUILDER_CODE
     )
     if not _builder_code.startswith("0x"):
         _builder_code = "0x" + _builder_code

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -355,3 +355,38 @@ def test_v2_invalid_order_type_rejected():
             side="BUY", price=0.5, size=10,
             tick_size=0.01, order_type="GIBBERISH",
         )
+
+
+# ==================== Builder attribution default ====================
+# Volume routed through the Simmer SDK must attribute to Simmer's builder
+# profile by default (builder-program revenue share + leaderboard). Prior to
+# this, the default was zero bytes32, so external operators who never set
+# POLY_BUILDER_CODE shipped unattributed volume — the attribution gap found
+# 2026-06-16 (~half of volume is external/local-signed). Maker/Taker fee rates
+# on the builder profile are 0%, so attaching the code adds no user cost.
+
+
+def test_v2_default_builder_code_is_simmer(monkeypatch):
+    monkeypatch.delenv("POLY_BUILDER_CODE", raising=False)
+    from simmer_sdk.signing import SIMMER_BUILDER_CODE, ZERO_BYTES32
+    d = _v2_signed(side="BUY", price=0.5, size=10.0, order_type="GTC")
+    assert d["builder"] == SIMMER_BUILDER_CODE
+    assert d["builder"] != ZERO_BYTES32
+
+
+def test_v2_builder_code_resolution_order(monkeypatch):
+    """explicit arg > POLY_BUILDER_CODE env > Simmer default; explicit zero opts out."""
+    from simmer_sdk.signing import ZERO_BYTES32
+    custom = "0x" + "22" * 32
+    # explicit arg beats env
+    monkeypatch.setenv("POLY_BUILDER_CODE", "0x" + "33" * 32)
+    d1 = _v2_signed(side="BUY", price=0.5, size=10.0, order_type="GTC", builder_code=custom)
+    assert d1["builder"] == custom
+    # env beats Simmer default when no arg
+    monkeypatch.setenv("POLY_BUILDER_CODE", custom)
+    d2 = _v2_signed(side="BUY", price=0.5, size=10.0, order_type="GTC")
+    assert d2["builder"] == custom
+    # explicit zero opts out of attribution
+    monkeypatch.delenv("POLY_BUILDER_CODE", raising=False)
+    d3 = _v2_signed(side="BUY", price=0.5, size=10.0, order_type="GTC", builder_code=ZERO_BYTES32)
+    assert d3["builder"] == ZERO_BYTES32


### PR DESCRIPTION
## Problem

We're a registered Polymarket builder (code `0xed9222…97f8`, profile "Simmer.Markets", 0% maker/taker fee) and **attribution works** — but only on **server-signed (managed-wallet)** flow, which carries the code via the server's `POLY_BUILDER_CODE` env.

**External/self-custody operators sign orders client-side with this SDK and the server only relays the pre-signed order — it can't retrofit the builder code.** The SDK defaulted `builder` to zero bytes32 unless the operator set `POLY_BUILDER_CODE` (which isn't surfaced to them), so that cohort shipped **unattributed**.

Measured 2026-06-16: **~53% of strict real volume ($54.6K of $103K / 30d) is external/local-signed** — i.e. roughly half our volume earns us no builder credit. Polymarket's per-builder time-series confirms our attributed volume tracks the overall volume cliff (peak ~$1.2M/wk Feb → ~$32K/wk now), with the external cohort missing.

## Fix

Default the V2 `builder` field to a new `SIMMER_BUILDER_CODE` constant instead of zero. Precedence is unchanged in order, only the fallback changes:

`explicit builder_code arg > POLY_BUILDER_CODE env > SIMMER_BUILDER_CODE (new)`

- The 3 resolution sites (EOA + DW/OWS V2 paths) repointed; `metadata` still defaults to zero.
- The builder code is a **public** on-chain attribution identifier (serialized in every order, shown on the public leaderboard + builder dashboard) — safe to hardcode in the open-source SDK. Not a secret.
- **No user cost:** Simmer's builder profile is Maker 0% / Taker 0% (confirmed in the builder dashboard).
- **Opt-out preserved:** operators pass `builder_code=ZERO_BYTES32` or set their own `POLY_BUILDER_CODE` to attribute elsewhere / not at all.

## Tests

`tests/test_polymarket_v2.py`: default == `SIMMER_BUILDER_CODE`; explicit arg beats env; env beats Simmer default; explicit zero opts out. Full signing suite green (69 passed).

## Rollout caveat

Orders are signed **client-side**, so this only takes effect as operators **upgrade** the installed SDK — recovery is gradual, not instant. New installs get it immediately. There is no server-side lever for already-installed operators (by custody design the server never signs their orders).

## Verification after merge/publish

Watch Simmer's attributed volume on `data-api.polymarket.com/v1/builders/volume?timePeriod=WEEK` (filter our builderCode) rise toward our real volume as operators upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)