### PR TITLE
ci(publish): OIDC trusted publishing for PyPI + npm

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -83,9 +83,14 @@ jobs:
       - name: Build and test
         run: npm test
 
-      - name: Publish npm package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # OIDC trusted publishing requires npm >= 11.5.1; node 22 ships npm 10.x.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing.
+      # Register the trusted publisher on npmjs.com → simmer-mcp → Settings
+      # (GitHub owner SpartanLabsXyz / repo simmer-sdk / workflow publish-packages.yml).
+      - name: Publish npm package (OIDC trusted publishing)
         run: npm publish --provenance --access public
 
   publish-sdk:
@@ -109,10 +114,11 @@ jobs:
       - name: Build wheel and sdist
         run: python -m build
 
-      - name: Publish to PyPI
+      # No password: authenticates via OIDC trusted publishing.
+      # Register the trusted publisher on pypi.org → simmer-sdk → Publishing
+      # (GitHub owner SpartanLabsXyz / repo simmer-sdk / workflow publish-packages.yml).
+      - name: Publish to PyPI (OIDC trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   verify:
     name: Verify registries caught up


### PR DESCRIPTION
## What
Switches the auto-publish workflow from stored API tokens to **OIDC trusted publishing** on both registries.

- **PyPI** (`publish-sdk`): drop `password: ${{ secrets.PYPI_API_TOKEN }}` → `gh-action-pypi-publish` uses OIDC.
- **npm** (`publish-mcp`): drop `NODE_AUTH_TOKEN`; add `npm install -g npm@latest` (OIDC trusted publishing needs npm ≥ 11.5.1; node 22 ships 10.x).

Workflow already has `id-token: write`.

## Why
Neither `PYPI_API_TOKEN` nor `NPM_TOKEN` was ever configured, so the CI publish jobs failed on first real use (release 0.22.0 / 3.4.6 were published manually). Trusted publishing removes the stored secrets entirely, keeps account 2FA enforced, and ends the 90-day token-rotation toil (an expired npm token cost a debugging session on 2026-06-30).

## Required before this can publish (registry side — needs Adrian's login)
Register a GitHub Actions trusted publisher on each:
- **pypi.org** → simmer-sdk → Publishing → add: owner `SpartanLabsXyz`, repo `simmer-sdk`, workflow `publish-packages.yml`, environment blank
- **npmjs.com** → simmer-mcp → Settings → Trusted Publisher → GitHub Actions, same owner/repo/workflow

Until both are registered, the publish jobs will fail `invalid-publisher` — so merge this only once the publishers are registered, then validate on the next version bump.

Closes the CI half of SIM-3650 (the laptop bypass token can then be retired).