### PR TITLE
fix: quiet SIM SDK reads and summarize WC copytrader

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -342,9 +342,9 @@ class SimmerClient:
         # venue is set explicitly via the `venue=` arg (or from_env(venue=...))
         # and defaults to "sim" (paper). NOTE: the TRADING_VENUE env var is
         # intentionally NOT read here — do not reintroduce a log that implies
-        # an env var controls the venue. Surface the active mode truthfully at
-        # info level; constructing a client for read-only SIM reporting should
-        # not emit warning-level noise.
+        # an env var controls the venue. SIM construction is info-level so
+        # read-only reporting clients do not emit warning-level noise; live
+        # venues still warn because they can touch real funds.
         if venue == "sim":
             logger.info(
                 "venue='sim' — PAPER trading with virtual $SIM (no real money). "
@@ -352,7 +352,7 @@ class SimmerClient:
                 "SimmerClient.from_env(venue='polymarket')."
             )
         else:
-            logger.info("venue='%s' — LIVE trading with real funds.", venue)
+            logger.warning("venue='%s' — LIVE trading with real funds.", venue)
         self._private_key: Optional[str] = None  # EVM private key (Polymarket)
         self._wallet_address: Optional[str] = None  # EVM wallet address
         self._wallet_linked: Optional[bool] = None  # Cached linking status

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -245,7 +245,8 @@ class SimmerClient:
         private_key: Optional[str] = None,
         ows_wallet: Optional[str] = None,
         live: bool = True,
