### PR TITLE
chore(shock-ladder): bump to 0.1.5 for ClawHub republish (venue=sim guard)

### DIFF
--- a/skills/polymarket-soccer-shock-ladder/SKILL.md
+++ b/skills/polymarket-soccer-shock-ladder/SKILL.md
@@ -7,7 +7,7 @@ tags:
   - soccer
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.4"
+  version: "0.1.5"
   displayName: World Cup Shock Ladder
   difficulty: intermediate
   simmer:


### PR DESCRIPTION
Version-only bump so the ClawHub-published `polymarket-soccer-shock-ladder` carries the #234 venue=sim guard. Code already merged; this just bumps `metadata.version` 0.1.4 → 0.1.5 for the republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)