### PR TITLE
fix: preserve market outcome in sdk client

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -39,6 +39,7 @@ class Market:
     question: str
     status: str
     current_probability: float
+    outcome: Optional[bool] = None  # None = pending, True = YES won, False = NO won
     import_source: Optional[str] = None
     external_price_yes: Optional[float] = None
     divergence: Optional[float] = None
@@ -60,6 +61,7 @@ class Market:
     best_ask_size: Optional[float] = None  # Shares available at best_ask
     spread: Optional[float] = None  # best_ask - best_bid; null if either side null
     quote_ts: Optional[float] = None  # Epoch-second snapshot time (~30s freshness)
+    quote_age_seconds: Optional[float] = None  # Age of quote_ts at server response time
 
 
 @dataclass
@@ -1831,6 +1833,7 @@ class SimmerClient:
             question=m["question"],
             status=m.get("status", "active"),
             current_probability=m.get("current_probability", 0.5),
+            outcome=m.get("outcome"),
             import_source=m.get("import_source"),
             external_price_yes=m.get("external_price_yes"),
             divergence=m.get("divergence"),
@@ -1851,6 +1854,7 @@ class SimmerClient:
             best_ask_size=m.get("best_ask_size"),
             spread=m.get("spread"),
             quote_ts=m.get("quote_ts"),
+            quote_age_seconds=m.get("quote_age_seconds"),
         )
 
     def trade(

--- a/tests/test_market_parse.py
+++ b/tests/test_market_parse.py
@@ -1,0 +1,39 @@
+from simmer_sdk.client import SimmerClient
+
+
+def test_parse_market_preserves_resolution_outcome():
+    market = SimmerClient._parse_market({
+        "id": "m1",
+        "question": "Did YES win?",
+        "status": "resolved",
+        "current_probability": 1.0,
+        "outcome": True,
+    })
+
+    assert market.outcome is True
+
+
+def test_parse_market_preserves_false_outcome_and_quote_age():
+    market = SimmerClient._parse_market({
+        "id": "m2",
+        "question": "Did NO win?",
+        "status": "resolved",
+        "current_probability": 0.0,
+        "outcome": False,
+        "quote_ts": 1780000000.0,
+        "quote_age_seconds": 2.5,
+    })
+
+    assert market.outcome is False
+    assert market.quote_ts == 1780000000.0
+    assert market.quote_age_seconds == 2.5
+
+
+def test_parse_market_defaults_outcome_to_none_for_pending_markets():
+    market = SimmerClient._parse_market({
+        "id": "m3",
+        "question": "Pending?",
+        "current_probability": 0.42,
+    })
+
+    assert market.outcome is None


### PR DESCRIPTION
Summary
- add Market.outcome to the Python SDK dataclass
- parse outcome from /api/sdk/markets and /api/sdk/markets/{id} responses
- carry quote_age_seconds through the SDK Market object

Tests
- python3.11 -m pytest -q tests/test_market_parse.py tests/test_find_markets_server_query.py tests/test_client_constructors.py

Companion
- Pairs with SupaFund/simmer#1463 for the server endpoint fixes.

Closes SIM-3347