-        starting_balance: float = 10_000.0
+        starting_balance: float = 10_000.0,
+        _ignore_env_wallets: bool = False,
     ):
         """
         Initialize the Simmer client.
@@ -379,11 +380,10 @@ class SimmerClient:
         # Used to decide whether to inject wallet_address into the trade payload — see
         # _execute_polymarket_trade(). When None, the check has not yet been performed.
 
-        # OWS wallet: explicit param always wins; implicit OWS_WALLET env is
-        # only needed for live Polymarket signing. Default SIM/read-only
-        # clients should not warn about local wallet setup they will not use.
-        _ows_env = os.environ.get("OWS_WALLET")
-        effective_ows = ows_wallet or (_ows_env if venue == "polymarket" else None)
+        # OWS wallet: explicit param always wins. Some construction helpers
+        # intentionally ignore ambient wallet env vars for read-only SIM use.
+        _ows_env = None if _ignore_env_wallets else os.environ.get("OWS_WALLET")
+        effective_ows = ows_wallet or _ows_env
         if effective_ows:
             try:
                 from simmer_sdk.ows_utils import get_ows_wallet_address
@@ -409,8 +409,16 @@ class SimmerClient:
         # Check WALLET_PRIVATE_KEY first, fall back to deprecated SIMMER_PRIVATE_KEY
         if not self._ows_wallet:
             import warnings
-            _wallet_key = os.environ.get(self.PRIVATE_KEY_ENV_VAR) if venue == "polymarket" else None
-            _legacy_key = os.environ.get(self.PRIVATE_KEY_ENV_VAR_LEGACY) if venue == "polymarket" else None
+            _wallet_key = (
+                os.environ.get(self.PRIVATE_KEY_ENV_VAR)
+                if venue == "polymarket" and not _ignore_env_wallets
+                else None
+            )
+            _legacy_key = (
+                os.environ.get(self.PRIVATE_KEY_ENV_VAR_LEGACY)
+                if venue == "polymarket" and not _ignore_env_wallets
+                else None
+            )
             if _wallet_key and _legacy_key and _wallet_key != _legacy_key:
                 warnings.warn(
                     "Both WALLET_PRIVATE_KEY and SIMMER_PRIVATE_KEY are set with different values. "
@@ -572,6 +580,9 @@ class SimmerClient:
                 "Get an API key at simmer.markets/dashboard → SDK tab, "
                 "then export SIMMER_API_KEY=sk_live_... in your environment."
             )
+        venue = kwargs.get("venue", "sim")
+        if venue in ("sim", "simmer", "sandbox") and "private_key" not in kwargs and "ows_wallet" not in kwargs:
+            kwargs["_ignore_env_wallets"] = True
         return cls(api_key=api_key, **kwargs)
 
     @classmethod

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -341,16 +341,17 @@ class SimmerClient:
         # venue is set explicitly via the `venue=` arg (or from_env(venue=...))
         # and defaults to "sim" (paper). NOTE: the TRADING_VENUE env var is
         # intentionally NOT read here — do not reintroduce a log that implies
-        # an env var controls the venue. Surface the active mode truthfully so
-        # callers never mistake paper ($SIM) trades for live ones, or vice versa.
+        # an env var controls the venue. Surface the active mode truthfully at
+        # info level; constructing a client for read-only SIM reporting should
+        # not emit warning-level noise.
         if venue == "sim":
-            logger.warning(
+            logger.info(
                 "venue='sim' — PAPER trading with virtual $SIM (no real money). "
                 "For LIVE trading pass venue='polymarket' per trade, or "
                 "SimmerClient.from_env(venue='polymarket')."
             )
         else:
-            logger.warning("venue='%s' — LIVE trading with real funds.", venue)
+            logger.info("venue='%s' — LIVE trading with real funds.", venue)
         self._private_key: Optional[str] = None  # EVM private key (Polymarket)
         self._wallet_address: Optional[str] = None  # EVM wallet address
         self._wallet_linked: Optional[bool] = None  # Cached linking status
@@ -378,9 +379,11 @@ class SimmerClient:
         # Used to decide whether to inject wallet_address into the trade payload — see
         # _execute_polymarket_trade(). When None, the check has not yet been performed.
 
-        # OWS wallet: param > env var > fall through to raw key
+        # OWS wallet: explicit param always wins; implicit OWS_WALLET env is
+        # only needed for live Polymarket signing. Default SIM/read-only
+        # clients should not warn about local wallet setup they will not use.
         _ows_env = os.environ.get("OWS_WALLET")
-        effective_ows = ows_wallet or _ows_env
+        effective_ows = ows_wallet or (_ows_env if venue == "polymarket" else None)
         if effective_ows:
             try:
                 from simmer_sdk.ows_utils import get_ows_wallet_address
@@ -406,8 +409,8 @@ class SimmerClient:
         # Check WALLET_PRIVATE_KEY first, fall back to deprecated SIMMER_PRIVATE_KEY
         if not self._ows_wallet:
             import warnings
-            _wallet_key = os.environ.get(self.PRIVATE_KEY_ENV_VAR)
-            _legacy_key = os.environ.get(self.PRIVATE_KEY_ENV_VAR_LEGACY)
+            _wallet_key = os.environ.get(self.PRIVATE_KEY_ENV_VAR) if venue == "polymarket" else None
+            _legacy_key = os.environ.get(self.PRIVATE_KEY_ENV_VAR_LEGACY) if venue == "polymarket" else None
             if _wallet_key and _legacy_key and _wallet_key != _legacy_key:
                 warnings.warn(
                     "Both WALLET_PRIVATE_KEY and SIMMER_PRIVATE_KEY are set with different values. "
@@ -435,8 +438,8 @@ class SimmerClient:
                         self._wallet_address[:10] + "..." if self._wallet_address else "unknown"
                     )
 
-        # Solana key: Auto-detect from environment for Kalshi trading
-        if os.environ.get(self.SOLANA_PRIVATE_KEY_ENV_VAR):
+        # Solana key: Auto-detect from environment for Kalshi trading only.
+        if venue == "kalshi" and os.environ.get(self.SOLANA_PRIVATE_KEY_ENV_VAR):
             self._solana_key_available = True
             # Derive wallet address (deferred until needed to avoid import if not used)
             try:
@@ -520,14 +523,15 @@ class SimmerClient:
             except Exception as e:
                 logger.warning("Risk alert check failed: %s", e)
 
-        # Server-side SDK version compatibility check (fail-quiet).
-        # Emits DeprecationWarning if the server says this SDK version is
-        # deprecated or blocked.  One call per client instance, no re-check.
-        try:
-            from .version_check import check_server_version_compatibility
-            check_server_version_compatibility(self.base_url, _sdk_version, self._session)
-        except Exception as e:
-            logger.debug("SDK version check setup error — ignoring: %s", e)
+        # Server-side SDK version compatibility check (fail-quiet). The
+        # warning is about real-venue signing compatibility, so do not emit it
+        # for SIM/read-only client construction.
+        if venue != "sim":
+            try:
+                from .version_check import check_server_version_compatibility
+                check_server_version_compatibility(self.base_url, _sdk_version, self._session)
+            except Exception as e:
+                logger.debug("SDK version check setup error — ignoring: %s", e)
 
     def __repr__(self):
         return f"SimmerClient(venue={self.venue!r}, base_url={self.base_url!r})"

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -411,12 +411,12 @@ class SimmerClient:
             import warnings
             _wallet_key = (
                 os.environ.get(self.PRIVATE_KEY_ENV_VAR)
-                if venue == "polymarket" and not _ignore_env_wallets
+                if not _ignore_env_wallets
                 else None
             )
             _legacy_key = (
                 os.environ.get(self.PRIVATE_KEY_ENV_VAR_LEGACY)
-                if venue == "polymarket" and not _ignore_env_wallets
+                if not _ignore_env_wallets
                 else None
             )
             if _wallet_key and _legacy_key and _wallet_key != _legacy_key:

--- a/skills/polymarket-worldcup-copytrader/copytrader.py
+++ b/skills/polymarket-worldcup-copytrader/copytrader.py
@@ -211,6 +211,39 @@ def _resolve_venue(cli_venue: str = None) -> str:
     return cli_venue or _config.get("venue") or "sim"
 
 
+def _portfolio_summary_line(client, venue: str) -> str:
+    """Best-effort terminal accounting summary for autonomous run logs."""
+    try:
+        portfolio = client.get_portfolio(venue=venue) or {}
+    except Exception as e:
+        return f"portfolio=unavailable ({type(e).__name__})"
+
+    bucket = portfolio.get(venue) or {}
+    if venue == "sim":
+        realized = unrealized = None
+        for stats in (portfolio.get("by_source") or {}).values():
+            if not isinstance(stats, dict):
+                continue
+            realized = (realized or 0.0) + float(stats.get("realized_pnl") or 0.0)
+            unrealized = (unrealized or 0.0) + float(stats.get("unrealized_pnl") or 0.0)
+        pnl = bucket.get("pnl", portfolio.get("sim_pnl"))
+        parts = [
+            f"portfolio_pnl=${float(pnl or 0):.2f}",
+            f"exposure=${float(bucket.get('total_exposure') or 0):.2f}",
+        ]
+        if realized is not None or unrealized is not None:
+            parts.append(f"realized=${float(realized or 0):.2f}")
+            parts.append(f"unrealized=${float(unrealized or 0):.2f}")
+        return " | ".join(parts)
+
+    pnl = bucket.get("pnl", portfolio.get("pnl_total"))
+    exposure = bucket.get("total_exposure", portfolio.get("total_exposure"))
+    return (
+        f"portfolio_pnl=${float(pnl or 0):.2f} | "
+        f"exposure=${float(exposure or 0):.2f}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Leader fetch
 # ---------------------------------------------------------------------------
@@ -634,8 +667,13 @@ def run(dry_run: bool = True, venue: str = None) -> None:
 
     plan["trades_executed"] = executed
     _emit_automaton(plan, executed)
+    failed = len([t for t in trades if t.get("success") is False])
+    accounting = _portfolio_summary_line(client, effective_venue)
     print(f"\n{'─' * 50}")
-    print(f"✅ WC Copytrader run complete — {executed}/{len(trades)} trades executed.")
+    print(
+        f"✅ WC Copytrader run complete — {executed}/{len(trades)} trades executed "
+        f"({failed} failed) | {accounting}"
+    )
 
 
 def _emit_automaton(plan: dict, trades_executed: int) -> None:

--- a/skills/polymarket-worldcup-copytrader/tests/test_copytrader.py
+++ b/skills/polymarket-worldcup-copytrader/tests/test_copytrader.py
@@ -73,6 +73,15 @@ def _make_skill_module(leaders_response, plan_response=None, trade_success=True,
     mock_client.auto_redeem.return_value = []
     mock_client.ensure_can_trade.return_value = {"ok": True, "max_safe_size": 30.0, "balance": 100.0}
     mock_client.trade.return_value = mock_trade_result
+    mock_client.get_portfolio.return_value = {
+        "sim": {"pnl": -18.68, "total_exposure": 324.90},
+        "by_source": {
+            "sdk:wc-copytrader": {
+                "realized_pnl": -10.52,
+                "unrealized_pnl": -8.16,
+            }
+        },
+    }
 
     if plan_response is None:
         plan_response = {
@@ -972,6 +981,17 @@ class TestLivePriceBound(unittest.TestCase):
         mod.run(dry_run=False, venue="sim")
         mock_client.trade.assert_called_once()
         self.assertIsNone(mock_client.trade.call_args[1].get("price"))
+
+    def test_terminal_summary_includes_accounting(self):
+        mod, mock_client = _make_skill_module(leaders_response=_leaders_response())
+        _, captured = _run_capturing(mod, dry_run=False, venue="sim")
+        mock_client.get_portfolio.assert_called_with(venue="sim")
+        summary = [line for line in captured if "WC Copytrader run complete" in line][-1]
+        self.assertIn("1/1 trades executed", summary)
+        self.assertIn("0 failed", summary)
+        self.assertIn("portfolio_pnl=$-18.68", summary)
+        self.assertIn("realized=$-10.52", summary)
+        self.assertIn("unrealized=$-8.16", summary)
 
     def test_dry_run_unaffected_by_missing_estimated_price(self):
         plan = self._plan(include_price=False)

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -8,6 +8,7 @@ suspicious surface area.
 
 import pytest
 import warnings
+import logging
 
 from simmer_sdk.client import SimmerClient
 
@@ -68,6 +69,23 @@ def test_from_env_sim_read_only_ignores_wallet_env_without_warnings(monkeypatch,
     assert client._private_key is None
     assert caught == []
     assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+
+def test_live_venue_construction_still_warns_real_funds(monkeypatch, caplog):
+    """Noise reduction for SIM clients must not hide live real-funds warnings."""
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("SIMMER_PRIVATE_KEY", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client = SimmerClient(api_key="sk_live_test_live", venue="polymarket")
+
+    assert client.venue == "polymarket"
+    assert any("LIVE trading with real funds" in r.getMessage() for r in caplog.records)
 
 
 def test_from_env_raises_when_api_key_missing(monkeypatch):

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -7,6 +7,7 @@ suspicious surface area.
 """
 
 import pytest
