### PR TITLE
fix(mcp): resync bundled weather-trader skill (1.23.1 → 1.23.2)

### DIFF
--- a/mcp/bundled-skills/polymarket-weather-trader/SKILL.md
+++ b/mcp/bundled-skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.1"
+  version: "1.23.2"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).


### PR DESCRIPTION
## What

Regenerates `mcp/bundled-skills/polymarket-weather-trader/SKILL.md` to match the canonical `skills/` source. One-line change: version `1.23.1` → `1.23.2`.

## Why — fixes the long-standing red `mcp-build` on main

The `Check MCP bundled skills are fresh` step (`bundle-skills.ts --check`, added in #229) has been **failing on every main run** since #247 bumped the weather-trader skill to 1.23.2 without running `npm run bundle-skills`. The bundle stayed at 1.23.1.

Diagnosis:
- **Impact was low** — the drift is *only* the version label; content is byte-identical. The published `simmer-mcp@3.4.4` shipped weather-trader labeled 1.23.1 vs canonical 1.23.2. Not broken, just mislabeled.
- **The real cost was a permanently red main** masking real failures — and the fact that PRs merged straight through it means **the freshness gate is not a required check**.

## Fix

`npm run bundle-skills` → regenerated the bundle (only weather-trader changed). `npm run check:bundle-skills` now passes (`bundle fresh: 25 skills, skipped 2`). Main goes green.

## Process follow-up (not in this PR)

Same "generated copy drifted because the regen step was skipped" class we've been clearing in docs. Two options to stop recurrence:
1. **Make `check:bundle-skills` a required status check** so a skill bump can't merge without regenerating, **or**
2. **Auto-regenerate in CI** (commit the bundle from the skill source) so humans never have to remember `npm run bundle-skills`.

Recommend (2) — removes the manual step entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHUEcNhY3MzBMyDtoftrmi