### PR TITLE
fix(shock-ladder): venue=sim skips order placement instead of per-rung errors (SIM-3314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`polymarket-soccer-shock-ladder`: `--venue sim` no longer emits per-rung placement errors.** The sim/LMSR venue has no order book, so limit-price rungs cannot be placed. The skill now detects `venue=sim` and skips order placement entirely — logging the computed ladder as `[shock-ladder] venue=sim: order book absent — computed ladder shown, NOT executed` — then deletes the signal normally. Previously every rung failed with a cryptic SDK error even when using sim as a smoke test. `--venue polymarket` behavior is unchanged.
+
 ## [0.20.0] - 2026-06-16
 
 ### Changed

--- a/skills/polymarket-soccer-shock-ladder/shock_ladder_trader.py
+++ b/skills/polymarket-soccer-shock-ladder/shock_ladder_trader.py
@@ -113,15 +113,19 @@ class Placement:
 
 
 def place_ladder(client, signal: dict, rungs: List[Rung], cfg: Config) -> List[Placement]:
-    """Place the 4 GTC limit buys (or log them in dry-run). Returns placements."""
+    """Place the 4 GTC limit buys (or log them in dry-run/sim). Returns placements."""
     market_id = signal["market_id"]
     side = signal["side"].lower()
     placements: List[Placement] = []
+    if cfg.venue == "sim":
+        print("[shock-ladder] venue=sim: order book absent — computed ladder shown, "
+              "NOT executed (use --venue polymarket to trade).")
     for r in rungs:
         shares_est = round(r.stake / r.price, 2) if r.price > 0 else 0.0
         tag = f"{r.label} {r.stake:.2f} USD @ {r.price:.3f} (~{shares_est:.1f} sh)"
-        if not cfg.live:
-            print(f"[shock-ladder] DRY-RUN would place BUY {side.upper()} {tag}")
+        if not cfg.live or cfg.venue == "sim":
+            label = "DRY-RUN" if not cfg.live else "sim"
+            print(f"[shock-ladder] {label} would place BUY {side.upper()} {tag}")
             placements.append(Placement(r, None, shares_est))
             continue
         try:
@@ -155,10 +159,11 @@ def manage_lifecycle(client, signal: dict, placements: List[Placement], cfg: Con
     side = signal["side"].lower()
     live_rungs = [p for p in placements if p.order_id or not cfg.live]
 
-    if not cfg.live:
+    if not cfg.live or cfg.venue == "sim":
         for p in live_rungs:
             ep = exit_price(p.rung.price, cfg.exit_cents)
-            print(f"[shock-ladder] DRY-RUN on fill of {p.rung.label} would place SELL "
+            label = "DRY-RUN" if not cfg.live else "sim"
+            print(f"[shock-ladder] {label} on fill of {p.rung.label} would place SELL "
                   f"{side.upper()} {p.shares:.1f} sh @ {ep:.3f} (+{cfg.exit_cents:.0f}¢)")
         return
 
@@ -191,6 +196,8 @@ def manage_lifecycle(client, signal: dict, placements: List[Placement], cfg: Con
 
 
 def _place_exit(client, signal: dict, p: Placement, side: str, cfg: Config) -> None:
+    if cfg.venue == "sim":
+        return  # order book absent; manage_lifecycle already returned early
     ep = exit_price(p.rung.price, cfg.exit_cents)
     try:
         res = client.trade(

--- a/skills/polymarket-soccer-shock-ladder/tests/test_shock_ladder_trader.py
+++ b/skills/polymarket-soccer-shock-ladder/tests/test_shock_ladder_trader.py
@@ -50,9 +50,12 @@ class FakeClient:
             return {"ok": True}
         return {}
 
-    def trade(self, **kw):  # must NOT be called in dry-run
+    def trade(self, **kw):  # must NOT be called in dry-run or venue=sim
         self.traded.append(kw)
-        raise AssertionError("trade() called in dry-run")
+        raise AssertionError("trade() called unexpectedly")
+
+    def get_open_orders(self):  # must NOT be called for venue=sim
+        raise AssertionError("get_open_orders() called for venue=sim")
 
 
 # --- config ---
@@ -128,3 +131,27 @@ def test_run_once_empty_is_noop():
     client = FakeClient(pending=[])
     assert t.run_once(client, t.Config(_args())) == 0
     assert client.deleted == []
+
+
+# --- venue=sim guard ---
+
+def test_venue_sim_no_trades_no_open_orders_and_deletes(capsys):
+    """venue=sim must never call trade() or get_open_orders(), even with --live."""
+    client = FakeClient()
+    cfg = t.Config(_args(venue="sim", live=True))
+    out = t.process_signal(client, _signal(), cfg)
+    assert out.startswith("handled:")
+    assert client.traded == []                        # no orders placed
+    assert client.deleted == ["mkt-1:1750000000.0"]  # signal cleaned up
+    captured = capsys.readouterr()
+    assert "order book absent" in captured.out
+
+
+def test_venue_sim_dryrun_no_trades_and_deletes():
+    """venue=sim + dry-run also places no trades (belt-and-suspenders)."""
+    client = FakeClient()
+    cfg = t.Config(_args(venue="sim", live=False))
+    out = t.process_signal(client, _signal(), cfg)
+    assert out.startswith("handled:")
+    assert client.traded == []
+    assert client.deleted == ["mkt-1:1750000000.0"]


### PR DESCRIPTION
The `polymarket-soccer-shock-ladder` skill was attempting to place CLOB limit orders even when `--venue sim` was specified, causing a cryptic per-rung SDK error (`price parameter only supported for venue='polymarket'`). The sim/LMSR venue has no order book, so this is structurally impossible.

## Changes

- `shock_ladder_trader.py`: guard `place_ladder()` — prints `venue=sim: order book absent — computed ladder shown, NOT executed` then logs each rung without calling `client.trade()`. Guard `manage_lifecycle()` — returns early (no `get_open_orders()` poll, no exit placement). Guard `_place_exit()` — defensive early return if sim venue somehow reached it.
- `tests/test_shock_ladder_trader.py`: two new tests asserting `venue=sim + --live` calls zero `trade()` / `get_open_orders()` and still deletes the signal; `FakeClient.get_open_orders()` raises `AssertionError` if called.
- `CHANGELOG.md`: unreleased entry (public framing, no internal details).

## Tests

```
cd simmer-sdk/skills/polymarket-soccer-shock-ladder && python3 -m pytest tests/ -x -v
27 passed in 0.11s
```

## Risk

Low — venue-guard only. `--venue polymarket` path is untouched; no trading logic, sizing, or strategy changes.

Closes SIM-3314