### PR TITLE
ci: auto-publish SDK packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,133 @@
+name: Publish Packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "simmer_sdk/**"
+      - "mcp/**"
+      - "skills/**"
+      - "scripts/check_publish_lag.py"
+      - "scripts/plan_package_publish.py"
+      - ".github/workflows/publish-packages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-packages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Plan publishes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      npm_publish_needed: ${{ steps.plan.outputs.npm_publish_needed }}
+      npm_repo_version: ${{ steps.plan.outputs.npm_repo_version }}
+      npm_published_version: ${{ steps.plan.outputs.npm_published_version }}
+      pypi_publish_needed: ${{ steps.plan.outputs.pypi_publish_needed }}
+      pypi_repo_version: ${{ steps.plan.outputs.pypi_repo_version }}
+      pypi_published_version: ${{ steps.plan.outputs.pypi_published_version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compare repo versions with registries
+        id: plan
+        run: python3 scripts/plan_package_publish.py
+
+  publish-mcp:
+    name: Publish simmer-mcp to npm
+    needs: plan
+    if: needs.plan.outputs.npm_publish_needed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: mcp
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python SDK for MCP tests
+        working-directory: .
+        run: pip install -e .
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify bundled skill content is fresh
+        run: npm run check:bundle-skills
+
+      - name: Build and test
+        run: npm test
+
+      - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  publish-sdk:
+    name: Publish simmer-sdk to PyPI
+    needs: plan
+    if: needs.plan.outputs.pypi_publish_needed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  verify:
+    name: Verify registries caught up
+    needs: [plan, publish-mcp, publish-sdk]
+    if: always() && (needs.plan.outputs.npm_publish_needed == 'true' || needs.plan.outputs.pypi_publish_needed == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check publish lag
+        run: python3 scripts/check_publish_lag.py

--- a/mcp/SUBMISSION.md
+++ b/mcp/SUBMISSION.md
@@ -117,5 +117,6 @@ Get your API key from [simmer.markets/dashboard](https://simmer.markets/dashboar
 
 - [ ] Bump `package.json` version
 - [ ] Update tool counts above if tools changed
-- [ ] Publish to npm: `npm publish` (interactive OTP in separate terminal)
+- [ ] Merge to `main`; `.github/workflows/publish-packages.yml` publishes to npm
+      when the repo version is ahead of the registry
 - [ ] Smithery auto-tracks npm — no manual step unless metadata changed

--- a/scripts/plan_package_publish.py
+++ b/scripts/plan_package_publish.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Plan npm/PyPI publishes for the release workflow.
+
+The CI publish-lag gate fails when a repo version is ahead of the public
+registry. This helper uses the same registry readers and semver comparator, but
+turns that state into GitHub Actions outputs so the release workflow can publish
+only the packages that need it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import check_publish_lag
+
+
+def github_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def emit(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    line = f"{name}={value}\n"
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+    else:
+        print(line, end="")
+
+
+def plan_package(label: str, repo_version: str, published_version: str) -> bool:
+    comparison = check_publish_lag.compare_versions(repo_version, published_version)
+    if comparison > 0:
+        print(f"{label}: publish needed ({repo_version} > {published_version})")
+        return True
+    if comparison < 0:
+        print(f"{label}: registry is newer ({published_version} > {repo_version}); no publish")
+        return False
+    print(f"{label}: already published at {repo_version}")
+    return False
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=check_publish_lag.ROOT)
+    parser.add_argument("--npm-published-version", help="Override npm latest version for tests.")
+    parser.add_argument("--pypi-published-version", help="Override PyPI latest version for tests.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+
+    npm_repo_version = check_publish_lag.read_npm_repo_version(root)
+    pypi_repo_version = check_publish_lag.read_pypi_repo_version(root)
+    npm_published_version = args.npm_published_version or check_publish_lag.fetch_npm_latest(
+        check_publish_lag.NPM_PACKAGE
+    )
+    pypi_published_version = args.pypi_published_version or check_publish_lag.fetch_pypi_latest(
+        check_publish_lag.PYPI_PACKAGE
+    )
+
+    npm_publish_needed = plan_package(
+        check_publish_lag.NPM_PACKAGE, npm_repo_version, npm_published_version
+    )
+    pypi_publish_needed = plan_package(
+        check_publish_lag.PYPI_PACKAGE, pypi_repo_version, pypi_published_version
+    )
+
+    emit("npm_repo_version", npm_repo_version)
+    emit("npm_published_version", npm_published_version)
+    emit("npm_publish_needed", github_bool(npm_publish_needed))
+    emit("pypi_repo_version", pypi_repo_version)
+    emit("pypi_published_version", pypi_published_version)
+    emit("pypi_publish_needed", github_bool(pypi_publish_needed))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except check_publish_lag.PublishLagError as exc:
+        print(f"::error::{exc}")
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add a publish-planning helper that reuses the existing publish-lag registry/version logic.
- Add a main-branch/manual GitHub Actions workflow that publishes simmer-mcp to npm and simmer-sdk to PyPI only when the repo version is ahead of the registry.
- Update the MCP submission release checklist to point at the auto-publish workflow.

## Verification
- python3 -m pytest tests/test_check_publish_lag.py -q
- python3 scripts/plan_package_publish.py --npm-published-version 3.4.4 --pypi-published-version 0.20.9
- python3 -m py_compile scripts/check_publish_lag.py scripts/plan_package_publish.py
- npm run check:bundle-skills
- npm test

Closes SIM-3381