### PR TITLE
chore(weather-trader): bump skill to 1.23.2

### DIFF
--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.1"
+  version: "1.23.2"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).


### PR DESCRIPTION
Version sync for the SIM-3412 canary-cap fix (#246). Published to ClawHub as polymarket-weather-trader@1.23.2; this bumps the repo SKILL.md to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)