### PR TITLE
fix: wire Hyperliquid main account and builder pass-through

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -686,7 +686,10 @@ class SimmerClient:
         WALLET_PRIVATE_KEY — HL is EVM-key-based, no new key needed). Orders
         sign and submit locally to ``api.hyperliquid.xyz``; the Simmer server
         is not in the execution path. Set ``SIMMER_HYPERLIQUID_TESTNET=1`` to
-        target testnet. Requires the ``[hyperliquid]`` extra.
+        target testnet. Set ``SIMMER_HYPERLIQUID_MAIN_ADDRESS`` when using an
+        approved agent key so reads default to the main account of record while
+        orders are signed by the agent key. Requires the ``[hyperliquid]``
+        extra.
 
         Note: this is the direct venue adapter. Unified ``trade(venue=
         "hyperliquid")`` routing (with server-side fill recording) lands in a
@@ -711,7 +714,10 @@ class SimmerClient:
             is_mainnet = os.environ.get(
                 "SIMMER_HYPERLIQUID_TESTNET", ""
             ).lower() not in ("1", "true", "yes")
-            self._hyperliquid_venue = HyperliquidVenue(signer, is_mainnet=is_mainnet)
+            main_address = os.environ.get("SIMMER_HYPERLIQUID_MAIN_ADDRESS") or None
+            self._hyperliquid_venue = HyperliquidVenue(
+                signer, is_mainnet=is_mainnet, main_address=main_address
+            )
         return self._hyperliquid_venue
 
     # ==========================================

