### PR TITLE
fix(sdk): trade() raises ValueError when shares passed on buy orders (SIM-3591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **`trade()`: passing `shares` on a buy order now raises `ValueError` immediately** instead of silently ignoring the value. Previously, calling `client.trade(..., shares=5, action="buy")` would discard `shares` and size the order from `amount`, making exact share-count buys impossible to achieve and producing no diagnostic signal. The error message directs callers to the correct pattern: set `amount = shares * price` (with a small buffer for tick rounding). The `shares` parameter docstring is updated to make clear it is for sells only.
+
 - **`polymarket-weather-trader`: international markets now capped at canary size.** Positions on international stations (Tokyo, Madrid, Ankara, etc.) use Open-Meteo as the sole source with no secondary cross-check. Previously these `missing_secondary` positions were sized at the full position size, producing outsized losses from unverified single-source forecasts. They now cap at `MAX_CANARY_USD` (default $2.00), matching the same protective ceiling used for adjacent-bucket disagreements. Set `SIMMER_WEATHER_REQUIRE_SOURCE_AGREEMENT=true` to skip them entirely.
 
 ## [0.20.3] - 2026-06-18

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1967,7 +1967,10 @@ class SimmerClient:
             market_id: Market ID to trade on
             side: 'yes' or 'no'
             amount: Amount to spend (for buys) — USDC for polymarket/kalshi, $SIM for sim
-            shares: Number of shares to sell (for sells)
+            shares: Number of shares to sell (sells only). Not used for buys — pass
+                ``amount`` instead. For an exact buy size: set
+                ``amount = shares * price`` (add ~0.1% buffer to survive tick
+                round-down, or use ``dry_run=True`` to confirm exact fill count).
             action: 'buy' or 'sell' (default: 'buy')
             venue: Override client's default venue for this trade.
                 - "sim": Simmer LMSR, $SIM virtual currency ("simmer" accepted as alias)
@@ -2071,6 +2074,13 @@ class SimmerClient:
             raise ValueError("shares required for sell orders")
         if not is_sell and amount <= 0:
             raise ValueError("amount required for buy orders")
+        if not is_sell and shares > 0:
+            raise ValueError(
+                "shares is for sell orders only. For an exact buy size, pass an "
+                "explicit price and set amount = shares * price (add ~0.1% buffer "
+                "to survive tick round-down, or use dry_run=True to confirm exact "
+                "fill count)."
+            )
 
         # Quantize to the venue's input precision before submission. Maker
         # (USDC) accepts max 2 decimals; shares accept max 5. Planner / Kelly

--- a/tests/test_decimal_validation.py
+++ b/tests/test_decimal_validation.py
@@ -105,3 +105,30 @@ class TestSharesDecimalQuantization:
         client = _make_client()
         with pytest.raises(ValueError, match="too small to place an order"):
             client.trade("m1", "yes", shares=0.000004, action="sell")
+
+
+class TestSharesBuyGuard:
+    """shares must not be passed on buy orders — fail loud instead of silently ignoring."""
+
+    def test_shares_on_buy_raises(self):
+        client = _make_client()
+        with pytest.raises(ValueError, match="shares is for sell orders only"):
+            client.trade("m1", "yes", amount=10.0, shares=5.0, action="buy")
+
+    def test_shares_on_default_buy_raises(self):
+        """action defaults to 'buy', so passing shares without action should also raise."""
+        client = _make_client()
+        with pytest.raises(ValueError, match="shares is for sell orders only"):
+            client.trade("m1", "yes", amount=10.0, shares=5.0)
+
+    def test_shares_zero_on_buy_allowed(self):
+        """shares=0 (default) on a buy is fine — no guard triggered."""
+        client = _make_client()
+        result = client.trade("m1", "yes", amount=10.0, shares=0)
+        assert result.success
+
+    def test_shares_on_sell_still_works(self):
+        """The sell path is unaffected by the buy guard."""
+        client = _make_client()
+        result = client.trade("m1", "yes", shares=5.0, action="sell")
+        assert result.success


### PR DESCRIPTION
Pro user passed `shares` + `amount` to `client.trade(..., action="buy")` expecting exact share-count sizing. The SDK accepted `shares`, transmitted it, then silently dropped it at every layer — signing zeroed it, backends sized from `amount`. No error, wrong behavior.

## Changes
- `simmer_sdk/client.py`: add `ValueError` guard at input validation (~line 2077): if `action=="buy"` and `shares>0`, raise immediately with a message pointing to `amount = shares * price` pattern
- `simmer_sdk/client.py`: update `shares` param docstring to state "sells only" + show the exact-buy-size workaround
- `tests/test_decimal_validation.py`: 4 new tests covering buy+shares raise, default-action+shares raise, shares=0 allowed, sell path unaffected
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`

## Tests
```
python3 -m pytest tests/test_decimal_validation.py -v
13 passed in 0.47s
```
All 9 pre-existing + 4 new tests pass.

Closes SIM-3591