### PR TITLE
fix(sdk): surface fee_rate_bps and fill_price on TradeResult (SIM-3592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **`TradeResult.fee_rate_bps` — taker fee rate now surfaces on trade results.** The server's quoted taker fee rate (in basis points) is now mapped through to `TradeResult.fee_rate_bps`. Previously the field was absent and `getattr(result, "fee_rate_bps", None)` always returned `None`. Currently `0` on Polymarket (fees are waived), but will reflect the real rate when fees go live.
+- **`TradeResult.fill_price` — alias for `new_price`.** A `fill_price` property now exposes the effective fill price per share alongside the existing `new_price` field for clarity.
+
 ### Fixed
 
 - **`polymarket-weather-trader`: international markets now capped at canary size.** Positions on international stations (Tokyo, Madrid, Ankara, etc.) use Open-Meteo as the sole source with no secondary cross-check. Previously these `missing_secondary` positions were sized at the full position size, producing outsized losses from unverified single-source forecasts. They now cap at `MAX_CANARY_USD` (default $2.00), matching the same protective ceiling used for adjacent-bucket disagreements. Set `SIMMER_WEATHER_REQUIRE_SOURCE_AGREEMENT=true` to skip them entirely.

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -136,6 +136,7 @@ class TradeResult:
     fill_status: str = "unknown"  # Server fill status: "filled", "submitted", "unconfirmed", "failed"
     order_id: Optional[str] = None  # CLOB order ID for GTC/GTD orders — use with cancel_order()
     retryable: bool = True  # False when server knows retrying is futile (position cleared on-chain)
+    fee_rate_bps: Optional[float] = None  # Taker fee rate in basis points (0 on Polymarket today)
 
     @property
     def shares_filled(self) -> float:
@@ -148,6 +149,11 @@ class TradeResult:
         if self.shares_requested <= 0:
             return self.success
         return self.shares_filled >= self.shares_requested
+
+    @property
+    def fill_price(self) -> float:
+        """Effective fill price (average price per share). Alias for new_price."""
+        return self.new_price
 
 
 @dataclass
@@ -2277,6 +2283,7 @@ class SimmerClient:
                 fill_status=d.get("fill_status", "unknown"),
                 order_id=d.get("order_id"),
                 retryable=d.get("retryable", True),
+                fee_rate_bps=d.get("fee_rate_bps"),
             )
 
         result = _build_result(data)


### PR DESCRIPTION
Agents calling `client.trade()` had no way to read the taker fee rate on the returned result — `result.fee_rate_bps` raised `AttributeError` (field absent), so users fell back to `getattr(..., None)` and always saw `None`. The server already sends `fee_rate_bps` in the trade response; this PR just wires it through.

## Changes
- `simmer_sdk/client.py`: add `fee_rate_bps: Optional[float] = None` to `TradeResult` dataclass; map `d.get("fee_rate_bps")` in `_build_result()`. Add `fill_price` property (alias for `new_price`) for naming clarity.
- `CHANGELOG.md`: note both additions under `[Unreleased]`.

## Tests
- `python3 -m pytest tests/ -x -q`: 40 passed, 1 pre-existing failure (`test_raw_key_derives_creds_and_posts_existing_endpoint_contract` — missing `py_clob_client` module, unrelated to this PR, confirmed present on `main` before this branch)
- Smoke test: `TradeResult(success=True, fee_rate_bps=0.0, new_price=0.55)` → `fee_rate_bps=0.0`, `fill_price=0.55`; `TradeResult(success=True)` → `fee_rate_bps=None`, `fill_price=0`

Not user-facing runtime behavior (additive new field + property, no existing field changed).

Closes SIM-3592