--- a/simmer_sdk/hyperliquid_signing.py
+++ b/simmer_sdk/hyperliquid_signing.py
@@ -79,11 +79,14 @@ def build_order_action(
     reduce_only: bool = False,
     tif: str = "Gtc",
     cloid: Optional[str] = None,
+    builder: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build a single-order HL exchange action (the object that gets hashed).
 
     ``tif`` is the time-in-force: "Gtc" (resting), "Ioc", or "Alo" (post-only).
     Prices/sizes are formatted to HL's wire rules by the SDK primitives.
+    ``builder`` is passed through to the official SDK so builder attribution is
+    embedded in the signed action hash.
     """
     signing = _hl_signing()
     order = {
@@ -98,7 +101,7 @@ def build_order_action(
 
         order["cloid"] = Cloid.from_str(cloid)
     wire = signing.order_request_to_order_wire(order, asset)
-    return signing.order_wires_to_order_action([wire])
+    return signing.order_wires_to_order_action([wire], builder=builder)
 
 
 def build_cancel_action(asset: int, oid: int) -> Dict[str, Any]:

--- a/simmer_sdk/hyperliquid_venue.py
+++ b/simmer_sdk/hyperliquid_venue.py
@@ -40,11 +40,18 @@ class HyperliquidVenue:
     """VenueAdapter implementation for Hyperliquid HIP-4 outcome markets.
 
     Args:
-        signer: a ``HyperliquidSigner`` (RawKey or OWS). Its ``address`` is the
-            account that holds positions and signs orders.
+        signer: a ``HyperliquidSigner`` (RawKey or OWS). It signs orders and
+            user actions.
         is_mainnet: True for ``api.hyperliquid.xyz``, False for testnet.
         base_url: override the API host (defaults by ``is_mainnet``).
         vault_address: optional sub-account/vault to trade on behalf of.
+        main_address: account-of-record for reads. Defaults to the signer
+            address for raw-key parity. In the recommended delegated setup,
+            instantiate the venue with the main key for ``approve_agent`` /
+            builder-fee approvals, then instantiate a separate agent-key venue
+            with ``main_address`` set to the main account for trading and
+            position/balance/order reads. Keep one venue instance per key and
+            avoid concurrent ``place_order`` calls on the same instance.
     """
 
     venue = "hyperliquid"
@@ -55,10 +62,12 @@ class HyperliquidVenue:
         is_mainnet: bool = True,
         base_url: Optional[str] = None,
         vault_address: Optional[str] = None,
+        main_address: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT,
     ):
         self._signer = signer
-        self.address = signer.address
+        self.signer_address = signer.address
+        self.address = main_address or signer.address
         self.is_mainnet = is_mainnet
         self.base_url = base_url or (MAINNET_API_URL if is_mainnet else TESTNET_API_URL)
         self.vault_address = vault_address
@@ -99,6 +108,7 @@ class HyperliquidVenue:
         tif: str = "Gtc",
         reduce_only: bool = False,
         cloid: Optional[str] = None,
+        builder: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Place a HIP-4 order.
 
@@ -112,13 +122,22 @@ class HyperliquidVenue:
             tif: "Gtc" (resting), "Ioc", or "Alo" (post-only).
             reduce_only: only reduce an existing position.
             cloid: optional client order id (hex string).
+            builder: optional Hyperliquid builder attribution object. It is
+                included in the signed action, not attached after signing.
 
         Returns the parsed ``/exchange`` response. On a resting order the
         ``oid`` is under ``response.data.statuses[i]``.
         """
         asset = outcome_asset_id(outcome_id, side)
         action = build_order_action(
-            asset, is_buy, limit_px, size, reduce_only=reduce_only, tif=tif, cloid=cloid
+            asset,
+            is_buy,
+            limit_px,
+            size,
+            reduce_only=reduce_only,
+            tif=tif,
+            cloid=cloid,
+            builder=builder,
         )
         nonce = now_ms()
         signature = self._signer.sign_l1_action(

--- a/simmer_sdk/venue_adapter.py
+++ b/simmer_sdk/venue_adapter.py
@@ -31,7 +31,7 @@ class VenueAdapter(Protocol):
     #: Stable venue identifier, e.g. "hyperliquid".
     venue: str
 
-    #: The address that signs and holds positions for this adapter instance.
+    #: The account-of-record address for default reads on this adapter instance.
     address: str
 
     def place_order(

--- a/tests/test_hyperliquid_client_integration.py
+++ b/tests/test_hyperliquid_client_integration.py
@@ -7,6 +7,7 @@ import pytest
 from simmer_sdk.client import SimmerClient
 
 TEST_KEY = "0x" + "33" * 32
+MAIN_ADDR = "0x" + "cd" * 20
 
 
 def test_venue_registered():
@@ -45,6 +46,14 @@ def test_hyperliquid_testnet_env(monkeypatch):
     monkeypatch.setenv("SIMMER_HYPERLIQUID_TESTNET", "1")
     c = SimmerClient(api_key="test", private_key=TEST_KEY)
     assert c.hyperliquid.is_mainnet is False
+
+
+def test_hyperliquid_main_address_env(monkeypatch):
+    pytest.importorskip("hyperliquid", reason="requires the [hyperliquid] extra")
+    monkeypatch.setenv("SIMMER_HYPERLIQUID_MAIN_ADDRESS", MAIN_ADDR)
+    c = SimmerClient(api_key="test", private_key=TEST_KEY)
+    assert c.hyperliquid.address == MAIN_ADDR
+    assert c.hyperliquid.signer_address != MAIN_ADDR
 
 
 def test_hyperliquid_property_without_signer_raises(monkeypatch):

--- a/tests/test_hyperliquid_signing.py
+++ b/tests/test_hyperliquid_signing.py
@@ -62,6 +62,17 @@ def test_build_order_action_wire_shape():
     assert wire["t"] == {"limit": {"tif": "Gtc"}}
 
 
+def test_build_order_action_includes_builder():
+    asset = outcome_asset_id(173, "yes")
+    builder = {"b": "0x" + "12" * 20, "f": 10}
+
+    action = build_order_action(
+        asset, is_buy=True, limit_px=0.05, sz=10.0, builder=builder
+    )
+
+    assert action["builder"] == builder
+
+
 def test_build_cancel_action_shape():
     asset = outcome_asset_id(173, "yes")
     action = build_cancel_action(asset, oid=12345)

--- a/tests/test_hyperliquid_venue.py
+++ b/tests/test_hyperliquid_venue.py
@@ -14,6 +14,7 @@ from simmer_sdk.venue_adapter import VenueAdapter
 
 TEST_KEY = "0x" + "22" * 32
 TEST_ADDR = Account.from_key(TEST_KEY).address
+MAIN_ADDR = "0x" + "ab" * 20
 
 
 class _FakeResp:
@@ -41,6 +42,15 @@ def test_conforms_to_venue_adapter_protocol(monkeypatch):
     assert isinstance(v, VenueAdapter)
     assert v.venue == "hyperliquid"
     assert v.address == TEST_ADDR
+    assert v.signer_address == TEST_ADDR
+
+
+def test_main_address_override_sets_account_of_record():
+    v = HyperliquidVenue(
+        RawKeyHyperliquidSigner(TEST_KEY), is_mainnet=True, main_address=MAIN_ADDR
+    )
+    assert v.signer_address == TEST_ADDR
+    assert v.address == MAIN_ADDR
 
 
 def test_place_order_posts_signed_action(monkeypatch):
@@ -57,6 +67,24 @@ def test_place_order_posts_signed_action(monkeypatch):
     assert set(body["signature"]) == {"r", "s", "v"}
     assert body["nonce"] > 0
     assert out["response"]["data"]["statuses"][0]["resting"]["oid"] == 999
+
+
+def test_place_order_posts_signed_action_with_builder(monkeypatch):
+    calls = []
+    builder = {"b": "0x" + "12" * 20, "f": 10}
+    v = _venue(monkeypatch, calls, {"status": "ok", "response": {"type": "order"}})
+
+    v.place_order(
+        size=10.0,
+        limit_px=0.05,
+        is_buy=True,
+        outcome_id=173,
+        side="yes",
+        builder=builder,
+    )
+
+    (_, body) = calls[0]
+    assert body["action"]["builder"] == builder
 
 
 def test_exchange_error_status_raises(monkeypatch):
@@ -96,6 +124,28 @@ def test_get_positions_extracts_asset_positions(monkeypatch):
     state = {"assetPositions": [{"position": {"coin": "#1730", "szi": "5.0"}}], "marginSummary": {}}
     v = _venue(monkeypatch, [], state)
     assert v.get_positions() == state["assetPositions"]
+
+
+def test_reads_default_to_main_address(monkeypatch):
+    calls = []
+    state = {"assetPositions": [], "marginSummary": {}}
+
+    def _fake_post(url, json=None, timeout=None):
+        calls.append((url, json))
+        return _FakeResp(200, state)
+
+    monkeypatch.setattr("simmer_sdk.hyperliquid_venue.requests.post", _fake_post)
+    v = HyperliquidVenue(
+        RawKeyHyperliquidSigner(TEST_KEY), is_mainnet=True, main_address=MAIN_ADDR
+    )
+
+    v.get_positions()
+    v.get_balances()
+    v.get_open_orders()
+
+    assert calls[0][1] == {"type": "clearinghouseState", "user": MAIN_ADDR}
+    assert calls[1][1] == {"type": "clearinghouseState", "user": MAIN_ADDR}
+    assert calls[2][1] == {"type": "openOrders", "user": MAIN_ADDR}
 
 
 def test_get_balances_parses_margin_summary(monkeypatch):


### PR DESCRIPTION
## Summary
- add HyperliquidVenue main_address account-of-record support while preserving signer_address
- pass builder through build_order_action/place_order so attribution is inside the signed action
- document/env-wire the delegated main-key + agent-key lifecycle and update venue protocol wording

## Tests
- python3 -m pytest tests/test_hyperliquid_signing.py tests/test_hyperliquid_venue.py tests/test_hyperliquid_client_integration.py

Closes SIM-3810