### PR TITLE
ci(publish): drop registry-url so npm uses OIDC (not placeholder token)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -59,11 +59,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No registry-url: setup-node's registry-url writes an _authToken placeholder
+      # into .npmrc (NODE_AUTH_TOKEN=XXXXX-…), and npm then tries token-auth with that
+      # bogus value and 404s instead of falling through to OIDC trusted publishing.
+      # Unscoped package defaults to the npmjs.org registry anyway.
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Follow-up to #269. The npm OIDC publish 404'd because `setup-node`'s `registry-url` writes an `_authToken` placeholder into `.npmrc`; npm tries token-auth with the dummy value and 404s instead of using OIDC. Dropping `registry-url` removes the placeholder → npm authenticates via OIDC trusted publishing.

PyPI already validated (0.22.1 live via OIDC). Merging this re-triggers the npm publish for 3.4.7 (still unpublished), no version burn.

Refs SIM-3650