+import warnings
 
 from simmer_sdk.client import SimmerClient
 
@@ -48,6 +49,25 @@ def test_from_env_only_api_key(monkeypatch):
     assert client.api_key == "sk_live_test_xyz"
     assert client._private_key is None
     assert client._ows_wallet is None
+
+
+def test_from_env_sim_read_only_ignores_wallet_env_without_warnings(monkeypatch, caplog):
+    """Default SIM/read-only construction should not warn about unused wallets."""
+    monkeypatch.setenv("SIMMER_API_KEY", "sk_live_test_quiet")
+    monkeypatch.setenv("OWS_WALLET", "missing-ows-wallet")
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", "0x" + "a" * 64)
+    monkeypatch.setenv("SIMMER_PRIVATE_KEY", "0x" + "b" * 64)
+    monkeypatch.setenv("SOLANA_PRIVATE_KEY", "not-a-solana-key")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        client = SimmerClient.from_env()
+
+    assert client.venue == "sim"
+    assert client._ows_wallet is None
+    assert client._private_key is None
+    assert caught == []
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
 
 def test_from_env_raises_when_api_key_missing(monkeypatch):

--- a/tests/test_hyperliquid_client_integration.py
+++ b/tests/test_hyperliquid_client_integration.py
@@ -25,6 +25,21 @@ def test_hyperliquid_property_builds_adapter(monkeypatch):
     assert c.hyperliquid is venue
 
 
+def test_hyperliquid_from_env_uses_wallet_private_key(monkeypatch):
+    monkeypatch.setenv("SIMMER_API_KEY", "test")
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.delenv("SIMMER_PRIVATE_KEY", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+
+    c = SimmerClient.from_env(venue="hyperliquid")
+
+    assert c._private_key == TEST_KEY
+
+
 def test_hyperliquid_testnet_env(monkeypatch):
     pytest.importorskip("hyperliquid", reason="requires the [hyperliquid] extra")
     monkeypatch.setenv("SIMMER_HYPERLIQUID_TESTNET", "1")


### PR DESCRIPTION
## Summary
- stop warning-level SDK constructor logs for default SIM/read-only clients
- skip implicit wallet env detection and V2 signing version warnings when constructing SIM clients
- add WC copytrader terminal accounting summary with executed/failed counts and portfolio PnL

## Tests
- PYTHONPATH=. python3 -m pytest tests/test_client_constructors.py skills/polymarket-worldcup-copytrader/tests/test_copytrader.py

Closes SIM-3304