### PR TITLE
feat(ci): skill-example-bind gate + fix 2 README trade() examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,29 @@ jobs:
       - name: Build + test MCP package
         working-directory: mcp
         run: npm test
+
+  skill-example-bind:
+    # Bind every documented SDK example (SKILL.md + README) against the shipped
+    # source. Catches the class of bug where an example uses a kwarg/method the
+    # package rejects — a copy-paste TypeError for builders. Never executes
+    # example code (AST + inspect.signature().bind_partial). See
+    # scripts/check_skill_examples.py. Sibling of simmer-docs' SDK Example Bind.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install SDK (editable) + pytest
+        run: pip install -e . pytest
+
+      - name: Self-test the example-bind checker
+        run: pytest scripts/test_check_skill_examples.py -q
+
+      - name: Bind documented SDK examples against the shipped source
+        run: python scripts/check_skill_examples.py skills/ README.md

--- a/README.md
+++ b/README.md
@@ -30,15 +30,17 @@ SKILL_SLUG = "my-skill-slug"   # Must match your ClawHub slug
 TRADE_SOURCE = f"sdk:{SKILL_SLUG}"
 
 _client = None
-def get_client():
+def get_client(live: bool = False):
     global _client
     if _client is None:
         venue = os.environ.get("TRADING_VENUE", "sim")
-        _client = SimmerClient(api_key=os.environ["SIMMER_API_KEY"], venue=venue)
+        # `live` controls paper vs real execution and is a constructor arg, not a
+        # per-trade flag. live=False => paper preview (no real order placed).
+        _client = SimmerClient(api_key=os.environ["SIMMER_API_KEY"], venue=venue, live=live)
     return _client
 
 def run(live: bool = False):
-    client = get_client()
+    client = get_client(live)
 
     # Find markets. Unfiltered browse is windowed to the newest ~1,000 active
     # markets — filter with sort="volume", q="...", or tags="..." to reach the rest.
@@ -53,12 +55,11 @@ def run(live: bool = False):
             market_id=markets[0].id,
             side="yes",
             amount=10.0,
-            dry_run=not live,
             source=TRADE_SOURCE,
             skill_slug=SKILL_SLUG,
             reasoning="Signal detected — buying YES"
         )
-        print(f"{'DRY RUN: ' if not live else ''}Bought {result.shares_bought:.2f} shares")
+        print(f"{'PAPER: ' if not live else ''}Bought {result.shares_bought:.2f} shares")
 
 if __name__ == "__main__":
     import sys
@@ -246,7 +247,7 @@ amount = size_position(
     min_ev=0.03,        # skip trades with edge < 3%
 )
 if amount > 0:
