### PR TITLE
ci(publish): node 24 for npm OIDC (npm >= 11.5.1) + version print

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -63,10 +63,11 @@ jobs:
       # into .npmrc (NODE_AUTH_TOKEN=XXXXX-…), and npm then tries token-auth with that
       # bogus value and 404s instead of falling through to OIDC trusted publishing.
       # Unscoped package defaults to the npmjs.org registry anyway.
+      # node 24 ships npm 11.x natively; OIDC trusted publishing needs npm >= 11.5.1.
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -86,9 +87,13 @@ jobs:
       - name: Build and test
         run: npm test
 
-      # OIDC trusted publishing requires npm >= 11.5.1; node 22 ships npm 10.x.
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+      # Belt-and-suspenders: ensure npm >= 11.5.1 for OIDC trusted publishing, and
+      # print the resolved versions so the publish path is diagnosable from the log.
+      - name: Ensure npm supports OIDC trusted publishing
+        run: |
+          npm install -g npm@latest
+          node --version
+          npm --version
 
       # No NODE_AUTH_TOKEN: npm authenticates via OIDC trusted publishing.
       # Register the trusted publisher on npmjs.com → simmer-mcp → Settings


### PR DESCRIPTION
Follow-up to #271. npm gave `ENEEDAUTH` with no provenance attempt → npm never tried OIDC, which means npm < 11.5.1 (the `npm install -g npm@latest` on node 22 wasn't on PATH for publish). Switch to node 24 (ships npm 11.x), keep the upgrade as belt-and-suspenders, and print node/npm versions for diagnosability.

Re-triggers npm publish for 3.4.7 (still unpublished); PyPI skips (0.22.1 live). Refs SIM-3650