### PR TITLE
feat(ci): add publish lag gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,22 @@ on:
   pull_request:
 
 jobs:
+  publish-lag:
+    name: Publish Lag Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check repo versions are published
+        run: python3 scripts/check_publish_lag.py
+
   skill-governance:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/check_publish_lag.py
+++ b/scripts/check_publish_lag.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Fail if repo package versions are ahead of the public registries.
+
+Local use:
+  python3 scripts/check_publish_lag.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NPM_PACKAGE = "simmer-mcp"
+PYPI_PACKAGE = "simmer-sdk"
+
+
+class PublishLagError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Semver:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str | int, ...]
+
+
+SEMVER_RE = re.compile(
+    r"^v?(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?$"
+)
+
+
+def parse_semver(version: str) -> Semver:
+    match = SEMVER_RE.match(version.strip())
+    if not match:
+        raise PublishLagError(f"Unsupported version format: {version!r}")
+
+    prerelease: list[str | int] = []
+    raw_prerelease = match.group("prerelease")
+    if raw_prerelease:
+        for part in raw_prerelease.split("."):
+            prerelease.append(int(part) if part.isdigit() else part)
+
+    return Semver(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=tuple(prerelease),
+    )
+
+
+def compare_versions(left: str, right: str) -> int:
+    left_version = parse_semver(left)
+    right_version = parse_semver(right)
+
+    left_core = (left_version.major, left_version.minor, left_version.patch)
+    right_core = (right_version.major, right_version.minor, right_version.patch)
+    if left_core != right_core:
+        return 1 if left_core > right_core else -1
+
+    if left_version.prerelease == right_version.prerelease:
+        return 0
+    if not left_version.prerelease:
+        return 1
+    if not right_version.prerelease:
+        return -1
+
+    for left_part, right_part in zip(left_version.prerelease, right_version.prerelease):
+        if left_part == right_part:
+            continue
+        if isinstance(left_part, int) and isinstance(right_part, int):
+            return 1 if left_part > right_part else -1
+        if isinstance(left_part, int):
+            return -1
+        if isinstance(right_part, int):
+            return 1
+        return 1 if left_part > right_part else -1
+
+    if len(left_version.prerelease) == len(right_version.prerelease):
+        return 0
+    return 1 if len(left_version.prerelease) > len(right_version.prerelease) else -1
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_npm_repo_version(root: Path) -> str:
+    package_json = read_json(root / "mcp" / "package.json")
+    return str(package_json["version"])
+
+
+def read_pypi_repo_version(root: Path) -> str:
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    in_project = False
+    for line in pyproject.splitlines():
+        stripped = line.strip()
+        if stripped == "[project]":
+            in_project = True
+            continue
+        if in_project and stripped.startswith("["):
+            break
+        if in_project and stripped.startswith("version"):
+            _, value = stripped.split("=", 1)
+            return value.strip().strip('"').strip("'")
+    raise PublishLagError("Could not find [project].version in pyproject.toml")
+
+
+def fetch_json(url: str) -> dict:
+    request = urllib.request.Request(url, headers={"User-Agent": "simmer-publish-lag-check"})
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def fetch_npm_latest(package_name: str) -> str:
+    payload = fetch_json(f"https://registry.npmjs.org/{package_name}")
+    return str(payload["dist-tags"]["latest"])
+
+
+def fetch_pypi_latest(package_name: str) -> str:
+    payload = fetch_json(f"https://pypi.org/pypi/{package_name}/json")
+    return str(payload["info"]["version"])
+
+
+def check_package(label: str, repo_version: str, published_version: str) -> bool:
+    comparison = compare_versions(repo_version, published_version)
+    if comparison > 0:
+        print(
+            f"::error::{label} repo version {repo_version} is ahead of "
+            f"published version {published_version}. Publish the package before merging."
+        )
+        return False
+    if comparison < 0:
+        print(
+            f"{label}: repo version {repo_version} is behind published version "
+            f"{published_version}; treating as already published/newer registry state."
+        )
+        return True
+
+    print(f"{label}: repo version {repo_version} matches published version {published_version}.")
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--npm-published-version", help="Override npm latest version for tests.")
+    parser.add_argument("--pypi-published-version", help="Override PyPI latest version for tests.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+
+    npm_repo_version = read_npm_repo_version(root)
+    pypi_repo_version = read_pypi_repo_version(root)
+    npm_published_version = args.npm_published_version or fetch_npm_latest(NPM_PACKAGE)
+    pypi_published_version = args.pypi_published_version or fetch_pypi_latest(PYPI_PACKAGE)
+
+    ok = True
+    ok &= check_package(NPM_PACKAGE, npm_repo_version, npm_published_version)
+    ok &= check_package(PYPI_PACKAGE, pypi_repo_version, pypi_published_version)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PublishLagError as exc:
+        print(f"::error::{exc}")
+        raise SystemExit(1)

--- a/tests/test_check_publish_lag.py
+++ b/tests/test_check_publish_lag.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+from scripts import check_publish_lag
+
+
+def write_package_files(root: Path, npm_version: str, pypi_version: str) -> None:
+    (root / "mcp").mkdir()
+    (root / "mcp" / "package.json").write_text(
+        f'{{"name": "simmer-mcp", "version": "{npm_version}"}}',
+        encoding="utf-8",
+    )
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "simmer-sdk"\nversion = "{pypi_version}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_compare_versions_is_semver_numeric() -> None:
+    assert check_publish_lag.compare_versions("3.4.10", "3.4.9") > 0
+    assert check_publish_lag.compare_versions("3.4.9", "3.4.10") < 0
+    assert check_publish_lag.compare_versions("3.4.10", "3.4.10") == 0
+
+
+def test_compare_versions_handles_prereleases() -> None:
+    assert check_publish_lag.compare_versions("1.0.0", "1.0.0-rc.1") > 0
+    assert check_publish_lag.compare_versions("1.0.0-beta.2", "1.0.0-beta.10") < 0
+
+
+@pytest.mark.parametrize(
+    ("repo_version", "published_version", "expected"),
+    [
+        ("3.4.4", "3.4.4", True),
+        ("3.4.4", "3.4.5", True),
+        ("3.4.10", "3.4.9", False),
+    ],
+)
+def test_check_package_outcomes(repo_version: str, published_version: str, expected: bool) -> None:
+    assert check_publish_lag.check_package("simmer-mcp", repo_version, published_version) is expected
+
+
+def test_main_fails_when_either_registry_lags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.0")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "root": tmp_path,
+                "npm_published_version": "3.4.9",
+                "pypi_published_version": "0.20.0",
+            },
+        )(),
+    )
+
+    assert check_publish_lag.main() == 1
+
+
+def test_main_passes_when_repo_matches_or_is_behind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_package_files(tmp_path, npm_version="3.4.4", pypi_version="0.20.0")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "root": tmp_path,
+                "npm_published_version": "3.4.4",
+                "pypi_published_version": "0.20.1",
+            },
+        )(),
+    )
+
+    assert check_publish_lag.main() == 0

--- a/tests/test_check_publish_lag.py
+++ b/tests/test_check_publish_lag.py
@@ -1,8 +1,19 @@
+import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
 
-from scripts import check_publish_lag
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_publish_lag", ROOT / "scripts" / "check_publish_lag.py"
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+check_publish_lag = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = check_publish_lag
+SPEC.loader.exec_module(check_publish_lag)
 
 
 def write_package_files(root: Path, npm_version: str, pypi_version: str) -> None:


### PR DESCRIPTION
## Summary
- add a blocking CI job that compares `mcp/package.json` against npm `simmer-mcp`
- compare root `pyproject.toml` against PyPI `simmer-sdk`
- add focused tests for semver ordering and pass/fail outcomes

## Verification
- `python3 -m pytest tests/test_check_publish_lag.py -q`
- `python3 scripts/check_publish_lag.py`
- `python3 scripts/check_publish_lag.py --npm-published-version 3.4.3 --pypi-published-version 0.20.2` exits 1 and emits GitHub error annotations

Closes SIM-3389
