### PR TITLE
docs(skill): add --entrypoint run.py to backtest example (Refs SIM-3452)

### DIFF
--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.7"
+  version: "1.24.8"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -96,7 +96,7 @@ Documentation references — open when the situation matches.
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |
-| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --window 30d` |
+| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --entrypoint run.py --window 30d` |
 
 ## Trade behavior (defaults at a glance)
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.7"
+  version: "1.24.8"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -96,7 +96,7 @@ Documentation references — open when the situation matches.
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |
-| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --window 30d` |
+| Validating a skill on historical data before risking capital | [docs.simmer.markets/backtesting](https://docs.simmer.markets/backtesting) — `pip install 'simmer-sdk[backtest]'` then `simmer backtest <skill> --entrypoint run.py --window 30d` |
 
 ## Trade behavior (defaults at a glance)
 


### PR DESCRIPTION
## What

Fixes the backtest example in the canonical Simmer overview skill (`skills/simmer/SKILL.md`).

- Backtest example now matches the real CLI signature: `simmer backtest <skill> --entrypoint run.py --window 30d` (was missing `--entrypoint run.py`).
- Bumped `metadata.version` `1.24.7` → `1.24.8` so ClawHub accepts the republish.

## Why

`skills/simmer/SKILL.md` is the **canonical source** that `website/public/skill.md` is auto-generated from. A prior PR (#1552, now closed) hand-edited the generated website copy instead, which failed the skill-drift CI check. This fixes the canonical so the website copy auto-follows on the next build.

Refs SIM-3452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfEr2rK2PokT9w8S8dGvaX