### PR TITLE
fix: support OWS combo DW activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **`trade()` no longer forces `order_type="FAK"` when callers omit it.** Omitted Polymarket order types now flow through as `None` so the backend's smart default applies (GTC for sells, FAK for buys). External-wallet signing still needs a concrete CLOB order type, so the SDK mirrors the same rule locally before signing. We are not flipping all buys to GTC: the audit found first-party thin-market skills already pass GTC explicitly, while changing every implicit buy to a resting order would be a larger backwards-compatibility break for callers expecting immediate-or-cancel behavior. Docs now recommend explicit `order_type="GTC"` plus `price` for thin books and maker-style limit entries. (SIM-2508)
 
+### Fixed
+
+- **Combo DW activation now supports OWS signing and tolerates backend hash lag.** `client.activate_combo_dw()` now signs the combo approval batch with either `WALLET_PRIVATE_KEY` or `OWS_WALLET`, matching `activate_polymarket_dw()` and `wrap_on_dw()` instead of rejecting OWS-only Elite deposit-wallet setups. Skill entrypoint integrity still rejects local tampering, but when the Simmer backend `content_hash` is stale it now verifies the local entrypoint against ClawHub's live published file before allowing an official latest install to run.
+
 ## [0.21.0] - 2026-06-27
 
 ### Added

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -801,7 +801,7 @@ class SimmerClient:
                                 "https://clawhub.ai/api/v1/skills/"
                                 f"{quote(self._skill_slug, safe='')}/file?path={quote(entrypoint, safe='')}"
                             )
