### PR TITLE
feat(combo): activate_combo_dw + DW combo support (E3)

### DIFF
--- a/mcp/bundled-skills/polymarket-combo-builder/SKILL.md
+++ b/mcp/bundled-skills/polymarket-combo-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polymarket-combo-builder
-description: Build an atomic Polymarket combo (parlay) - pick 2+ binary market legs, get live combined odds quoted over RFQ, and place the whole thing as ONE signed order. Every leg must hit to win; any single leg losing is a total loss of the stake. Live placement works with EOA / self-custody wallets today; deposit-wallet live is blocked pending Polymarket. Dry-run by default (a local plan, not a paper fill). Sports-general (World Cup ready).
+description: Build an atomic Polymarket combo (parlay) - pick 2+ binary market legs, get live combined odds quoted over RFQ, and place the whole thing as ONE signed order. Every leg must hit to win; any single leg losing is a total loss of the stake. Live placement works with EOA / self-custody wallets, and with deposit wallets after a one-time activate_combo_dw() setup. Dry-run by default (a local plan, not a paper fill). Sports-general (World Cup ready).
 category: world-cup
 tags:
   - world-cup
@@ -8,7 +8,7 @@ tags:
   - combo
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.0"
+  version: "0.1.1"
   displayName: Combo Builder
   difficulty: beginner
 ---
@@ -23,9 +23,8 @@ whole stake.
 
 This is the atomic combo — distinct from the leg-by-leg
 `polymarket-worldcup-parlay-roller`. **Live placement works with EOA /
-self-custody wallets today.** Deposit-wallet dry-run + signing paths exist, but
-**live deposit-wallet combos are blocked** until Polymarket enables
-combo-exchange approvals for deposit wallets (details below).
+self-custody wallets, and with deposit wallets** after a one-time
+`activate_combo_dw()` setup (details below).
 
 Read [DISCLAIMER.md](./DISCLAIMER.md) before going live. This is a framework,
 not an edge, and it runs in **dry-run by default**. Dry-run is a **local plan**
@@ -74,24 +73,36 @@ configured wallet (`WALLET_PRIVATE_KEY`) and a live Simmer client.
 
 ## Wallet support
 
-- **EOA** (`signature_type 0`): standard self-custody key. **Works today.**
-- **Deposit wallet** (`signature_type 3` / POLY_1271): signing works, but live
-  combos are **not yet available** — see below.
+- **EOA** (`signature_type 0`): standard self-custody key. **Works today**, no
+  extra setup.
+- **Deposit wallet** (`signature_type 3` / POLY_1271): **works after a one-time
+  `activate_combo_dw()`** — see below.
 
 OWS-signed wallets are not yet supported for combos — use a raw
-`WALLET_PRIVATE_KEY` (the deposit-wallet owner key) for now.
+`WALLET_PRIVATE_KEY` (the deposit-wallet owner key) for now. This applies to
+both placing combos and `activate_combo_dw()`.
 
-### ⚠️ Deposit wallets: not enabled yet (pending Polymarket)
+### Deposit wallets: one-time combo activation
 
-Combos settle on a separate exchange that your wallet must approve first. A
-**deposit wallet** can only approve contracts through Polymarket's relayer
-(its `execute` is `onlyFactory` → `onlyOperator`), and that relayer **doesn't
-yet permit approving the combo exchange** — so a deposit-wallet combo signs
-correctly but would fail at on-chain settlement. The skill detects this and
-**blocks a live deposit-wallet combo with a clear message** rather than letting
-it fail confusingly. This auto-resolves once Polymarket whitelists the combo
-exchange on the deposit-wallet relayer. **EOA / self-custody wallets are
-unaffected and work today.** (Dry-run works for all wallet types.)
+Combos settle on a **separate exchange** that your wallet must approve first.
+The standard DW activation (`activate_polymarket_dw()`) does **not** set this —
+combo approval is opt-in. Run it once per deposit wallet:
+
+```python
+client.activate_combo_dw()              # user-primary DW
+client.activate_combo_dw(agent_id="…")  # per-agent (Elite) DW
+```
+
+This signs the combo-exchange approval batch locally and Simmer's server
+relays it **gaslessly** under our builder credentials (it approves the combo
+exchange to spend the DW's pUSD + combo position tokens). It is idempotent —
+safe to re-run. After it completes, `place_combo(..., dry_run=False)` settles
+normally for the deposit wallet.
+
+Before a live DW placement the SDK runs a quick on-chain pre-check and, if the
+combo approval is missing, raises a clear **"run `client.activate_combo_dw()`
+first"** error instead of letting the order fail at settlement. (Dry-run works
+for all wallet types with no activation.)
 
 ## Notes
 

