### PR TITLE
release: 0.22.1 / mcp 3.4.7 — validate OIDC trusted publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-06-30
+
+### Changed
+
+- No functional change. Validation release to exercise the new OIDC trusted-publishing CI path (PyPI + npm) end-to-end. (Refs SIM-3650)
+
 ## [0.22.0] - 2026-06-29
 
 ### Changed

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.22.0"
+version = "0.22.1"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Validation release (no functional change) to prove the new tokenless OIDC publish path works end-to-end now that trusted publishers are registered on PyPI + simmer-mcp.

On merge, `publish-packages.yml` should publish both via OIDC — no stored tokens. If a trusted-publisher field is mis-registered it fails `invalid-publisher` (no version burned; fix + re-dispatch).

Refs SIM-3650