### PR TITLE
docs(simmer-mcp-setup): raw primitives are exposed (stale note fix, v3.3.0)

### DIFF
--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.1.2"
+version: "0.1.3"
 published: true
 description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.2"
+  version: "0.1.3"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -25,9 +25,9 @@ The Simmer MCP gives your agent a catalog of **pre-built Simmer trading skills**
 
 **What this MCP is for:** running pre-baked Simmer trading strategies through your agent. Ask *"run the `polymarket_copytrading` skill on the top 3 markets in dry-run mode"* and Claude Code (or Cursor / OpenClaw / etc.) invokes it. Each skill runs as a subprocess that calls the Simmer API. Real trades land on the configured venue — paper `sim` by default, real venues require an explicit triple opt-in (`dry_run=false` + `trading_venue=polymarket|kalshi` + `SIMMER_MCP_ALLOW_LIVE=true` env var on the MCP server).
 
-**What this MCP doesn't do (yet):** expose raw trade primitives like `place_order` or `get_briefing` as standalone tools. Ad-hoc operations like *"buy $10 yes on this BTC market"* or *"show me my current portfolio"* aren't possible through MCP today — those still need the [Python SDK](https://clawhub.ai/skills/simmer), which exposes `client.trade()`, `client.get_briefing()`, etc. directly. Raw MCP primitives are a tracked follow-up.
+**Raw trade primitives (added in MCP v3.3.0):** the MCP now exposes raw primitives as standalone tools alongside the per-skill executors — `simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, `simmer_cancel_order`, and `get_portfolio`/`get_positions`/`get_expiring_positions`. So ad-hoc operations like *"show me Polymarket markets for the world cup"* or *"place a $2 paper YES on this market"* now work directly through MCP. `simmer_trade` is **paper-by-default** — live execution needs the triple gate (`dry_run=false` + a live `trading_venue` + `SIMMER_MCP_ALLOW_LIVE=true`). The [Python SDK](https://clawhub.ai/skills/simmer) still offers the fullest primitive surface (`client.trade()`, `client.get_briefing()`, etc.) for custom logic.
 
-So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strategies through your agent with safety defaults; SDK builds custom logic with full primitive access.
+So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strategies *and* raw primitives through your agent with safety defaults; the SDK builds custom logic with full primitive access.
 
 ## What you'll have at the end
 


### PR DESCRIPTION
Doc-drift cleanup from the overnight pack build. The `simmer-mcp-setup` skill said raw trade primitives 'aren't possible through MCP today' — stale since **v3.3.0** (SIM-2323) added `simmer_get_markets`/`simmer_get_market_context`/`simmer_get_briefing`/`simmer_trade`/`get_portfolio`. Updated to reflect they're exposed (simmer_trade paper-by-default behind the triple gate). Version 0.1.2→0.1.3; **republish is Adrian's call** — leave for review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)