--- a/mcp/bundled-skills/polymarket-combo-builder/clawhub.json
+++ b/mcp/bundled-skills/polymarket-combo-builder/clawhub.json
@@ -3,7 +3,7 @@
   "primaryEnv": "SIMMER_API_KEY",
   "requires": {
     "env": ["SIMMER_API_KEY"],
-    "pip": ["simmer-sdk>=0.20.1", "requests>=2.28", "websockets>=12.0"]
+    "pip": ["simmer-sdk>=0.20.3", "requests>=2.28", "websockets>=12.0"]
   },
   "envVars": [
     {

--- a/mcp/bundled-skills/polymarket-combo-builder/combo_builder.py
+++ b/mcp/bundled-skills/polymarket-combo-builder/combo_builder.py
@@ -117,8 +117,17 @@ def run(live: bool):
             direction=direction, dry_run=False,
             on_status=lambda s: print(f"  [{s}]"),
         )
+    except ValueError as e:
+        # Deposit-wallet combos need a one-time approval; the SDK pre-check
+        # raises ValueError pointing at activate_combo_dw(). Surface the CLI
+        # equivalent.
+        if "activate_combo_dw" in str(e):
+            sys.exit(
+                f"\nCombo not placed: {e}\n\n"
+                "  -> Run once for this wallet:  python combo_builder.py --activate-combo\n"
+            )
+        raise
     except ComboPlacementError as e:
-        # Most common: deposit-wallet combos aren't enabled yet (see below).
         sys.exit(f"\nCombo not placed: {e}")
     print("Result:")
     print(json.dumps(result, indent=2))
@@ -126,13 +135,36 @@ def run(live: bool):
         print(f"\nFilled. tx: https://polygonscan.com/tx/{result['tx_hash']}")
 
 
+def activate_combo():
+    """One-time deposit-wallet combo activation (approves the combo exchange).
+
+    EOA / self-custody wallets need no activation — this is only for deposit
+    wallets (signature_type 3). Idempotent and gasless (server-relayed).
+    """
+    from simmer_sdk.client import SimmerClient
+
+    api_key = os.getenv("SIMMER_API_KEY")
+    if not api_key:
+        sys.exit("Set SIMMER_API_KEY (simmer.markets/dashboard -> SDK tab).")
+    client = SimmerClient(api_key=api_key, venue="polymarket", live=True)
+    print("=== Activating deposit-wallet combos (one-time) ===")
+    result = client.activate_combo_dw()
+    print(json.dumps(result, indent=2))
+    print("\nDone. You can now place deposit-wallet combos with --live.")
+
+
 def main():
     ap = argparse.ArgumentParser(description="Place an atomic Polymarket combo (parlay).")
     ap.add_argument("--live", action="store_true", help="Place for real (money path). Default: dry-run.")
     ap.add_argument("--legs", action="store_true", help="Browse combo-eligible legs and exit.")
+    ap.add_argument("--activate-combo", action="store_true",
+                    help="One-time: approve the combo exchange for a deposit wallet, then exit.")
     args = ap.parse_args()
     if args.legs:
         browse_legs()
+        return
+    if args.activate_combo:
+        activate_combo()
         return
     run(live=args.live)
 

--- a/simmer_sdk/batch_validation.py
+++ b/simmer_sdk/batch_validation.py
@@ -109,7 +109,9 @@ def validate_dw_approval_calls(calls: list) -> None:
         PUSD,
         V2_FEE_ESCROW,
         CTF_COLLATERAL_ADAPTER,
+        COMBO_POSITION_MANAGER,
         active_spenders,
+        combo_spenders,
         redemption_spenders,
     )
 
@@ -117,12 +119,22 @@ def validate_dw_approval_calls(calls: list) -> None:
 
     pusd_l = PUSD.lower()
     ctf_l = CONDITIONAL_TOKENS.lower()
+    combo_pm_l = COMBO_POSITION_MANAGER.lower()
     allowed_pairs: set[tuple[str, str]] = set()
     for spender in active_spenders():
         s = spender.lower()
         allowed_pairs.add((pusd_l, s))   # pUSD → spender (ERC20 approve)
         allowed_pairs.add((ctf_l, s))    # CTF  → spender (ERC1155 setApprovalForAll)
     allowed_pairs.add((pusd_l, V2_FEE_ESCROW.lower()))
+    # Combo (parlay) approvals — opt-in, set by activate_combo_dw(). pUSD →
+    # combo exchange (ERC20 approve) + combo Position Manager → combo exchange
+    # (ERC1155 setApprovalForAll). Mirror of the server's
+    # get_allowed_dw_approval_targets() combo additions. NOTE the ERC1155 leg
+    # is on COMBO_POSITION_MANAGER (combo position tokens live there), NOT CTF.
+    for spender in combo_spenders():
+        s = spender.lower()
+        allowed_pairs.add((pusd_l, s))
+        allowed_pairs.add((combo_pm_l, s))
     for adapter in redemption_spenders():
         allowed_pairs.add((ctf_l, adapter.lower()))
     allowed_pairs.add((pusd_l, CTF_COLLATERAL_ADAPTER.lower()))

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1213,12 +1213,13 @@ class SimmerClient:
         OWS-signed wallets are not yet supported for combos — raw-key /
         external-EOA (incl. deposit-wallet owner key) only for now.
 
-        **Deposit-wallet limitation:** DW combos sign correctly but a DW can't
-        yet APPROVE the combo exchange (Polymarket's relayer rejects it —
-        DW.execute is onlyFactory->Factory.proxy onlyOperator), so a live DW
-        combo is blocked with a clear error until Polymarket whitelists the
-        combo exchange on the deposit-wallet relayer. EOA wallets work today.
-        Pass ``allow_deposit_wallet=True`` to override once that's enabled.
+        **Deposit-wallet combos:** supported. A DW must first approve the
+        combo exchange once via :meth:`activate_combo_dw` (the standard DW
+        activation does NOT set this — combos settle on a separate exchange).
+        Before a real DW placement this method does a best-effort on-chain
+        check and raises a clear "run activate_combo_dw() first" error if the
+        combo approval is missing, rather than letting the order fail at
+        settlement on a missing allowance. EOA wallets need no extra approval.
 
         Args:
             leg_position_ids: chosen-side CTF token id per leg (>= 2), from
@@ -1227,6 +1228,10 @@ class SimmerClient:
             side: combo position side ("YES" or "NO"; currently YES-only upstream).
             direction: "BUY" or "SELL".
             dry_run: default True (no money). False = real placement.
