### PR TITLE
docs(contributing): note core-skill edits must re-bundle the MCP copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,21 @@ This repo is the **Python SDK and official skills** for Simmer. Contributions we
 
 **For new features or API changes**, open an issue first so we can align before you write code.
 
+## Editing a core skill
+
+A handful of core skills (`simmer`, `simmer-wallet-setup`, `simmer-mcp-setup`, `simmer-briefing`, `preflight`) live here under `skills/` and are the canonical source for two generated copies:
+
+- the **MCP bundle** at `mcp/bundled-skills/` — committed, so it must be regenerated in the same PR;
+- the **website** `public/skill.md` — auto-generated on the website build; don't hand-edit it.
+
+So when you change a file under `skills/`, also run:
+
+```bash
+cd mcp && npm run bundle-skills   # regenerates mcp/bundled-skills/
+```
+
+and commit the resulting bundle change. CI's `mcp-build` job runs `check:bundle-skills` and **fails the PR if the committed bundle is stale** — this is the most common surprise red check on skill edits. See [mcp/CONTRIBUTING.md](mcp/CONTRIBUTING.md) for details.
+
 ## AI-assisted PRs welcome
 
 Built this with Claude, Codex, or another AI tool? Great — just note it in the PR description. We care that the code is correct and you understand what it does, not how it was written.


### PR DESCRIPTION
## What

Adds an **Editing a core skill** section to the root `CONTRIBUTING.md` explaining that core skills under `skills/` are the canonical source for two generated copies — the committed MCP bundle (`mcp/bundled-skills/`) and the website's `public/skill.md` — and that editing a skill requires re-running `npm run bundle-skills` and committing the result.

## Why

The MCP bundle is committed and CI-enforced (`mcp-build` → `check:bundle-skills`), so a canonical skill edit that skips the re-bundle fails the PR. That step was only documented in `mcp/CONTRIBUTING.md`, which someone editing a skill under `skills/` wouldn't think to open — so the failure shows up as a surprise red check (it just bit us on #259). This closes the discoverability gap without changing the architecture.

No-dependency, docs-only follow-up to the SIM-3452 skill fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfEr2rK2PokT9w8S8dGvaX