### PR TITLE
docs(sdk): correct get_portfolio by_source docstring (sim carries realized P&L)

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3264,7 +3264,14 @@ class SimmerClient:
             - total: {positions_count, total_exposure} summed across venues
             - balance_usdc, sim_balance, sim_pnl, positions_count, total_exposure:
               legacy flat fields (deprecated but still populated)
-            - by_source: Breakdown by trade source (polymarket only)
+            - by_source: Per-strategy breakdown keyed by trade source. For
+              venue="sim", each entry carries realized_pnl, unrealized_pnl,
+              exposure, positions, and trade_count (exact, ledger-derived) —
+              this is the intended path for per-strategy realized/unrealized
+              P&L attribution; do not rebuild it from get_trades() rows (the
+              per-trade pnl field is a fill attribute, not an accounting one).
+              Polymarket/Kalshi entries are exposure-only (per-source realized
+              P&L for real venues is not yet available).
 
         Example:
             # Cross-venue (default):


### PR DESCRIPTION
## What

The `get_portfolio()` `by_source` docstring said the breakdown was **"(polymarket only)"** — that's backwards.

- **sim** entries carry per-source `realized_pnl`/`unrealized_pnl`/`exposure`/`positions`/`trade_count` (SIM-3274, exact ledger-derived) — this **is** the intended per-strategy P&L attribution path.
- **polymarket/kalshi** entries are exposure-only (per-source realized P&L for real venues isn't available yet — the reconciliation wall).

## Why

A builder (yue) consuming sim trade history hit the per-trade `pnl=0` (a fill attribute, not accounting) and was about to rebuild a local FIFO model because the docstring pointed them away from the real path. Doc-only; the runtime field has been live since 6/16, so no behavior change.

## Note

Repo-truth fix. The corrected docstring reaches installed packages on the next PyPI republish (manual) — not cutting a release just for this; batch into the next SDK release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)