### PR TITLE
fix(mcp): troubleshoot_error guides free users to self-raise trade cap (3.4.5)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/mcp/src/troubleshoot.ts
+++ b/mcp/src/troubleshoot.ts
@@ -24,7 +24,7 @@ const LOCAL_FALLBACK: Array<{ patterns: string[]; fix: string }> = [
   },
   {
     patterns: ["daily trade limit", "trades/day"],
-    fix: "Daily trade limit counts across all venues (sim + real). Raise via PATCH /api/sdk/user/settings with max_trades_per_day (Free: up to 1,000, Pro: up to 5,000). Sells are exempt.",
+    fix: "Daily trade limit counts across all venues (sim + real). Free users can self-raise this to 1,000/day (no upgrade needed) via PATCH /api/sdk/user/settings with max_trades_per_day; Pro raises the ceiling to 5,000. Sell orders are never blocked by this limit (you can always exit), but completed trades of either side count toward the daily total.",
   },
 ];
 


### PR DESCRIPTION
Live counterpart to simmer PR #1537 + simmer-docs #87 — this is the **npm `simmer-mcp@3.x`** package agents actually run.

The `troubleshoot_error` fix-text for "daily trade limit" said the limit counts across venues and "Sells are exempt." It never told free users they can **self-raise `max_trades_per_day` to 1,000 without upgrading**, and "Sells are exempt" overstates it.

- `mcp/src/troubleshoot.ts:27` — reworded to lead with the free self-raise (Pro raises the ceiling to 5,000) and to state that sells are never *blocked* (you can always exit) but completed trades of either side *count* toward the daily total.
- `mcp/package.json` — bump 3.4.4 → 3.4.5.

No test asserts the old string (checked `mcp/tests/troubleshoot.test.ts`). Ships to npm on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)