-    client.trade(market_id=..., side="BUY", outcome="YES",
+    client.trade(market_id=..., side="yes",
                  amount=amount, reasoning="Kelly: 70% vs 55%, +15% edge")
 ```
 

--- a/scripts/check_skill_examples.py
+++ b/scripts/check_skill_examples.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Bind documented SDK examples in SKILL.md / README against the shipped SDK source.
+
+Why this exists
+---------------
+Skill docs and the README ship *with* the SDK, so their ``client.<method>(...)``
+examples must match the package in the same commit. When a signature changes and
+an example doesn't, a builder who copies the example gets a TypeError. Doc-vs-doc
+linting can't catch this; only the real signature can. This gate (run after
+``pip install -e .``) binds every documented SDK call against the installed
+source — if a kwarg/method the shipped code rejects appears in an example, the
+build fails.
+
+It's the SDK-repo sibling of the simmer-docs ``SDK Example Bind`` gate. The
+difference: docs pin an external floor version (``.sdk-doc-floor``); here the
+relevant target is the source being shipped, so it binds against whatever
+``pip install -e .`` put on the path.
+
+Safety
+------
+NEVER executes example code. Parses each python block with ``ast`` and uses
+``inspect.signature(...).bind_partial(...)`` with placeholder values — no API
+key, no network, no possibility of a trade.
+
+Conventions
+-----------
+- Scans ```python / ```py fenced blocks in ``*.md`` / ``*.mdx`` (indented fences
+  inside MDX components are handled).
+- Tracks ``var = SimmerClient(...)`` / ``.from_env()`` / ``.with_ows_wallet()``
+  assignments per file, and seeds the doc convention ``client`` -> SimmerClient,
+  ``gamma`` -> GammaClient — but only for files that actually establish a
+  SimmerClient, and never inside a block that imports a foreign client lib
+  (py_clob_client). Anything uncertain is skipped (bias to no-false-positives).
+
+Escape hatches
+--------------
+``<!-- bind:skip -->`` before a fence excludes an illustrative/pseudo-code block.
+``<!-- bind:floor=X.Y.Z -->`` is accepted for parity but rarely needed here.
+
+Usage
+-----
+    python scripts/check_skill_examples.py skills/simmer/SKILL.md README.md
+    python scripts/check_skill_examples.py            # scan whole repo
+
+Exit code 1 if any example fails to bind.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import inspect
+import re
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+CLIENT_CLASS_NAMES = {"SimmerClient", "GammaClient"}
+DEFAULT_VAR_CLASS = {"client": "SimmerClient", "c": "SimmerClient", "gamma": "GammaClient"}
+
+FENCE_RE = re.compile(r"^(\s*)```\s*(\w+)")
+SKIP_RE = re.compile(r"bind:skip")
+FLOOR_RE = re.compile(r"bind:floor=([0-9][0-9A-Za-z.\-]*)")
+FOREIGN_CLIENT_RE = re.compile(r"\bpy_clob_client\w*\b")
+
+_PLACEHOLDER = object()
+
+
+@dataclass
+class Block:
+    path: Path
+    start_line: int
+    code: str
+    floor_override: str | None
+
+
+@dataclass
+class Violation:
+    path: Path
+    line: int
+    call: str
+    reason: str
+    floor: str
+
+
+def extract_blocks(path: Path) -> list[Block]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    blocks: list[Block] = []
+    i, n = 0, len(lines)
+    while i < n:
+        m = FENCE_RE.match(lines[i])
+        if not m or m.group(2).lower() not in ("python", "py"):
+            i += 1
+            continue
+        fence_line = i + 1
+        skip = False
+        floor_override = None
+        j = i - 1
+        while j >= 0 and not lines[j].strip():
+            j -= 1
+        if j >= 0:
+            if SKIP_RE.search(lines[j]):
+                skip = True
+            fm = FLOOR_RE.search(lines[j])
+            if fm:
+                floor_override = fm.group(1)
+        body: list[str] = []
+        i += 1
+        while i < n and not lines[i].strip().startswith("```"):
+            body.append(lines[i])
+            i += 1
+        i += 1
+        if skip:
+            continue
+        blocks.append(
+            Block(path=path, start_line=fence_line, code=textwrap.dedent("\n".join(body)), floor_override=floor_override)
+        )
+    return blocks
+
+
+def _rhs_class(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Name) and func.id in CLIENT_CLASS_NAMES:
+        return func.id
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id in CLIENT_CLASS_NAMES:
+        return func.value.id
+    return None
+
+
+def _call_str(var: str, method: str, node: ast.Call) -> str:
+    parts = [ast.unparse(a) for a in node.args]
+    parts += [f"{kw.arg}=..." if kw.arg else "**..." for kw in node.keywords]
+    return f"{var}.{method}({', '.join(parts)})"
+
+
+def bind_check(cls: type, method: str, node: ast.Call) -> str | None:
+    raw = inspect.getattr_static(cls, method, None)
+    if raw is None:
+        return f"{cls.__name__} has no attribute '{method}'"
+    if isinstance(raw, staticmethod):
+        func, self_offset = raw.__func__, 0
+    elif isinstance(raw, classmethod):
+        func, self_offset = getattr(cls, method), 0
+    elif inspect.isfunction(raw):
+        func, self_offset = raw, 1
+    else:
+        return None
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError):
+        return None
+    if any(isinstance(a, ast.Starred) for a in node.args):
+        return None
+    if any(kw.arg is None for kw in node.keywords):
+        return None
+    pos = [_PLACEHOLDER] * (len(node.args) + self_offset)
+    kwargs = {kw.arg: _PLACEHOLDER for kw in node.keywords}
+    try:
+        sig.bind_partial(*pos, **kwargs)
+    except TypeError as e:
+        return str(e)
+    return None
+
+
+def check_block(block: Block, classes: dict[str, type], default_floor: str, seed_defaults: bool) -> list[Violation]:
+    floor = block.floor_override or default_floor
+    try:
+        tree = ast.parse(block.code)
+    except SyntaxError:
+        return []
+    var_class: dict[str, str] = {}
+    if seed_defaults and not FOREIGN_CLIENT_RE.search(block.code):
+        var_class.update(DEFAULT_VAR_CLASS)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            cls_name = _rhs_class(node.value)
+            if cls_name:
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        var_class[tgt.id] = cls_name
+    violations: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name)):
+            continue
+        cls_name = var_class.get(func.value.id)
+        if not cls_name:
+            continue
+        cls = classes.get(cls_name)
+        if cls is None:
+            continue
+        reason = bind_check(cls, func.attr, node)
+        if reason:
+            violations.append(
+                Violation(path=block.path, line=block.start_line + node.lineno, call=_call_str(func.value.id, func.attr, node), reason=reason, floor=floor)
+            )
+    return violations
+
+
+def load_classes() -> dict[str, type]:
+    classes: dict[str, type] = {}
+    try:
+        from simmer_sdk import SimmerClient  # type: ignore
+
+        classes["SimmerClient"] = SimmerClient
+    except Exception as e:  # pragma: no cover
+        print(f"FATAL: could not import SimmerClient from simmer_sdk: {e}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        from simmer_sdk import GammaClient  # type: ignore
+
+        classes["GammaClient"] = GammaClient
+    except Exception:
+        pass
+    return classes
+
+
+def installed_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("simmer-sdk")
+    except Exception:
+        return "unknown"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="files or dirs to scan (default: repo root)")
+    parser.add_argument("--floor", help="bind against this version label (default: installed source version)")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    installed = installed_version()
+    # The SDK repo binds against the source being shipped, so the floor IS the
+    # installed (editable) version unless a .sdk-doc-floor pins one explicitly.
+    floor_file = repo_root / ".sdk-doc-floor"
+    if args.floor:
+        floor = args.floor
+    elif floor_file.exists():
+        floor = floor_file.read_text().strip()
+    else:
+        floor = installed
+
+    print(f"checking SDK skill examples — binding against simmer-sdk {floor} (installed {installed})")
+
+    targets = [Path(p) for p in args.paths] if args.paths else [repo_root]
+    files: list[Path] = []
+    for t in targets:
+        if t.is_dir():
+            files.extend(sorted(set(t.rglob("*.md")) | set(t.rglob("*.mdx"))))
+        elif t.suffix in (".md", ".mdx"):
+            files.append(t)
+
+    classes = load_classes()
+    all_violations: list[Violation] = []
+    n_blocks = 0
+    establishes_re = re.compile(r"\bsimmer_sdk\b|SimmerClient\s*[(.]")
+    for f in files:
+        seed_defaults = bool(establishes_re.search(f.read_text(encoding="utf-8")))
+        for block in extract_blocks(f):
+            n_blocks += 1
+            all_violations.extend(check_block(block, classes, floor, seed_defaults))
+
+    print(f"scanned {len(files)} files, {n_blocks} python blocks")
+    if not all_violations:
+        print("OK — all documented SDK calls bind against the shipped signature.")
+        return 0
+
+    print(f"\nFAIL — {len(all_violations)} example call(s) do not bind against simmer-sdk {floor}:\n")
+    for v in all_violations:
+        rel = v.path.relative_to(repo_root) if v.path.is_absolute() else v.path
+        print(f"  {rel}:{v.line}")
+        print(f"    {v.call}")
+        print(f"    -> {v.reason}")
+    print(
+        "\nFix: correct the example, add `<!-- bind:skip -->` if it is intentionally\n"
+        "illustrative, or update the SDK if the example documents intended behavior."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_skill_examples.py
+++ b/scripts/test_check_skill_examples.py
@@ -1,0 +1,64 @@
+"""Self-test for the SDK skill-example bind checker.
+
+Runs against the editable-installed simmer-sdk so it both exercises the checker's
+logic and confirms the checker stays correct as the SDK evolves.
+"""
+from pathlib import Path
+
+import pytest
+
+import check_skill_examples as chk  # scripts/ is on sys.path when pytest runs this file
+
+SimmerClient = pytest.importorskip("simmer_sdk").SimmerClient
+CLASSES = {"SimmerClient": SimmerClient}
+
+
+def _violations(code: str, *, seed_defaults: bool = True):
+    block = chk.Block(path=Path("test.md"), start_line=1, code=code, floor_override=None)
+    return chk.check_block(block, CLASSES, "local", seed_defaults)
+
+
+def test_good_trade_binds():
+    assert _violations('client.trade(market_id="x", side="yes", amount=1.0)') == []
+
+
+def test_unexpected_kwarg_is_flagged():
+    v = _violations('client.trade(market_id="x", side="yes", outcome="YES", amount=1.0)')
+    assert len(v) == 1
+    assert "outcome" in v[0].reason
+
+
+def test_dry_run_kwarg_is_flagged():
+    v = _violations('client.trade(market_id="x", side="yes", amount=1.0, dry_run=True)')
+    assert len(v) == 1
+    assert "dry_run" in v[0].reason
+
+
+def test_missing_method_is_flagged():
+    v = _violations("client.no_such_method()")
+    assert len(v) == 1
+    assert "no attribute" in v[0].reason
+
+
+def test_foreign_client_block_is_suppressed():
+    code = "from py_clob_client_v2.clob_types import OrderArgs\nclient.create_order(args)"
+    assert _violations(code, seed_defaults=True) == []
+
+
+def test_non_simmer_file_is_not_seeded():
+    assert _violations("client.create_order(args)", seed_defaults=False) == []
+
+
+def test_explicit_assignment_always_maps():
+    code = 'c = SimmerClient(api_key="x")\nc.trade(market_id="m", side="yes", bogus=1)'
+    v = _violations(code, seed_defaults=False)
+    assert len(v) == 1
+    assert "bogus" in v[0].reason
+
+
+def test_kwargs_splat_is_not_flagged():
+    assert _violations("client.trade(**params)") == []
+
+
+def test_syntax_fragment_is_skipped():
+    assert _violations("client.trade(market_id=") == []


### PR DESCRIPTION
## What

Adds **skill-example-bind** to CI — binds every documented `client.<method>(...)` call in `skills/*/SKILL.md` + `README.md` against the shipped SDK source. Plus the **2 live README bugs it caught on first run**.

This is the SDK-repo sibling of the simmer-docs `SDK Example Bind` gate (simmer-docs#84). The difference: docs pin an external floor version; here the canonical SKILL.md ships *with* the SDK, so examples must bind against the source in the same commit (`pip install -e .`).

## Why

Same failure mode as the docs report: an example uses a kwarg/method the shipped package rejects → a builder copies it → `TypeError`. The existing SDK CI (`pip install -e .` + import smoke + pytest) tests the source but never extracts/binds the doc examples.

## How (money-safe)

Never executes example code. AST-extracts calls and runs `inspect.signature().bind_partial()` with placeholders against the installed source — no key, no network, no trade. Conventions tuned to zero false-positives: file-level SimmerClient seeding, foreign-client (`py_clob_client`) suppression, splat/fragment skipping. Escape hatch: `<!-- bind:skip -->`.

## The 2 bugs it caught (fixed here)

- **`README.md:52`** — `client.trade(..., dry_run=not live, ...)`. `dry_run` is not a `trade()` kwarg; `live` is a **constructor** arg. Rewired to `SimmerClient(..., live=live)` (paper mode) and dropped `dry_run` from the call. Verified `live`/`venue` are valid `__init__` params.
- **`README.md:249`** — `client.trade(side="BUY", outcome="YES", ...)`. No `outcome` param; `side` takes `"yes"`/`"no"`. Fixed to `side="yes"`.

## Coverage / verification

- Gate over `skills/ + README`: **OK** — 59 files, 62 blocks bind clean (after fixes).
- Canonical `skills/simmer/SKILL.md` and all 26 skills already bound clean (so `website/public/skill.md`, generated from the canonical, is fine).
- `mcp/bundled-skills/` also scanned clean and is covered transitively by the existing `check:bundle-skills` freshness gate, so the new job scopes to `skills/ + README` to avoid double-scanning generated artifacts.
- Self-test (`scripts/test_check_skill_examples.py`): **9/9**, runs against the installed SDK so the checker stays correct as signatures evolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHUEcNhY3MzBMyDtoftrmi