### PR TITLE
docs(get_trades): document market_source field on trade rows

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3230,14 +3230,22 @@ class SimmerClient:
 
         Returns:
             Dict containing:
-            - trades: List of trade rows, each tagged with `venue`
+            - trades: List of trade rows. Each row carries:
+                - `venue`: where the trade executed — 'sim', 'polymarket',
+                  or 'kalshi'. Sim trades are always 'sim'.
+                - `market_source`: which underlying venue the market mirrors —
+                  'polymarket', 'kalshi', or None (native Simmer market). For
+                  sim trades this is the field that tells you the origin venue
+                  (since `venue` is always 'sim'); for real trades it mirrors
+                  `venue`.
             - total_count: Total matching trades across all filtered venues
 
         Example:
             # Cross-venue (default):
             history = client.get_trades(limit=20)
             for t in history['trades']:
-                print(f"{t['venue']}: {t['side']} {t['shares']}")
+                # market_source distinguishes the origin venue of sim trades
+                print(f"{t['venue']} ({t['market_source']}): {t['side']} {t['shares']}")
 
             # Single venue:
             poly_trades = client.get_trades(venue="polymarket")


### PR DESCRIPTION
Docs-only. The backend `GET /api/sdk/trades` now returns **`market_source`** on every trade row (`'polymarket'` | `'kalshi'` | `null` for native Simmer markets), sourced from `markets.import_source` — shipped in simmer#1536.

`get_trades()` is a pass-through, so the field already reaches existing SDK installs once the backend deploys. This PR just documents it in the method docstring + example so the return shape is honest:

- Sim trades: `market_source` is the origin-venue signal (since `venue` is always `'sim'`).
- Real trades: `market_source` mirrors `venue`.

No code/behavior change, no version bump required for the field to work; fold into the next routine publish whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQZ3yTKskcV9Lr9XCwnBHW