+            allow_deposit_wallet: escape hatch — when True, skip the on-chain
+                combo-approval pre-check for a DW placement (use only if you've
+                already activated combos and want to avoid the extra RPC read,
+                or the check is misbehaving). DW combos are allowed either way.
 
         Returns the dry-run plan, or ``{status, tx_hash, rfq_id}`` on a fill.
         """
@@ -1257,6 +1262,25 @@ class SimmerClient:
                 "Refusing to place a real combo from a non-live client."
             )
 
+        # Deposit-wallet combo-approval pre-check. DW combos settle on the
+        # combo exchange (COMBO_EXCHANGE), which the standard DW activation
+        # does NOT approve. Without the approval the order signs fine but
+        # fails at on-chain settlement on a missing pUSD allowance — a
+        # confusing failure. Catch it early with a clear pointer to
+        # activate_combo_dw(). Best-effort: an RPC hiccup falls through to
+        # placement rather than blocking a valid trade. Skippable via
+        # allow_deposit_wallet=True.
+        if uses_dw and not dry_run and not allow_deposit_wallet:
+            approved = self._combo_dw_approved(dw)
+            if approved is False:
+                raise ValueError(
+                    "Deposit-wallet combos require a one-time combo-exchange "
+                    "approval that isn't set yet. Run client.activate_combo_dw() "
+                    "first (it approves the combo exchange to spend this DW's "
+                    "pUSD + combo position tokens), then retry. To skip this "
+                    "check, pass allow_deposit_wallet=True."
+                )
+
         # Derive CLOB L2 creds for the resolved identity only for a real
         # placement (network call). dry_run stays fully offline.
         creds: Dict[str, str] = {}
@@ -1280,8 +1304,47 @@ class SimmerClient:
             deposit_wallet_address=dw, signature_type=signature_type,
             direction=direction, side=side, builder_code=builder_code,
             max_retries=max_retries, on_status=on_status, dry_run=dry_run,
-            allow_deposit_wallet=allow_deposit_wallet,
+            # DW combos are allowed; the client already ran the approval
+            # pre-check above, so the module-level block must not re-fire.
+            allow_deposit_wallet=True,
         )
+
+    def _combo_dw_approved(self, dw_address: str) -> Optional[bool]:
+        """Best-effort on-chain check: has ``dw_address`` approved the combo
+        exchange to spend its pUSD?
+
+        Reads ``pUSD.allowance(dw, COMBO_EXCHANGE)`` via Simmer's Polygon RPC
+        proxy. A BUY combo spends pUSD, so a non-zero allowance is the gating
+        approval that ``activate_combo_dw()`` sets (it sets the ERC1155
+        operator approval in the same batch, so pUSD allowance is a faithful
+        proxy for "combos activated").
+
+        Returns:
+            True  — pUSD allowance to the combo exchange is non-zero.
+            False — allowance is zero (combos not activated).
+            None  — couldn't determine (RPC error / unexpected response);
+                    callers treat None as "don't block".
+        """
+        try:
+            from .polymarket_contracts import PUSD, COMBO_EXCHANGE
+
+            owner = dw_address.lower().replace("0x", "").rjust(64, "0")
+            spender = COMBO_EXCHANGE.lower().replace("0x", "").rjust(64, "0")
+            # ERC20 allowance(address,address) selector 0xdd62ed3e
+            data = "0xdd62ed3e" + owner + spender
+            resp = self._request("POST", "/api/rpc/polygon", json={
+                "jsonrpc": "2.0",
+                "method": "eth_call",
+                "params": [{"to": PUSD, "data": data}, "latest"],
+                "id": 1,
+            })
+            result = resp.get("result")
+            if not result or result == "0x":
+                return None
+            return int(result, 16) > 0
+        except Exception as exc:
+            print(f"[SimmerSDK] combo-approval pre-check skipped (RPC): {exc}")
+            return None
 
     def _cancel_orders_for_token(self, token_id: str):
         """Cancel all open orders for a token using local py_clob_client."""
@@ -5587,6 +5650,138 @@ class SimmerClient:
         )
 
         print(f"[DW-Activate] Done — {len(calls)} approval(s) set.")
+        return {"already_set": False, "calls_count": len(calls), "success": True}
+
+    def activate_combo_dw(self, agent_id: Optional[str] = None) -> Dict[str, Any]:
+        """Activate Polymarket **combo** (parlay) trading for a Deposit Wallet.
+
+        One-time setup that approves the combo exchange to spend this DW's
+        pUSD (ERC20) and combo position tokens (ERC1155 on the combo Position
+        Manager), so ``place_combo(...)`` can settle on-chain for the
+        deposit-wallet (signature_type 3) cohort. Mirrors
+        ``activate_polymarket_dw`` but requests the combo approval batch
+        (``{combo: true}``).
+
+        Combos settle on their own exchange (``COMBO_EXCHANGE``), distinct
+        from the V2 CLOB spenders — so this is required even for a DW that
+        already completed ``activate_polymarket_dw()``. It is kept OUT of the
+        standard activation cascade so non-combo users don't pay the extra
+        approval. The combo approvals are idempotent on-chain (re-running is a
+        no-op), and the batch also completes standard CLOB activation as a
+        side effect if that hasn't been done.
+
+        Two scopes (same routing as ``activate_polymarket_dw``):
+
+        - **User-primary** (default, ``agent_id=None``):
+          ``/api/user/wallet/external/dw-approvals/*``.
+        - **Per-agent** (``agent_id="..."``):
+          ``/api/user/agent/{agent_id}/wallet/external/dw-approvals/*``.
+
+        Raw-key only — OWS combo signing is not yet supported (matches
+        ``place_combo``). The combo approval batch is signed locally with
+        ``WALLET_PRIVATE_KEY`` / ``private_key``; the key never leaves the
+        process and the server relays the batch gaslessly under its builder
+        HMAC.
+
+        Requires:
+        - WALLET_PRIVATE_KEY env var or ``private_key`` constructor arg
+        - Account upgraded to a Deposit Wallet (per-agent: the agent's DW)
+        - eth-account installed
+
+        Returns:
+            Dict with keys ``already_set`` (bool), ``calls_count`` (int),
+            ``success`` (bool).
+
+        Raises:
+            ValueError: if no raw private key is configured
+            ImportError: if eth-account is not installed
+
+        Example (user-primary, raw key):
+            client = SimmerClient(api_key="sk_live_...")  # WALLET_PRIVATE_KEY in env
+            client.activate_combo_dw()
+            # now DW combos settle:
+            client.place_combo(leg_ids, 10.0, dry_run=False)
+        """
+        # OWS combo signing is not yet supported — require a raw key (matches
+        # place_combo's gate). An OWS-only client can't activate combos.
+        if not self._private_key:
+            raise ValueError(
+                "activate_combo_dw() requires a raw EOA private key (the "
+                "deposit-wallet owner key). Set WALLET_PRIVATE_KEY env var or "
+                "pass private_key= to the constructor. OWS combo signing is "
+                "not yet supported."
+            )
+        try:
+            from eth_account import Account  # noqa: F401 — early dep check
+        except ImportError:
+            raise ImportError(
+                "eth-account is required for activate_combo_dw(). "
+                "Install with: pip install eth-account"
+            )
+
+        if agent_id:
+            _dw_base = (
+                f"/api/user/agent/{agent_id}/wallet/external/dw-approvals"
+            )
+        else:
+            _dw_base = "/api/user/wallet/external/dw-approvals"
+
+        # Step 1 — prepare with {combo: true}. The server appends the combo
+        # approvals unconditionally (idempotent on-chain), so unlike the base
+        # method this rarely short-circuits to already_set; the short-circuit
+        # is kept defensively in case the server starts checking combo state.
+        if agent_id:
+            print(f"[Combo-Activate] Preparing combo approval batch (per-agent {agent_id})…")
+        else:
+            print("[Combo-Activate] Preparing combo approval batch…")
+        prepare = self._request(
+            "POST",
+            f"{_dw_base}/prepare",
+            json={"combo": True},
+        )
+
+        if prepare.get("already_set"):
+            print("[Combo-Activate] Combo approvals already set — nothing to do.")
+            return {"already_set": True, "calls_count": 0, "success": True}
+
+        typed_data = prepare.get("typed_data")
+        nonce = prepare.get("nonce")
+        deadline = prepare.get("deadline")
+        calls = prepare.get("calls", [])
+
+        if not typed_data or not nonce or deadline is None or not calls:
+            raise RuntimeError(
+                f"Unexpected prepare response — missing required fields. "
+                f"Got keys: {list(prepare.keys())}"
+            )
+
+        # Validate the server-supplied batch BEFORE signing — same client-side
+        # guard as the base method. The SDK validator accepts the combo
+        # (token, COMBO_EXCHANGE) pairs (see batch_validation.py), so an honest
+        # server's combo batch passes while anything else is refused.
+        from .batch_validation import validate_dw_approval_calls
+        validate_dw_approval_calls(calls)
+
+        print("[Combo-Activate] Signing combo approval batch locally…")
+        from eth_account import Account
+        signed = Account.sign_typed_data(self._private_key, full_message=typed_data)
+        signature = signed.signature.hex()
+        if not signature.startswith("0x"):
+            signature = "0x" + signature
+
+        print("[Combo-Activate] Submitting to relayer…")
+        self._request(
+            "POST",
+            f"{_dw_base}/submit",
+            json={
+                "signature": signature,
+                "nonce": nonce,
+                "deadline": deadline,
+                "calls": calls,
+            },
+        )
+
+        print(f"[Combo-Activate] Done — {len(calls)} combo approval(s) set.")
         return {"already_set": False, "calls_count": len(calls), "success": True}
 
     def wrap_on_dw(self) -> Dict[str, Any]:

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1252,6 +1252,15 @@ class SimmerClient:
                 "builds the plan but never signs or sends. Set WALLET_PRIVATE_KEY."
             )
 
+        # Per-agent API keys carry their DW state on /api/sdk/agents/me, NOT
+        # /api/sdk/settings (which only sees the user-primary wallet). Without
+        # this load a per-agent DW key resolves uses_dw=False and would sign an
+        # EOA combo (sig_type 0) instead of the DW combo (sig_type 3) — the
+        # order's maker would be the agent EOA, not its deposit wallet.
+        # Idempotent (guarded by _per_agent_dw_loaded); a no-op for
+        # user-primary keys (whose DW state is already set from settings).
+        self._load_per_agent_dw_state()
+
         uses_dw = bool(self._uses_deposit_wallet and self._deposit_wallet_address)
         signature_type = 3 if uses_dw else 0
         dw = self._deposit_wallet_address if uses_dw else None

--- a/simmer_sdk/combo.py
+++ b/simmer_sdk/combo.py
@@ -292,7 +292,7 @@ def place_combo(
     max_retries: int = 2,
     on_status: Optional[Callable[[str], None]] = None,
     dry_run: bool = True,
-    allow_deposit_wallet: bool = False,
+    allow_deposit_wallet: bool = True,
 ) -> Dict[str, Any]:
     """Place a combo via the requester RFQ WebSocket.
 
@@ -333,26 +333,21 @@ def place_combo(
     if dry_run:
         return plan
 
-    # Deposit-wallet gate. DW combo *identity + signing* work, but a DW cannot
-    # APPROVE the combo exchange: DepositWallet.execute is onlyFactory and
-    # DepositWalletFactory.proxy is onlyOperator (Polymarket's relayer only),
-    # and that relayer rejects approvals to the combo exchange 0xe333…
-    # ("operator not in the allowed list"). So a DW combo signs fine but fails
-    # at on-chain settlement on missing allowance. Block it with a clear
-    # message instead of a confusing settlement failure. Auto-overridable:
-    # once Polymarket whitelists 0xe333 on the DW relayer and the DW is
-    # approved, pass allow_deposit_wallet=True. (Verified 2026-06-16.)
+    # Deposit-wallet combos are SUPPORTED (proven end-to-end on-chain, E/D2,
+    # 2026-06-18). A DW must first approve the combo exchange once — the DW
+    # signs the approval batch locally and Simmer's server relays it under our
+    # builder HMAC (the combo (token, COMBO_EXCHANGE) pairs are whitelisted in
+    # the relay guard). That one-time setup is `client.activate_combo_dw()`;
+    # the SimmerClient also runs an on-chain pre-check before placing. At this
+    # low-level module entry `allow_deposit_wallet` defaults True. Passing it
+    # False explicitly disables DW combos (kept for back-compat / testing).
     if signature_type == 3 and not allow_deposit_wallet:
         raise ComboPlacementError(
-            "Deposit-wallet combos are not available yet. A deposit wallet can "
-            "only approve contracts via Polymarket's relayer (DW.execute is "
-            "onlyFactory -> Factory.proxy is onlyOperator), and that relayer "
-            "currently rejects approvals to the combo exchange 0xe3333700…  "
-            "('operator not in the allowed list'). So the order would sign but "
-            "fail at settlement on a missing allowance. EOA / self-custody "
-            "wallets work today. This auto-resolves once Polymarket whitelists "
-            "the combo exchange on the deposit-wallet relayer; pass "
-            "allow_deposit_wallet=True to override once your DW is approved."
+            "Deposit-wallet combos are disabled for this call "
+            "(allow_deposit_wallet=False). DW combos are supported — approve "
+            "the combo exchange once with client.activate_combo_dw(), then "
+            "place via the SimmerClient (which gates on the approval), or pass "
+            "allow_deposit_wallet=True here."
         )
 
     return asyncio.run(_place_combo_ws(

--- a/simmer_sdk/polymarket_contracts.py
+++ b/simmer_sdk/polymarket_contracts.py
@@ -75,6 +75,19 @@ NEG_RISK_CTF_COLLATERAL_ADAPTER = "0xadA2005600Dec949baf300f4C6120000bDB6eAab"  
 
 
 # ============================================================
+# Combo (parlay) infrastructure
+# ============================================================
+# Combos settle on their own exchange + position-token contract, distinct
+# from the V2 CLOB spenders. A deposit wallet must approve COMBO_EXCHANGE to
+# spend its pUSD (ERC20) AND its combo position tokens (ERC1155 on
+# COMBO_POSITION_MANAGER — NOT the CTF; combo position tokens live there,
+# Polymarket-confirmed 2026-06-18). Mirrors the server
+# `simmer_v3/polymarket_contracts.py` COMBO_* constants.
+COMBO_EXCHANGE = "0xe3333700cA9d93003F00f0F71f8515005F6c00Aa"
+COMBO_POSITION_MANAGER = "0x006F54F7f9A22e0000CC2AB60031000000ae9fEF"
+
+
+# ============================================================
 # Convenience aliases
 # ============================================================
 USDC_E = V1_COLLATERAL_TOKEN    # same address, named by role
@@ -171,3 +184,14 @@ def redemption_spenders() -> list[str]:
     routed through the adapter contracts. Both V1 and V2 wallets need these.
     """
     return [CTF_COLLATERAL_ADAPTER, NEG_RISK_CTF_COLLATERAL_ADAPTER]
+
+
+def combo_spenders() -> list[str]:
+    """Spenders a deposit wallet must approve to trade combos (parlays).
+
+    Just the combo exchange today. Kept separate from active_spenders() so
+    the standard DW activation cascade is unchanged — combo approval is an
+    opt-in extra (run `client.activate_combo_dw()`) for users who actually
+    build combos. Mirrors the server `combo_spenders()`.
+    """
+    return [COMBO_EXCHANGE]

--- a/skills/polymarket-combo-builder/SKILL.md
+++ b/skills/polymarket-combo-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polymarket-combo-builder
-description: Build an atomic Polymarket combo (parlay) - pick 2+ binary market legs, get live combined odds quoted over RFQ, and place the whole thing as ONE signed order. Every leg must hit to win; any single leg losing is a total loss of the stake. Live placement works with EOA / self-custody wallets today; deposit-wallet live is blocked pending Polymarket. Dry-run by default (a local plan, not a paper fill). Sports-general (World Cup ready).
+description: Build an atomic Polymarket combo (parlay) - pick 2+ binary market legs, get live combined odds quoted over RFQ, and place the whole thing as ONE signed order. Every leg must hit to win; any single leg losing is a total loss of the stake. Live placement works with EOA / self-custody wallets, and with deposit wallets after a one-time activate_combo_dw() setup. Dry-run by default (a local plan, not a paper fill). Sports-general (World Cup ready).
 category: world-cup
 tags:
   - world-cup
@@ -8,7 +8,7 @@ tags:
   - combo
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.0"
+  version: "0.1.1"
   displayName: Combo Builder
   difficulty: beginner
 ---
@@ -23,9 +23,8 @@ whole stake.
 
 This is the atomic combo — distinct from the leg-by-leg
 `polymarket-worldcup-parlay-roller`. **Live placement works with EOA /
-self-custody wallets today.** Deposit-wallet dry-run + signing paths exist, but
-**live deposit-wallet combos are blocked** until Polymarket enables
-combo-exchange approvals for deposit wallets (details below).
+self-custody wallets, and with deposit wallets** after a one-time
+`activate_combo_dw()` setup (details below).
 
 Read [DISCLAIMER.md](./DISCLAIMER.md) before going live. This is a framework,
 not an edge, and it runs in **dry-run by default**. Dry-run is a **local plan**
@@ -74,24 +73,36 @@ configured wallet (`WALLET_PRIVATE_KEY`) and a live Simmer client.
 
 ## Wallet support
 
-- **EOA** (`signature_type 0`): standard self-custody key. **Works today.**
-- **Deposit wallet** (`signature_type 3` / POLY_1271): signing works, but live
-  combos are **not yet available** — see below.
+- **EOA** (`signature_type 0`): standard self-custody key. **Works today**, no
+  extra setup.
+- **Deposit wallet** (`signature_type 3` / POLY_1271): **works after a one-time
+  `activate_combo_dw()`** — see below.
 
 OWS-signed wallets are not yet supported for combos — use a raw
-`WALLET_PRIVATE_KEY` (the deposit-wallet owner key) for now.
+`WALLET_PRIVATE_KEY` (the deposit-wallet owner key) for now. This applies to
+both placing combos and `activate_combo_dw()`.
 
-### ⚠️ Deposit wallets: not enabled yet (pending Polymarket)
+### Deposit wallets: one-time combo activation
 
-Combos settle on a separate exchange that your wallet must approve first. A
-**deposit wallet** can only approve contracts through Polymarket's relayer
-(its `execute` is `onlyFactory` → `onlyOperator`), and that relayer **doesn't
-yet permit approving the combo exchange** — so a deposit-wallet combo signs
-correctly but would fail at on-chain settlement. The skill detects this and
-**blocks a live deposit-wallet combo with a clear message** rather than letting
-it fail confusingly. This auto-resolves once Polymarket whitelists the combo
-exchange on the deposit-wallet relayer. **EOA / self-custody wallets are
-unaffected and work today.** (Dry-run works for all wallet types.)
+Combos settle on a **separate exchange** that your wallet must approve first.
+The standard DW activation (`activate_polymarket_dw()`) does **not** set this —
+combo approval is opt-in. Run it once per deposit wallet:
+
+```python
+client.activate_combo_dw()              # user-primary DW
+client.activate_combo_dw(agent_id="…")  # per-agent (Elite) DW
+```
+
+This signs the combo-exchange approval batch locally and Simmer's server
+relays it **gaslessly** under our builder credentials (it approves the combo
+exchange to spend the DW's pUSD + combo position tokens). It is idempotent —
+safe to re-run. After it completes, `place_combo(..., dry_run=False)` settles
+normally for the deposit wallet.
+
+Before a live DW placement the SDK runs a quick on-chain pre-check and, if the
+combo approval is missing, raises a clear **"run `client.activate_combo_dw()`
+first"** error instead of letting the order fail at settlement. (Dry-run works
+for all wallet types with no activation.)
 
 ## Notes
 

--- a/skills/polymarket-combo-builder/clawhub.json
+++ b/skills/polymarket-combo-builder/clawhub.json
@@ -3,7 +3,7 @@
   "primaryEnv": "SIMMER_API_KEY",
   "requires": {
     "env": ["SIMMER_API_KEY"],
-    "pip": ["simmer-sdk>=0.20.1", "requests>=2.28", "websockets>=12.0"]
+    "pip": ["simmer-sdk>=0.20.3", "requests>=2.28", "websockets>=12.0"]
   },
   "envVars": [
     {

--- a/skills/polymarket-combo-builder/combo_builder.py
+++ b/skills/polymarket-combo-builder/combo_builder.py
@@ -117,8 +117,17 @@ def run(live: bool):
             direction=direction, dry_run=False,
             on_status=lambda s: print(f"  [{s}]"),
         )
+    except ValueError as e:
+        # Deposit-wallet combos need a one-time approval; the SDK pre-check
+        # raises ValueError pointing at activate_combo_dw(). Surface the CLI
+        # equivalent.
+        if "activate_combo_dw" in str(e):
+            sys.exit(
+                f"\nCombo not placed: {e}\n\n"
+                "  -> Run once for this wallet:  python combo_builder.py --activate-combo\n"
+            )
+        raise
     except ComboPlacementError as e:
-        # Most common: deposit-wallet combos aren't enabled yet (see below).
         sys.exit(f"\nCombo not placed: {e}")
     print("Result:")
     print(json.dumps(result, indent=2))
@@ -126,13 +135,36 @@ def run(live: bool):
         print(f"\nFilled. tx: https://polygonscan.com/tx/{result['tx_hash']}")
 
 
+def activate_combo():
+    """One-time deposit-wallet combo activation (approves the combo exchange).
+
+    EOA / self-custody wallets need no activation — this is only for deposit
+    wallets (signature_type 3). Idempotent and gasless (server-relayed).
+    """
+    from simmer_sdk.client import SimmerClient
+
+    api_key = os.getenv("SIMMER_API_KEY")
+    if not api_key:
+        sys.exit("Set SIMMER_API_KEY (simmer.markets/dashboard -> SDK tab).")
+    client = SimmerClient(api_key=api_key, venue="polymarket", live=True)
+    print("=== Activating deposit-wallet combos (one-time) ===")
+    result = client.activate_combo_dw()
+    print(json.dumps(result, indent=2))
+    print("\nDone. You can now place deposit-wallet combos with --live.")
+
+
 def main():
     ap = argparse.ArgumentParser(description="Place an atomic Polymarket combo (parlay).")
     ap.add_argument("--live", action="store_true", help="Place for real (money path). Default: dry-run.")
     ap.add_argument("--legs", action="store_true", help="Browse combo-eligible legs and exit.")
+    ap.add_argument("--activate-combo", action="store_true",
+                    help="One-time: approve the combo exchange for a deposit wallet, then exit.")
     args = ap.parse_args()
     if args.legs:
         browse_legs()
+        return
+    if args.activate_combo:
+        activate_combo()
         return
     run(live=args.live)
 

--- a/tests/test_activate_combo_dw.py
+++ b/tests/test_activate_combo_dw.py
@@ -167,6 +167,23 @@ def test_place_combo_dw_precheck_skipped_when_allow_flag():
         assert "activate_combo_dw" not in str(ei.value)
 
 
+def test_place_combo_loads_per_agent_dw_state_for_sig3():
+    """Regression (caught in E3 live verify): a per-agent API key carries its DW
+    state on /api/sdk/agents/me, not /api/sdk/settings. place_combo must load it
+    so the combo signs as sig_type 3 (maker=DW), not EOA sig0. Before the fix the
+    dry-run plan resolved sig0 / maker=EOA."""
+    client = _make_client(dw=False, live=True)  # settings says no DW (user-primary view)
+    me_payload = {
+        "per_agent_wallet_address": "0xEOA",
+        "per_agent_deposit_wallet_address": FAKE_DW,
+        "per_agent_dw_active": True,
+    }
+    with patch.object(client, "_request", return_value=me_payload):
+        plan = client.place_combo(leg_position_ids=["111", "222"], size_usdc=1.0, dry_run=True)
+    assert plan["identity"]["signature_type"] == 3
+    assert plan["identity"]["maker_address"] == FAKE_DW
+
+
 def test_combo_dw_approved_decodes_allowance():
     client = _make_client(dw=True)
     # Non-zero allowance → approved

--- a/tests/test_activate_combo_dw.py
+++ b/tests/test_activate_combo_dw.py
@@ -1,0 +1,182 @@
+"""Tests for client.activate_combo_dw() + the place_combo DW approval pre-check
+(E3 — combo deposit-wallet publish).
+
+Pure unit tests — no network, no real signing. Covers:
+  - missing raw private key raises before any network call (OWS not supported)
+  - prepare is POSTed with {combo: true}, and the combo approval batch passes
+    the client-side validator → sign → submit happy path
+  - per-agent routing hits the agent dw-approvals endpoints
+  - place_combo's on-chain pre-check blocks an unapproved DW with a pointer to
+    activate_combo_dw(), and the _combo_dw_approved RPC helper decodes allowance
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from eth_abi import encode as _abi_encode
+
+from simmer_sdk.client import SimmerClient
+from simmer_sdk.polymarket_contracts import (
+    PUSD,
+    COMBO_EXCHANGE,
+    COMBO_POSITION_MANAGER,
+)
+
+API_BASE = "https://api.simmer.example.com/api"
+FAKE_KEY = "sk_live_testkey"
+FAKE_PRIVATE_KEY = "0x" + "ab" * 32
+FAKE_DW = "0x4fBd7fcC42C9b393A95E059042E7c0553B124326"
+_MAX = (1 << 256) - 1
+
+FAKE_TYPED_DATA = {
+    "domain": {"name": "DepositWallet", "version": "1", "chainId": 137},
+    "types": {"DepositWalletBatch": [{"name": "nonce", "type": "uint256"}]},
+    "primaryType": "DepositWalletBatch",
+    "message": {"nonce": "1"},
+}
+
+# The real combo approval batch: pUSD.approve(COMBO_EXCHANGE) +
+# COMBO_POSITION_MANAGER.setApprovalForAll(COMBO_EXCHANGE). Must pass the
+# client-side validator (else the SDK would refuse to sign the honest batch).
+_COMBO_CALLS = [
+    {
+        "target": PUSD,
+        "value": "0",
+        "data": "0x095ea7b3" + _abi_encode(["address", "uint256"], [COMBO_EXCHANGE, _MAX]).hex(),
+    },
+    {
+        "target": COMBO_POSITION_MANAGER,
+        "value": "0",
+        "data": "0xa22cb465" + _abi_encode(["address", "bool"], [COMBO_EXCHANGE, True]).hex(),
+    },
+]
+
+PREPARE_COMBO = {
+    "already_set": False,
+    "calls": _COMBO_CALLS,
+    "typed_data": FAKE_TYPED_DATA,
+    "nonce": "42",
+    "deadline": 9999999999,
+    "deposit_wallet_address": FAKE_DW,
+}
+
+
+def _make_client(private_key=FAKE_PRIVATE_KEY, *, dw=False, live=False):
+    client = SimmerClient.__new__(SimmerClient)
+    client._api_key = FAKE_KEY
+    client._api_base = API_BASE
+    client._private_key = private_key
+    client._ows_wallet = None
+    client._wallet_address = "0xEOA"
+    client._session = MagicMock()
+    client.live = live
+    client._uses_deposit_wallet = dw
+    client._deposit_wallet_address = FAKE_DW if dw else None
+    client._clob_client = None
+    return client
+
+
+# --- activate_combo_dw -----------------------------------------------------
+
+
+def test_requires_raw_private_key():
+    client = _make_client(private_key=None)
+    client._ows_wallet = "some-ows-wallet"  # OWS combo signing not supported
+    with pytest.raises(ValueError, match="raw EOA private key"):
+        client.activate_combo_dw()
+
+
+def test_prepare_sends_combo_flag_and_submits():
+    client = _make_client()
+    fake_sig = MagicMock()
+    fake_sig.signature.hex.return_value = "0xdeadbeef"
+    calls_seen = []
+
+    def fake_request(method, path, **kwargs):
+        calls_seen.append((method, path, kwargs.get("json")))
+        if path.endswith("prepare"):
+            return PREPARE_COMBO
+        return {"success": True, "all_set": True}
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("eth_account.Account.sign_typed_data", return_value=fake_sig):
+            result = client.activate_combo_dw()
+
+    assert result == {"already_set": False, "calls_count": 2, "success": True}
+    # prepare carried {combo: True} on the user-primary endpoint
+    method, path, body = calls_seen[0]
+    assert path == "/api/user/wallet/external/dw-approvals/prepare"
+    assert body == {"combo": True}
+    # then submit
+    assert calls_seen[1][1].endswith("/dw-approvals/submit")
+
+
+def test_per_agent_routing():
+    client = _make_client()
+    fake_sig = MagicMock()
+    fake_sig.signature.hex.return_value = "0xfeed"
+    paths = []
+
+    def fake_request(method, path, **kwargs):
+        paths.append(path)
+        if path.endswith("prepare"):
+            return PREPARE_COMBO
+        return {"success": True}
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("eth_account.Account.sign_typed_data", return_value=fake_sig):
+            client.activate_combo_dw(agent_id="abc-123")
+
+    assert paths[0] == "/api/user/agent/abc-123/wallet/external/dw-approvals/prepare"
+    assert paths[1].endswith("/agent/abc-123/wallet/external/dw-approvals/submit")
+
+
+def test_already_set_short_circuits():
+    client = _make_client()
+    with patch.object(client, "_request", return_value={"already_set": True}) as mock_req:
+        result = client.activate_combo_dw()
+    assert result == {"already_set": True, "calls_count": 0, "success": True}
+    mock_req.assert_called_once()
+
+
+# --- place_combo DW pre-check ---------------------------------------------
+
+
+def test_place_combo_dw_unapproved_blocks_with_activate_hint():
+    client = _make_client(dw=True, live=True)
+    with patch.object(client, "_combo_dw_approved", return_value=False):
+        with pytest.raises(ValueError, match="activate_combo_dw"):
+            client.place_combo(
+                leg_position_ids=["111", "222"], size_usdc=2.0,
+                dry_run=False,
+            )
+
+
+def test_place_combo_dw_precheck_skipped_when_allow_flag():
+    """allow_deposit_wallet=True skips the pre-check entirely (no RPC read)."""
+    client = _make_client(dw=True, live=True)
+    with patch.object(client, "_combo_dw_approved", side_effect=AssertionError("should not be called")):
+        # Will fail later at creds/network, but must NOT raise the pre-check
+        # ValueError nor call _combo_dw_approved.
+        with pytest.raises(Exception) as ei:
+            client.place_combo(
+                leg_position_ids=["111", "222"], size_usdc=2.0,
+                dry_run=False, allow_deposit_wallet=True,
+            )
+        assert "activate_combo_dw" not in str(ei.value)
+
+
+def test_combo_dw_approved_decodes_allowance():
+    client = _make_client(dw=True)
+    # Non-zero allowance → approved
+    with patch.object(client, "_request", return_value={"result": "0x" + "f" * 64}):
+        assert client._combo_dw_approved(FAKE_DW) is True
+    # Zero allowance → not approved
+    with patch.object(client, "_request", return_value={"result": "0x" + "0" * 64}):
+        assert client._combo_dw_approved(FAKE_DW) is False
+    # Empty / RPC hiccup → None (don't block)
+    with patch.object(client, "_request", return_value={"result": "0x"}):
+        assert client._combo_dw_approved(FAKE_DW) is None
+    with patch.object(client, "_request", side_effect=RuntimeError("rpc down")):
+        assert client._combo_dw_approved(FAKE_DW) is None

--- a/tests/test_batch_validation.py
+++ b/tests/test_batch_validation.py
@@ -69,6 +69,29 @@ def test_approval_valid_passes():
     validate_dw_approval_calls([_set_approval(CONDITIONAL_TOKENS, SPENDER)])
 
 
+def test_combo_approval_pairs_pass():
+    """activate_combo_dw()'s batch — pUSD.approve(COMBO_EXCHANGE) +
+    COMBO_POSITION_MANAGER.setApprovalForAll(COMBO_EXCHANGE) — must pass the
+    client-side validator, else the SDK would refuse to sign the (honest)
+    combo approval batch the server returns. Mirror of the server's
+    get_allowed_dw_approval_targets() combo additions."""
+    from simmer_sdk.polymarket_contracts import COMBO_EXCHANGE, COMBO_POSITION_MANAGER
+    validate_dw_approval_calls([
+        _approve(PUSD, COMBO_EXCHANGE),
+        _set_approval(COMBO_POSITION_MANAGER, COMBO_EXCHANGE),
+    ])
+
+
+def test_combo_ctf_to_exchange_rejected():
+    """The ERC1155 combo leg is on COMBO_POSITION_MANAGER, NOT the CTF — combo
+    position tokens live on the Position Manager. CTF→COMBO_EXCHANGE is not a
+    whitelisted pair (approving it is a no-op that would strand a fill), so the
+    validator must refuse it."""
+    from simmer_sdk.polymarket_contracts import COMBO_EXCHANGE
+    with pytest.raises(BatchValidationError, match="not a known approval pair"):
+        validate_dw_approval_calls([_set_approval(CONDITIONAL_TOKENS, COMBO_EXCHANGE)])
+
+
 def test_approval_to_attacker_spender_rejected():
     with pytest.raises(BatchValidationError, match="not a known approval pair"):
         validate_dw_approval_calls([_approve(PUSD, ATTACKER)])

--- a/tests/test_combo_placement.py
+++ b/tests/test_combo_placement.py
@@ -71,15 +71,19 @@ def test_validation_dw_requires_address():
                        leg_position_ids=LEGS, size_usdc=1.0, signature_type=3, dry_run=True)
 
 
-def test_dw_live_is_gated():
-    """A live DW combo (sig3, dry_run=False) is blocked with a clear message
-    until Polymarket whitelists the combo exchange on the DW relayer."""
-    with pytest.raises(cb.ComboPlacementError, match="not available yet"):
+def test_dw_live_explicitly_disabled():
+    """DW combos are SUPPORTED now (proven on-chain). The module default
+    (allow_deposit_wallet=True) allows them; passing allow_deposit_wallet=False
+    explicitly disables a DW combo with a clear message that points at
+    activate_combo_dw(). (The SimmerClient gates on the on-chain approval
+    pre-check; this is the low-level module's opt-out.)"""
+    with pytest.raises(cb.ComboPlacementError, match="activate_combo_dw"):
         cb.place_combo(
             creds={"apiKey": "k", "secret": "s", "passphrase": "p"},
             private_key=TEST_PK, eoa_address=TEST_EOA,
             leg_position_ids=LEGS, size_usdc=1.0, signature_type=3,
             deposit_wallet_address=TEST_DW, dry_run=False,  # live
+            allow_deposit_wallet=False,  # explicit opt-out
         )
 
 


### PR DESCRIPTION
Publish Polymarket **deposit-wallet combos** to all cohorts via the SDK, on top of the proven on-chain path (D1/D2) and the server combo-approval endpoint (simmer #1380, E1/E2).

## What
- `client.activate_combo_dw(agent_id=None)` — mirror of `activate_polymarket_dw`; POSTs `/dw-approvals/prepare` with `{combo:true}` → signs the combo-exchange approval batch locally (raw key) → submits gaslessly. User-primary + per-agent routing. OWS combo signing still unsupported.
- `batch_validation.validate_dw_approval_calls` (the **client-side** security mirror) extended to accept the combo `(pUSD, COMBO_EXCHANGE)` + `(COMBO_POSITION_MANAGER, COMBO_EXCHANGE)` pairs — without this the SDK would refuse to sign the honest combo batch the server returns. `CTF→COMBO_EXCHANGE` stays rejected (combo position tokens live on the Position Manager, not the CTF).
- `polymarket_contracts`: add `COMBO_EXCHANGE`, `COMBO_POSITION_MANAGER`, `combo_spenders()` (mirror server).
- `place_combo`: DW combos now allowed (gate flipped, `combo.py` default `allow_deposit_wallet=True`); best-effort on-chain pUSD-allowance pre-check raises "run activate_combo_dw() first" instead of a settlement failure.
- `place_combo` now calls `_load_per_agent_dw_state()` so per-agent keys resolve sig_type 3 / maker=DW (the trade path already did; combo path didn't → would sign EOA sig0).
- skill `polymarket-combo-builder`: drop the EOA-only / DW-blocked caveat, document `activate_combo_dw` + a `--activate-combo` CLI; keep the OWS caveat. skill 0.1.1, clawhub pin `simmer-sdk>=0.20.3`.

## Verification
Live-verified end-to-end via the **published path** against the throwaway per-agent fixture (agent `6c7ecbd8` / DW `0x4fBd`): `activate_combo_dw()` then `place_combo(dry_run=False)` → **MINED** `0x34f7241e669b141a0a25e696cdb8a8898c1cfeb5ddeac2fc7ae292ab38bb9752` (rfq `rfq-37ca601f3b498df866dfc12c`). 48 offline tests pass.

## Ship order (E4)
Merge **simmer #1380 (server E1/E2) first** → prod, then this, then bump 0.20.2→**0.20.3** + republish PyPI + ClawHub. Money-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)