### PR TITLE
fix(weather-trader): group buckets by event_ref, not legacy event_id (v1.23.3)

### DIFF
--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.2"
+  version: "1.23.3"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).
@@ -49,6 +49,10 @@ Use this skill when the user wants to:
 - Buy low on weather predictions
 - Check their weather trading positions
 - Configure trading thresholds or locations
+
+## What's New in v1.23.3
+
+- **Event grouping now keys on `event_ref`** (the canonical parent-event id, present on every market) instead of the legacy `event_id`, which SDK-imported markets historically lacked. Fixes temperature buckets silently dropping out of their event group (missing buckets when `event_id` came back null).
 
 ## What's New in v1.21.0
 

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -1454,8 +1454,10 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
 
     events = {}
     for market in markets:
-        # Group by event_id if available, otherwise derive from question
-        event_key = market.get("event_id")
+        # Group by event_ref (canonical parent-event id, set on every import
+        # path) — legacy event_id was missing on SDK-imported markets, which
+        # split sibling temperature buckets into separate groups.
+        event_key = market.get("event_ref") or market.get("event_id")
         if not event_key:
             # Fall back: parse question to derive (location, date) grouping key
             info = parse_weather_event(market.get("event_name") or market.get("question", ""))


### PR DESCRIPTION
Companion to SupaFund/simmer#1645 (SIM-3825). SDK-imported markets had `event_id: null`, splitting temperature buckets out of their event group — reported by a user building a weather bot. `event_ref` is the canonical parent-event id present on every market; legacy `event_id` kept as fallback. Version bump 1.23.2 → 1.23.3 + changelog entry; ClawHub republish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg5jmXUVybNkoi79dHVTkk