### PR TITLE
fix(weather-trader): cap missing-secondary (international) positions to canary size (SIM-3412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **`polymarket-weather-trader`: international markets now capped at canary size.** Positions on international stations (Tokyo, Madrid, Ankara, etc.) use Open-Meteo as the sole source with no secondary cross-check. Previously these `missing_secondary` positions were sized at the full position size, producing outsized losses from unverified single-source forecasts. They now cap at `MAX_CANARY_USD` (default $2.00), matching the same protective ceiling used for adjacent-bucket disagreements. Set `SIMMER_WEATHER_REQUIRE_SOURCE_AGREEMENT=true` to skip them entirely.
+
 ## [0.20.3] - 2026-06-18
 
 ### Added

--- a/mcp/bundled-skills/polymarket-weather-trader/tests/test_source_agreement.py
+++ b/mcp/bundled-skills/polymarket-weather-trader/tests/test_source_agreement.py
@@ -178,10 +178,16 @@ class TestApplySourceTier(unittest.TestCase):
         self.assertIsNone(size)
         self.assertIn("spread", reason.lower())
 
-    def test_missing_secondary_default_allows(self):
+    def test_missing_secondary_caps_to_canary(self):
+        # SIM-3412: missing secondary → canary cap, not full size.
         size, reason = wt.apply_source_tier_to_sizing("missing_secondary", 5.0)
-        self.assertEqual(size, 5.0)
-        self.assertIn("single-source", reason.lower())
+        self.assertEqual(size, 2.0)
+        self.assertIn("canary", reason.lower())
+
+    def test_missing_secondary_under_canary_not_capped_up(self):
+        # Canary cap is a ceiling, not a floor.
+        size, _ = wt.apply_source_tier_to_sizing("missing_secondary", 1.0)
+        self.assertEqual(size, 1.0)
 
     def test_missing_secondary_with_require_agreement_skips(self):
         wt.REQUIRE_SOURCE_AGREEMENT = True

--- a/mcp/bundled-skills/polymarket-weather-trader/weather_trader.py
+++ b/mcp/bundled-skills/polymarket-weather-trader/weather_trader.py
@@ -723,8 +723,8 @@ def parse_temperature_bucket(outcome_name: str) -> tuple:
 #                  (or skip if REQUIRE_SOURCE_AGREEMENT=true).
 #   - wide       → temp spread > MAX_SOURCE_SPREAD_F, or buckets non-adjacent.
 #                  Always skip.
-#   - missing_secondary → no secondary available (intl today). Behave per
-#                  REQUIRE_SOURCE_AGREEMENT flag.
+#   - missing_secondary → no secondary available (intl today). Cap to
+#                  MAX_CANARY_USD (or skip if REQUIRE_SOURCE_AGREEMENT=true).
 
 def _bucket_for_temp(temp, all_markets):
     """Find the market whose bucket contains the given temperature."""

--- a/mcp/bundled-skills/polymarket-weather-trader/weather_trader.py
+++ b/mcp/bundled-skills/polymarket-weather-trader/weather_trader.py
@@ -803,7 +803,8 @@ def apply_source_tier_to_sizing(tier, base_size):
     if tier == 'missing_secondary':
         if REQUIRE_SOURCE_AGREEMENT:
             return (None, "no secondary source; REQUIRE_SOURCE_AGREEMENT=true")
-        return (base_size, "no secondary source — single-source mode")
+        capped = min(base_size, MAX_CANARY_USD)
+        return (capped, f"no secondary source — canary cap ${MAX_CANARY_USD:.2f}")
     if tier == 'wide':
         return (None, f"source spread > {MAX_SOURCE_SPREAD_F}°F equivalent — skip")
     if tier == 'adjacent':

--- a/skills/polymarket-weather-trader/tests/test_source_agreement.py
+++ b/skills/polymarket-weather-trader/tests/test_source_agreement.py
@@ -178,10 +178,16 @@ class TestApplySourceTier(unittest.TestCase):
         self.assertIsNone(size)
         self.assertIn("spread", reason.lower())
 
-    def test_missing_secondary_default_allows(self):
+    def test_missing_secondary_caps_to_canary(self):
+        # SIM-3412: missing secondary → canary cap, not full size.
         size, reason = wt.apply_source_tier_to_sizing("missing_secondary", 5.0)
-        self.assertEqual(size, 5.0)
-        self.assertIn("single-source", reason.lower())
+        self.assertEqual(size, 2.0)
+        self.assertIn("canary", reason.lower())
+
+    def test_missing_secondary_under_canary_not_capped_up(self):
+        # Canary cap is a ceiling, not a floor.
+        size, _ = wt.apply_source_tier_to_sizing("missing_secondary", 1.0)
+        self.assertEqual(size, 1.0)
 
     def test_missing_secondary_with_require_agreement_skips(self):
         wt.REQUIRE_SOURCE_AGREEMENT = True

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -723,8 +723,8 @@ def parse_temperature_bucket(outcome_name: str) -> tuple:
 #                  (or skip if REQUIRE_SOURCE_AGREEMENT=true).
 #   - wide       → temp spread > MAX_SOURCE_SPREAD_F, or buckets non-adjacent.
 #                  Always skip.
-#   - missing_secondary → no secondary available (intl today). Behave per
-#                  REQUIRE_SOURCE_AGREEMENT flag.
+#   - missing_secondary → no secondary available (intl today). Cap to
+#                  MAX_CANARY_USD (or skip if REQUIRE_SOURCE_AGREEMENT=true).
 
 def _bucket_for_temp(temp, all_markets):
     """Find the market whose bucket contains the given temperature."""
@@ -803,7 +803,8 @@ def apply_source_tier_to_sizing(tier, base_size):
     if tier == 'missing_secondary':
         if REQUIRE_SOURCE_AGREEMENT:
             return (None, "no secondary source; REQUIRE_SOURCE_AGREEMENT=true")
-        return (base_size, "no secondary source — single-source mode")
+        capped = min(base_size, MAX_CANARY_USD)
+        return (capped, f"no secondary source — canary cap ${MAX_CANARY_USD:.2f}")
     if tier == 'wide':
         return (None, f"source spread > {MAX_SOURCE_SPREAD_F}°F equivalent — skip")
     if tier == 'adjacent':


### PR DESCRIPTION
International markets (Tokyo, Madrid, Ankara, Amsterdam, Taipei, etc.) use Open-Meteo as sole source with no secondary cross-check. Previously `missing_secondary` positions were sized at full position size, producing the -$592 international loss surfaced in SIM-3410.

## Changes
- `skills/polymarket-weather-trader/weather_trader.py`: `apply_source_tier_to_sizing('missing_secondary', ...)` now caps to `MAX_CANARY_USD` (default $2.00) instead of passing full size
- `mcp/bundled-skills/polymarket-weather-trader/weather_trader.py`: same fix in bundled copy
- `skills/polymarket-weather-trader/tests/test_source_agreement.py`: updated `test_missing_secondary_default_allows` → `test_missing_secondary_caps_to_canary` + added under-canary ceiling test
- `CHANGELOG.md`: entry under [Unreleased]

## Tests
```
15 passed in 0.09s
```
All existing + new tests pass. `apply_source_tier_to_sizing('missing_secondary', 5.0)` returns `(2.0, "no secondary source — canary cap $2.00")` with `MAX_CANARY_USD=2.0`.

Closes SIM-3412
Refs SIM-3410