### PR TITLE
docs: add backtest entrypoint to simmer skill

### DIFF
--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.7"
+  version: "1.24.8"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -96,7 +96,7 @@ Documentation references — open when the situation matches.
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |
-| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --window 30d` |
+| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --entrypoint run.py --window 30d` |
 
 ## Trade behavior (defaults at a glance)
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.7"
+  version: "1.24.8"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -96,7 +96,7 @@ Documentation references — open when the situation matches.
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |
-| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --window 30d` |
+| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --entrypoint run.py --window 30d` |
 
 ## Trade behavior (defaults at a glance)
 


### PR DESCRIPTION
## Summary
- Add the required `--entrypoint run.py` flag to the Simmer skill backtest example.
- Bump the Simmer skill metadata version from 1.24.7 to 1.24.8.
- Keep the MCP bundled skill snapshot aligned with the canonical skill.

## Verification
- `rg --pcre2 -n "simmer backtest <skill>(?! --entrypoint)" skills/simmer mcp/bundled-skills/simmer README.md` returned no matches.
- `rg -n "simmer backtest <skill> --entrypoint run\.py --window 30d|version: \"1\.24\.8\"" skills/simmer/SKILL.md mcp/bundled-skills/simmer/SKILL.md` confirmed both copies.

Closes SIM-3452