### PR TITLE
release: simmer-sdk 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-06-27
+
 ### Added
 
 - **`TradeResult.fee_rate_bps` — taker fee rate now surfaces on trade results.** The server's quoted taker fee rate (in basis points) is now mapped through to `TradeResult.fee_rate_bps`. Previously the field was absent and `getattr(result, "fee_rate_bps", None)` always returned `None`. Currently `0` on Polymarket (fees are waived), but will reflect the real rate when fees go live.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.20.3"
+version = "0.21.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## What
Bump `simmer-sdk` 0.20.3 → **0.21.0** and cut the `[Unreleased]` CHANGELOG into a dated 0.21.0 section.

Bundles all currently-unreleased changes:
- `TradeResult.fee_rate_bps` now surfaced — was absent, `getattr(...)` returned `None` (SIM-3592, #261)
- `TradeResult.fill_price` alias for `new_price` (SIM-3592, #261)
- `trade()` raises `ValueError` when `shares` passed on a buy — was silently ignored (SIM-3591, #262)
- `polymarket-weather-trader` international markets capped at canary size (pre-existing unreleased)

Minor bump: additive `TradeResult` fields + the `shares` buy-guard behavior change.

## ⚠️ Merge order
`publish-lag` will be **RED** until 0.21.0 is on PyPI (the gate fails when repo version is ahead of the registry). Intended flow:
1. From this branch: `python -m build && twine upload dist/*` (Adrian's PyPI creds)
2. publish-lag re-runs green
3. Merge this PR

Refs SIM-3591, SIM-3592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)