### PR TITLE
fix(copytrading): delete reactor signals by signal_id (SIM-3297)

### DIFF
--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.11.2"
+  version: "1.12.0"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---

--- a/skills/polymarket-copytrading/copytrading_trader.py
+++ b/skills/polymarket-copytrading/copytrading_trader.py
@@ -827,12 +827,19 @@ def _process_reactor_signal(client, signal: dict) -> bool:
         reason=None,
     )
 
-    # Delete the signal to prevent reprocessing on the next poll. Non-fatal:
-    # if the delete fails, the 60s TTL will clean it up; worst case we'd
-    # re-process the same tx_hash once, which client.trade() handles via
-    # idempotency on the server-side trade path.
+    # Delete the signal to prevent reprocessing on the next poll. Maker-leg
+    # signals (SIM-3297) are keyed by a leg-scoped signal_id (e.g.
+    # "{tx_hash}:maker:{leg}:{maker}:{token}"), so we MUST delete by the
+    # server-provided signal_id — deleting by the bare tx_hash would never match
+    # the maker key and the signal would re-execute on every poll until its TTL.
+    # The reactor path runs trade(..., allow_rebuy=True), so a missed delete
+    # genuinely re-trades; this is not covered by trade-path idempotency.
+    # Falls back to tx_hash for taker signals and older servers that don't return
+    # signal_id. The server route accepts the colon-laden id via a :path param.
+    # Non-fatal: a failed delete is TTL-bounded.
+    signal_id = signal.get("signal_id") or tx_hash
     try:
-        client._request("DELETE", f"/api/sdk/reactor/pending/{tx_hash}")
+        client._request("DELETE", f"/api/sdk/reactor/pending/{signal_id}")
     except Exception as e:
         print(f"[reactor] delete warn for {tx_short}...: {type(e).__name__}: {e}")
 


### PR DESCRIPTION
## What

The reactor consumer (`copytrading_trader.py`) deleted executed signals by bare `tx_hash`. Maker-leg signals (SIM-3297) use a leg-scoped `signal_id` (`{tx_hash}:maker:{leg}:{maker}:{token}`), so the bare-`tx_hash` DELETE never matched the Redis key → the signal re-executed on **every poll until TTL** (~30 duplicate trades). The reactor path runs `trade(..., allow_rebuy=True)`, so missed deletes genuinely re-trade — not covered by trade-path idempotency.

## Fix

Delete by the server-provided `signal_id`, falling back to `tx_hash` for taker signals and older servers. Server route already accepts the colon-laden id via a `:path` param and backfills `signal_id` in the pending GET. Skill bumped to **v1.12.0**.

## Coordination (money-path)

Pairs with simmer PR #1556 (server). The server gates maker-leg emission behind `REACTOR_MAKER_LEGS_ENABLED` (default **OFF**). **Sequence:** ship + republish this skill to ClawHub → confirm affected reactor users updated → flip the server flag ON. Until then no maker signals are emitted, so no duplicate-trade exposure.

Refs SIM-3297

🤖 Generated with [Claude Code](https://claude.com/claude-code)