### PR TITLE
fix(mcp): troubleshoot copy — daily cap counts buys only (sells & redeems exempt)

### DIFF
--- a/mcp/src/troubleshoot.ts
+++ b/mcp/src/troubleshoot.ts
@@ -24,7 +24,7 @@ const LOCAL_FALLBACK: Array<{ patterns: string[]; fix: string }> = [
   },
   {
     patterns: ["daily trade limit", "trades/day"],
-    fix: "Daily trade limit counts across all venues (sim + real). Free users can self-raise this to 1,000/day (no upgrade needed) via PATCH /api/sdk/user/settings with max_trades_per_day; Pro raises the ceiling to 5,000. Sell orders are never blocked by this limit (you can always exit), but completed trades of either side count toward the daily total.",
+    fix: "The daily trade limit counts only BUYS across all venues (sim + real) — sells (exits) and redeems are exempt. Free users can self-raise this to 1,000/day (no upgrade needed) via PATCH /api/sdk/user/settings with max_trades_per_day; Pro raises the ceiling to 5,000.",
   },
 ];
 


### PR DESCRIPTION
Mirrors simmer **#1539** (the daily-cap count now filters to buys). Updates the `troubleshoot_error` fallback text for "daily trade limit" to state sells (exits) and redeems are exempt.

Version stays **3.4.5** — the earlier publish attempt failed on auth (`ENEEDAUTH`, no `NPM_TOKEN`), so 3.4.5 never hit npm. This folds in so the manual publish ships everything at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)