### PR TITLE
ci: trigger docs example bind after SDK publish

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -128,6 +128,65 @@ jobs:
       - name: Publish to PyPI (OIDC trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  docs-example-bind:
+    name: Re-run docs SDK example bind
+    needs: [plan, publish-sdk]
+    if: needs.plan.outputs.pypi_publish_needed == 'true' && needs.publish-sdk.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Dispatch and monitor simmer-docs SDK Example Bind
+        env:
+          GH_TOKEN: ${{ secrets.SIMMER_DOCS_DISPATCH_TOKEN }}
+          SDK_VERSION: ${{ needs.plan.outputs.pypi_repo_version }}
+          SDK_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "SIMMER_DOCS_DISPATCH_TOKEN is required to trigger SpartanLabsXyz/simmer-docs"
+            exit 1
+          fi
+
+          started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          gh api repos/SpartanLabsXyz/simmer-docs/dispatches \
+            --method POST \
+            -f event_type=simmer-sdk-published \
+            -F client_payload[sdk_version]="$SDK_VERSION" \
+            -F client_payload[sdk_sha]="$SDK_SHA" \
+            -F client_payload[sdk_repo]="$GITHUB_REPOSITORY"
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            run_id="$(gh api 'repos/SpartanLabsXyz/simmer-docs/actions/workflows/sdk-example-bind.yml/runs?event=repository_dispatch&branch=main&per_page=10' \
+              --jq ".workflow_runs[] | select(.created_at >= \"$started_at\") | .id" | head -n 1)"
+            if [ -n "$run_id" ]; then
+              break
+            fi
+            sleep 10
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "Timed out waiting for simmer-docs SDK Example Bind workflow to start"
+            exit 1
+          fi
+
+          echo "Monitoring simmer-docs SDK Example Bind run $run_id"
+          for _ in $(seq 1 60); do
+            status="$(gh api "repos/SpartanLabsXyz/simmer-docs/actions/runs/$run_id" --jq .status)"
+            conclusion="$(gh api "repos/SpartanLabsXyz/simmer-docs/actions/runs/$run_id" --jq '.conclusion // ""')"
+            if [ "$status" = "completed" ]; then
+              if [ "$conclusion" = "success" ]; then
+                exit 0
+              fi
+              echo "simmer-docs SDK Example Bind concluded: $conclusion"
+              exit 1
+            fi
+            sleep 10
+          done
+
+          echo "Timed out waiting for simmer-docs SDK Example Bind run $run_id"
+          exit 1
+
   verify:
     name: Verify registries caught up
     needs: [plan, publish-mcp, publish-sdk]


### PR DESCRIPTION
## Summary
- After a PyPI SDK publish, dispatch simmer-docs SDK Example Bind with the published SDK version.
- Monitor the remote docs workflow and fail the SDK publish run if the docs gate fails or never starts.
- Require SIMMER_DOCS_DISPATCH_TOKEN for cross-repo dispatch/read access.

## Verification
- python3 -m pytest scripts/test_check_skill_examples.py -q
- python3 -m py_compile scripts/check_skill_examples.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-packages.yml"); puts "ok"'\n- Python 3.11 venv: pip install -e . pytest, run checker self-test, run scripts/check_skill_examples.py skills/ README.md\n\nPaired with SpartanLabsXyz/simmer-docs PR for the dispatch receiver and floor/latest matrix.\n\nCloses SIM-3458