### PR TITLE
release: simmer-sdk 0.22.0 + simmer-mcp 3.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-29
+
 ### Changed
 
 - **`trade()` no longer forces `order_type="FAK"` when callers omit it.** Omitted Polymarket order types now flow through as `None` so the backend's smart default applies (GTC for sells, FAK for buys). External-wallet signing still needs a concrete CLOB order type, so the SDK mirrors the same rule locally before signing. We are not flipping all buys to GTC: the audit found first-party thin-market skills already pass GTC explicitly, while changing every implicit buy to a resting order would be a larger backwards-compatibility break for callers expecting immediate-or-cancel behavior. Docs now recommend explicit `order_type="GTC"` plus `price` for thin books and maker-style limit entries. (SIM-2508)

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.21.0"
+version = "0.22.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Cuts the release that ships the two fixes already merged to main but sitting under `[Unreleased]`:

- **simmer-sdk 0.22.0** — `trade()` order-type default fix (SIM-2508, #267) + combo DW OWS activation fix (SIM-3373, #266)
- **simmer-mcp 3.4.6** — refreshed bundled simmer skill (order_type GTC guidance)

On merge, `publish-packages.yml` will detect repo version > registry version and publish both packages.

Note: the "Publish Lag Check" on this PR is expected RED (0.22.0 not yet on PyPI). It self-resolves after the post-merge publish.

Refs SIM-2508 SIM-3373