-                            live_resp = self._session.get(live_url, timeout=5)
+                            live_resp = requests.get(live_url, timeout=5)
                             if live_resp.status_code == 200:
                                 live_content = live_resp.text
                                 live_hash = hashlib.sha256(

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -12,7 +12,7 @@ import logging
 import requests
 from typing import Optional, List, Dict, Any, Callable
 from dataclasses import dataclass
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
@@ -744,7 +744,9 @@ class SimmerClient:
         """Verify local skill entrypoint hash matches the backend-published hash.
 
         Raises RuntimeError on mismatch. Logs warning and allows on NULL hash
-        or backend unreachable.
+        or backend unreachable. If the Simmer backend hash is stale but the
+        local entrypoint matches the live ClawHub file exactly, logs a warning
+        and allows the official install to run.
         """
         try:
             from pathlib import Path
@@ -794,6 +796,37 @@ class SimmerClient:
                         return
 
                     if local_hash != published_hash:
+                        try:
+                            live_url = (
+                                "https://clawhub.ai/api/v1/skills/"
+                                f"{quote(self._skill_slug, safe='')}/file?path={quote(entrypoint, safe='')}"
+                            )
+                            live_resp = self._session.get(live_url, timeout=5)
+                            if live_resp.status_code == 200:
+                                live_content = live_resp.text
+                                live_hash = hashlib.sha256(
+                                    live_content.encode("utf-8")
+                                ).hexdigest()
+                                if local_hash == live_hash:
+                                    logger.warning(
+                                        "Skill '%s' local entrypoint matches "
+                                        "ClawHub live content, but Simmer "
+                                        "backend content_hash is stale "
+                                        "(local=%s..., backend=%s...). "
+                                        "Allowing official install to run.",
+                                        self._skill_slug,
+                                        local_hash[:12],
+                                        published_hash[:12],
+                                    )
+                                    return
+                        except Exception as e:
+                            logger.debug(
+                                "ClawHub live hash fallback failed for skill "
+                                "'%s': %s",
+                                self._skill_slug,
+                                e,
+                            )
+
                         raise RuntimeError(
                             f"Skill '{self._skill_slug}' entrypoint integrity check failed. "
                             f"Local hash ({local_hash[:12]}...) does not match published hash "
@@ -5736,24 +5769,24 @@ class SimmerClient:
         - **Per-agent** (``agent_id="..."``):
           ``/api/user/agent/{agent_id}/wallet/external/dw-approvals/*``.
 
-        Raw-key only — OWS combo signing is not yet supported (matches
-        ``place_combo``). The combo approval batch is signed locally with
-        ``WALLET_PRIVATE_KEY`` / ``private_key``; the key never leaves the
-        process and the server relays the batch gaslessly under its builder
-        HMAC.
+        The combo approval batch is signed locally with ``WALLET_PRIVATE_KEY``
+        / ``private_key`` or with the configured OWS wallet; the key never
+        leaves the process / OWS vault and the server relays the batch
+        gaslessly under its builder HMAC.
 
         Requires:
-        - WALLET_PRIVATE_KEY env var or ``private_key`` constructor arg
+        - WALLET_PRIVATE_KEY env var / ``private_key`` constructor arg,
+          OR OWS_WALLET env var / ``ows_wallet`` constructor arg
         - Account upgraded to a Deposit Wallet (per-agent: the agent's DW)
-        - eth-account installed
+        - eth-account installed for the raw-key path
 
         Returns:
             Dict with keys ``already_set`` (bool), ``calls_count`` (int),
             ``success`` (bool).
 
         Raises:
-            ValueError: if no raw private key is configured
-            ImportError: if eth-account is not installed
+            ValueError: if no signing key is configured
+            ImportError: if eth-account is not installed and using raw-key signing
 
         Example (user-primary, raw key):
             client = SimmerClient(api_key="sk_live_...")  # WALLET_PRIVATE_KEY in env
@@ -5761,22 +5794,21 @@ class SimmerClient:
             # now DW combos settle:
             client.place_combo(leg_ids, 10.0, dry_run=False)
         """
-        # OWS combo signing is not yet supported — require a raw key (matches
-        # place_combo's gate). An OWS-only client can't activate combos.
-        if not self._private_key:
+        if not self._private_key and not self._ows_wallet:
             raise ValueError(
-                "activate_combo_dw() requires a raw EOA private key (the "
-                "deposit-wallet owner key). Set WALLET_PRIVATE_KEY env var or "
-                "pass private_key= to the constructor. OWS combo signing is "
-                "not yet supported."
+                "activate_combo_dw() requires a signing key. "
+                "Set WALLET_PRIVATE_KEY env var, pass private_key to the "
+                "constructor, or configure an OWS wallet (OWS_WALLET env var "
+                "or ows_wallet arg)."
             )
-        try:
-            from eth_account import Account  # noqa: F401 — early dep check
-        except ImportError:
-            raise ImportError(
-                "eth-account is required for activate_combo_dw(). "
-                "Install with: pip install eth-account"
-            )
+        if self._private_key:
+            try:
+                from eth_account import Account  # noqa: F401 — early dep check
+            except ImportError:
+                raise ImportError(
+                    "eth-account is required for activate_combo_dw(). "
+                    "Install with: pip install eth-account"
+                )
 
         if agent_id:
             _dw_base = (
@@ -5822,11 +5854,17 @@ class SimmerClient:
         validate_dw_approval_calls(calls)
 
         print("[Combo-Activate] Signing combo approval batch locally…")
-        from eth_account import Account
-        signed = Account.sign_typed_data(self._private_key, full_message=typed_data)
-        signature = signed.signature.hex()
-        if not signature.startswith("0x"):
-            signature = "0x" + signature
+        if self._private_key:
+            from eth_account import Account
+            signed = Account.sign_typed_data(self._private_key, full_message=typed_data)
+            signature = signed.signature.hex()
+            if not signature.startswith("0x"):
+                signature = "0x" + signature
+        else:
+            from simmer_sdk.ows_utils import ows_sign_typed_data
+            import json as _json
+            sig = ows_sign_typed_data(self._ows_wallet, _json.dumps(typed_data))
+            signature = sig if sig.startswith("0x") else "0x" + sig
 
         print("[Combo-Activate] Submitting to relayer…")
         self._request(

--- a/skills/polymarket-combo-builder/SKILL.md
+++ b/skills/polymarket-combo-builder/SKILL.md
@@ -69,7 +69,8 @@ python combo_builder.py --legs     # browse combo-eligible legs (no config neede
 ```
 
 Dry-run opens no socket, signs nothing, and moves no money. `--live` requires a
-configured wallet (`WALLET_PRIVATE_KEY`) and a live Simmer client.
+configured wallet (`WALLET_PRIVATE_KEY` or `OWS_WALLET`) and a live Simmer
+client.
 
 ## Wallet support
 
@@ -78,9 +79,12 @@ configured wallet (`WALLET_PRIVATE_KEY`) and a live Simmer client.
 - **Deposit wallet** (`signature_type 3` / POLY_1271): **works after a one-time
   `activate_combo_dw()`** — see below.
 
-OWS-signed wallets are not yet supported for combos — use a raw
-`WALLET_PRIVATE_KEY` (the deposit-wallet owner key) for now. This applies to
-both placing combos and `activate_combo_dw()`.
+OWS-signed deposit wallets can run the `activate_combo_dw()` setup headlessly
+with the same local OWS vault used for standard DW activation. Live combo order
+placement still requires the SDK's combo signing path to support that wallet
+type; if placement rejects your OWS setup, use a raw `WALLET_PRIVATE_KEY` for
+the wallet that owns the deposit wallet until OWS combo order signing is
+available.
 
 ### Deposit wallets: one-time combo activation
 
@@ -93,11 +97,12 @@ client.activate_combo_dw()              # user-primary DW
 client.activate_combo_dw(agent_id="…")  # per-agent (Elite) DW
 ```
 
-This signs the combo-exchange approval batch locally and Simmer's server
-relays it **gaslessly** under our builder credentials (it approves the combo
-exchange to spend the DW's pUSD + combo position tokens). It is idempotent —
-safe to re-run. After it completes, `place_combo(..., dry_run=False)` settles
-normally for the deposit wallet.
+This signs the combo-exchange approval batch locally with your raw key or OWS
+vault, and Simmer's server relays it **gaslessly** under our builder
+credentials (it approves the combo exchange to spend the DW's pUSD + combo
+position tokens). It is idempotent — safe to re-run. After it completes,
+`place_combo(..., dry_run=False)` settles normally for supported deposit-wallet
+signers.
 
 Before a live DW placement the SDK runs a quick on-chain pre-check and, if the
 combo approval is missing, raises a clear **"run `client.activate_combo_dw()`

--- a/tests/test_activate_combo_dw.py
+++ b/tests/test_activate_combo_dw.py
@@ -2,9 +2,10 @@
 (E3 — combo deposit-wallet publish).
 
 Pure unit tests — no network, no real signing. Covers:
-  - missing raw private key raises before any network call (OWS not supported)
+  - missing signing key raises before any network call
   - prepare is POSTed with {combo: true}, and the combo approval batch passes
     the client-side validator → sign → submit happy path
+  - OWS signing follows the same typed-data path as base DW activation
   - per-agent routing hits the agent dw-approvals endpoints
   - place_combo's on-chain pre-check blocks an unapproved DW with a pointer to
     activate_combo_dw(), and the _combo_dw_approved RPC helper decodes allowance
@@ -80,10 +81,9 @@ def _make_client(private_key=FAKE_PRIVATE_KEY, *, dw=False, live=False):
 # --- activate_combo_dw -----------------------------------------------------
 
 
-def test_requires_raw_private_key():
+def test_requires_signing_key():
     client = _make_client(private_key=None)
-    client._ows_wallet = "some-ows-wallet"  # OWS combo signing not supported
-    with pytest.raises(ValueError, match="raw EOA private key"):
+    with pytest.raises(ValueError, match="requires a signing key"):
         client.activate_combo_dw()
 
 
@@ -110,6 +110,28 @@ def test_prepare_sends_combo_flag_and_submits():
     assert body == {"combo": True}
     # then submit
     assert calls_seen[1][1].endswith("/dw-approvals/submit")
+
+
+def test_ows_signing_supported_for_combo_activation():
+    client = _make_client(private_key=None)
+    client._ows_wallet = "herman-v3"
+    submit_payload = {}
+
+    def fake_request(method, path, **kwargs):
+        if path.endswith("prepare"):
+            return PREPARE_COMBO
+        submit_payload.update(kwargs.get("json") or {})
+        return {"success": True, "all_set": True}
+
+    with patch.object(client, "_request", side_effect=fake_request):
+        with patch("simmer_sdk.ows_utils.ows_sign_typed_data", return_value="cafebabe") as sign:
+            result = client.activate_combo_dw()
+
+    assert result == {"already_set": False, "calls_count": 2, "success": True}
+    assert submit_payload["signature"] == "0xcafebabe"
+    signed_wallet, signed_message = sign.call_args.args
+    assert signed_wallet == "herman-v3"
+    assert '"DepositWalletBatch"' in signed_message
 
 
 def test_per_agent_routing():

--- a/tests/test_skill_integrity.py
+++ b/tests/test_skill_integrity.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+class _Resp:
+    def __init__(self, status_code: int, *, payload=None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, backend_hash: str, live_text: str):
+        self.backend_hash = backend_hash
+        self.live_text = live_text
+        self.urls = []
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        if url.endswith("/api/sdk/skills"):
+            return _Resp(
+                200,
+                payload={
+                    "skills": [
+                        {
+                            "id": "polymarket-combo-builder",
+                            "content_hash": self.backend_hash,
+                        }
+                    ]
+                },
+            )
+        return _Resp(200, text=self.live_text)
+
+
+def _write_skill(tmp_path: Path, entrypoint_text: str) -> Path:
+    skill_dir = tmp_path / "polymarket-combo-builder"
+    skill_dir.mkdir()
+    (skill_dir / "clawhub.json").write_text(
+        json.dumps({"automaton": {"entrypoint": "combo_builder.py"}}),
+        encoding="utf-8",
+    )
+    (skill_dir / "combo_builder.py").write_text(entrypoint_text, encoding="utf-8")
+    return skill_dir
+
+
+def _client(session) -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client.base_url = "https://api.simmer.example.com"
+    client._skill_slug = "polymarket-combo-builder"
+    client._session = session
+    return client
+
+
+def test_skill_integrity_allows_backend_hash_lag_when_clawhub_live_matches(tmp_path):
+    entrypoint = "print('official current skill')\n"
+    stale_hash = hashlib.sha256(b"old published content").hexdigest()
+    session = _Session(backend_hash=stale_hash, live_text=entrypoint)
+
+    _client(session)._verify_skill_integrity(_write_skill(tmp_path, entrypoint))
+
+    assert any("clawhub.ai/api/v1/skills/polymarket-combo-builder/file" in u for u in session.urls)
+
+
+def test_skill_integrity_still_rejects_local_file_that_matches_neither_hash(tmp_path):
+    entrypoint = "print('locally modified')\n"
+    stale_hash = hashlib.sha256(b"old published content").hexdigest()
+    session = _Session(backend_hash=stale_hash, live_text="print('official current skill')\n")
+
+    with pytest.raises(RuntimeError, match="entrypoint integrity check failed"):
+        _client(session)._verify_skill_integrity(_write_skill(tmp_path, entrypoint))

--- a/tests/test_skill_integrity.py
+++ b/tests/test_skill_integrity.py
@@ -20,9 +20,8 @@ class _Resp:
 
 
 class _Session:
-    def __init__(self, backend_hash: str, live_text: str):
+    def __init__(self, backend_hash: str):
         self.backend_hash = backend_hash
-        self.live_text = live_text
         self.urls = []
 
     def get(self, url, **kwargs):
@@ -39,7 +38,7 @@ class _Session:
                     ]
                 },
             )
-        return _Resp(200, text=self.live_text)
+        raise AssertionError(f"unexpected session request: {url}")
 
 
 def _write_skill(tmp_path: Path, entrypoint_text: str) -> Path:
@@ -61,20 +60,40 @@ def _client(session) -> SimmerClient:
     return client
 
 
-def test_skill_integrity_allows_backend_hash_lag_when_clawhub_live_matches(tmp_path):
+def test_skill_integrity_allows_backend_hash_lag_when_clawhub_live_matches(
+    tmp_path, monkeypatch
+):
     entrypoint = "print('official current skill')\n"
     stale_hash = hashlib.sha256(b"old published content").hexdigest()
-    session = _Session(backend_hash=stale_hash, live_text=entrypoint)
+    session = _Session(backend_hash=stale_hash)
+    external_requests = []
+
+    def fake_requests_get(url, **kwargs):
+        external_requests.append((url, kwargs))
+        return _Resp(200, text=entrypoint)
+
+    monkeypatch.setattr("simmer_sdk.client.requests.get", fake_requests_get)
 
     _client(session)._verify_skill_integrity(_write_skill(tmp_path, entrypoint))
 
-    assert any("clawhub.ai/api/v1/skills/polymarket-combo-builder/file" in u for u in session.urls)
+    assert session.urls == ["https://api.simmer.example.com/api/sdk/skills"]
+    assert len(external_requests) == 1
+    live_url, kwargs = external_requests[0]
+    assert "clawhub.ai/api/v1/skills/polymarket-combo-builder/file" in live_url
+    assert kwargs == {"timeout": 5}
 
 
-def test_skill_integrity_still_rejects_local_file_that_matches_neither_hash(tmp_path):
+def test_skill_integrity_still_rejects_local_file_that_matches_neither_hash(
+    tmp_path, monkeypatch
+):
     entrypoint = "print('locally modified')\n"
     stale_hash = hashlib.sha256(b"old published content").hexdigest()
-    session = _Session(backend_hash=stale_hash, live_text="print('official current skill')\n")
+    session = _Session(backend_hash=stale_hash)
+
+    def fake_requests_get(url, **kwargs):
+        return _Resp(200, text="print('official current skill')\n")
+
+    monkeypatch.setattr("simmer_sdk.client.requests.get", fake_requests_get)
 
     with pytest.raises(RuntimeError, match="entrypoint integrity check failed"):
         _client(session)._verify_skill_integrity(_write_skill(tmp_path, entrypoint))


### PR DESCRIPTION
## Summary
- let `client.activate_combo_dw()` sign approval batches with `OWS_WALLET`, matching `activate_polymarket_dw()` and `wrap_on_dw()`
- keep skill integrity checks strict for local tampering, but fall back to ClawHub live content when the Simmer backend `content_hash` is stale
- update combo-builder wallet guidance and regression tests

## Tests
- `python3 -m pytest -q tests/test_activate_combo_dw.py tests/test_skill_integrity.py tests/test_batch_validation.py`
- `python3 -m pytest -q skills/polymarket-combo-builder/tests`

Closes SIM-3373