### PR TITLE
feat(copy): positioning-copy refresh — agent-layer framing in SKILL.md + README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Positioning copy refresh** — `SKILL.md` description and opening paragraph updated to agent-layer framing: "one identity, one self-custody wallet, one cross-venue track record … and a loop that makes strategies better over time." `README.md` opening paragraph and bullet list updated to match. No behavioral change.
+
 ## [0.22.1] - 2026-06-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![PyPI version](https://badge.fury.io/py/simmer-sdk.svg)](https://pypi.org/project/simmer-sdk/)
 
-Simmer is the leading prediction market interface for AI agents. Autonomous trading agents place trades on venues like Polymarket and Kalshi through a unified API and SDK — with self-custody wallets, safety rails, and smart context.
+Simmer is the agent layer for prediction markets. Your agent gets a persistent identity, one self-custody wallet, and a cross-venue track record that spans Polymarket, Kalshi, and more — with safety rails, autoresearch, and a loop that makes your strategies better over time.
 
-- **AI-native trading platform** — designed for autonomous agents, with full support for manual trading too. Users install trading skills and let their agents trade autonomously.
-- **$SIM simulated trading** — paper-trade with virtual currency before risking real funds.
-- **Multi-venue** — trade Polymarket and Kalshi through one unified API.
+- **Agent account** — persistent identity, self-custody wallet, and a cross-venue track record that compounds over time.
+- **$SIM practice venue** — paper-trade with virtual currency before risking real funds.
+- **Polymarket + Kalshi** — real-money trading on the two largest prediction market venues.
 
 ## Installation
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: simmer
-description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
+description: The agent layer for prediction markets. One persistent identity, one self-custody wallet, one cross-venue track record — with safety rails and a loop that makes your strategies better over time.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.8"
+  version: "1.24.9"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -19,7 +19,7 @@ metadata:
 
 # Simmer
 
-Trade prediction markets as an AI agent. One SDK across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, agent-native API.
+Your agent's persistent prediction market account. One identity, one self-custody wallet, one cross-venue track record — across Polymarket, Kalshi, and the virtual $SIM practice venue. Safety rails and an autoresearch loop that makes strategies better over time.
 
 ## Safety rails (read first)
 


### PR DESCRIPTION
Retire "through one API" / "unified API" / venue-count-led framing. Propagate canonical agent-layer edge copy per product-strategy standing-decision #6.

## Changes

- `skills/simmer/SKILL.md`: description + opening paragraph updated; version bumped to 1.24.9
- `README.md`: opening paragraph + bullet list updated to agent-layer framing
- `CHANGELOG.md`: entry added under [Unreleased]

## Canonical framing applied

"Your agent's persistent prediction market account. One identity, one self-custody wallet, one cross-venue track record — across Polymarket, Kalshi, and the virtual $SIM practice venue. Safety rails and an autoresearch loop that makes strategies better over time."

## Tests

- No behavioral change; copy and version bump only
- `website/public/skill.md` auto-follows on next build from the SDK canonical

Refs SIM-3772