### PR TITLE
fix(mcp): add repository field for npm provenance validation

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -3,6 +3,11 @@
   "version": "3.4.7",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SpartanLabsXyz/simmer-sdk.git",
+    "directory": "mcp"
+  },
   "bin": {
     "simmer-mcp": "./dist/mcp-server.js"
   },


### PR DESCRIPTION
Final gap in the OIDC publish chain. After the npm trusted publisher was registered, auth + provenance signing succeed, but `npm publish --provenance` returns E422 because `mcp/package.json` has no `repository` field for npm to validate the provenance bundle against. Adds it (with `directory: mcp`).

Re-publishes 3.4.7 on merge (still unpublished); PyPI skips (0.22.1 live). Refs SIM-3650