### PR TITLE
docs(copytrader): SIMMER_API_KEY is auto-set when registering via the simmer skill

### DIFF
--- a/skills/polymarket-worldcup-copytrader/SKILL.md
+++ b/skills/polymarket-worldcup-copytrader/SKILL.md
@@ -61,6 +61,8 @@ You follow this set, not wallets you chose yourself.
    ```bash
    export SIMMER_API_KEY=...   # simmer.markets/dashboard → SDK tab
    ```
+   If your agent already registered via the `simmer` skill, `SIMMER_API_KEY` is
+   set from the registration response — the dashboard is only for recovering it.
 
 3. **Optional — Polymarket wallet key** (only for `--venue polymarket --live`):
    ```bash

--- a/skills/polymarket-worldcup-copytrader/SKILL.md
+++ b/skills/polymarket-worldcup-copytrader/SKILL.md
@@ -8,7 +8,7 @@ tags:
   - copytrading
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.1"
+  version: "0.1.2"
   displayName: World Cup Copytrader
   difficulty: beginner
   sensitivity: sensitive


### PR DESCRIPTION
## What

One-line clarification in `polymarket-worldcup-copytrader/SKILL.md` Setup: the dashboard SDK tab is not the *only* way to get a key. Agents that register via the `simmer` overview skill already have `SIMMER_API_KEY` from the registration response (`POST /api/sdk/agents/register` returns `api_key`); the dashboard is only for *recovering* it.

## Why

Surfaced reviewing the WC Copytrader X-thread: the SKILL.md Setup read as if a browser/dashboard step was mandatory, which contradicts the agent-native onboarding the `/worldcup` page promotes (`install simmer` → headless self-registration → auto key + 10K \$SIM).

## Scope

Docs only, no behavior change. `mcp/bundled-skills/` is a gitignored build artifact and regenerates from `skills/` on the next bundle — no manual mirror needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)