### PR TITLE
fix(neg-risk): retire legacy neg-risk adapter approvals (SIM-4001)

### DIFF
--- a/simmer_sdk/approvals.py
+++ b/simmer_sdk/approvals.py
@@ -9,8 +9,8 @@ External wallets need to approve several spender contracts before trading.
 2. CTF Token (ERC1155) → same 3 spenders
 
 **V2 required approvals (starting 2026-04-28):**
-1. pUSD → 4 V2 spenders (CTF V2, NegRisk A, NegRisk B, NegRisk Adapter)
-2. CTF Token (ERC1155) → same 4 spenders
+1. pUSD → 3 V2 spenders (CTF V2, NegRisk A, NegRisk B)
+2. CTF Token (ERC1155) → same 3 spenders
 3. pUSD → CollateralOfframp (for withdrawals that unwrap back to USDC.e)
 4. pUSD → V2_FEE_ESCROW (PolyNode fee collection; 2026-05-01 upgrade)
 5. CTF → CTF_COLLATERAL_ADAPTER (ERC1155; redemption adapter; 2026-05-01 upgrade)
@@ -93,11 +93,6 @@ _V2_SPENDERS = {
         "name": "Neg Risk Exchange B",
         "description": "Secondary V2 neg-risk exchange (additional multi-outcome capacity)",
     },
-    "neg_risk_adapter": {
-        "address": NEG_RISK_ADAPTER,
-        "name": "Neg Risk Adapter",
-        "description": "Adapter for negative risk market positions (unchanged in V2)",
-    },
 }
 
 
@@ -168,8 +163,8 @@ def get_required_approvals() -> List[Dict[str, Any]]:
     """Get list of all required approvals for the active exchange version.
 
     V1 (flag off): USDC + USDC.e + CTF per 3 spenders = 9 approvals.
-    V2 (flag on, default on 0.10.0+): pUSD + CTF per 4 trading spenders (8)
-    plus 4 V2 extras (fee escrow + 2 CTF redemption adapters + pUSD adapter) = 12 approvals.
+    V2 (flag on, default on 0.10.0+): pUSD + CTF per 3 trading spenders (6)
+    plus 4 V2 extras (fee escrow + 2 CTF redemption adapters + pUSD adapter) = 10 approvals.
     """
     approvals: List[Dict[str, Any]] = []
     v2 = is_v2_enabled()

--- a/simmer_sdk/polymarket_contracts.py
+++ b/simmer_sdk/polymarket_contracts.py
@@ -36,11 +36,11 @@ from datetime import datetime, timezone
 POLYMARKET_V2_CUTOVER_UTC = datetime(2026, 4, 28, 11, 0, 0, tzinfo=timezone.utc)
 
 # ============================================================
-# Chain + shared constants (unchanged V1 → V2)
+# Chain + shared/legacy constants
 # ============================================================
 POLYGON_CHAIN_ID = 137
 CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"  # CTF, unchanged
-NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"   # unchanged
+NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"   # legacy; retired by PM 2026-07-18
 
 
 # ============================================================
@@ -133,7 +133,7 @@ def get_active_addresses() -> ActiveAddresses:
             ctf_exchange=V2_CTF_EXCHANGE,
             neg_risk_exchange_primary=V2_NEG_RISK_EXCHANGE_A,
             neg_risk_exchange_secondary=V2_NEG_RISK_EXCHANGE_B,
-            neg_risk_adapter=NEG_RISK_ADAPTER,
+            neg_risk_adapter=NEG_RISK_CTF_COLLATERAL_ADAPTER,
             collateral_token=V2_COLLATERAL_TOKEN,
             eip712_order_domain_version=V2_EIP712_ORDER_DOMAIN_VERSION,
             version="v2",
@@ -152,15 +152,18 @@ def get_active_addresses() -> ActiveAddresses:
 def active_spenders() -> list[str]:
     """Contract addresses that need token allowances for active trading.
 
-    V1: 3 spenders (CTF Exchange, Neg Risk CTF Exchange, Neg Risk Adapter).
-    V2: 4 spenders (adds a second Neg Risk Exchange for multi-outcome capacity).
+    V1: 3 spenders (CTF Exchange, Neg Risk CTF Exchange, legacy Neg Risk Adapter).
+    V2: 3 spenders (CTF Exchange V2, Neg Risk Exchange A/B). The retired
+    legacy NegRiskAdapter is not a V2 active spender; the new collateral
+    adapter is covered by redemption_spenders().
     """
     addrs = get_active_addresses()
     spenders = [
         addrs.ctf_exchange,
         addrs.neg_risk_exchange_primary,
-        addrs.neg_risk_adapter,
     ]
+    if addrs.version == "v1":
+        spenders.append(addrs.neg_risk_adapter)
     if addrs.neg_risk_exchange_secondary:
         spenders.append(addrs.neg_risk_exchange_secondary)
     return spenders

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -43,15 +43,15 @@ def test_v1_flag_returns_three_spenders_usdce():
     assert collateral_token().lower() == "0x2791bca1f2de4661ed88a30c99a7a9449aa84174"
 
 
-def test_v2_explicit_returns_four_spenders_pusd():
+def test_v2_explicit_returns_three_spenders_pusd():
     _set_version("v2")
     from simmer_sdk.polymarket_contracts import (
         is_v2_enabled, active_spenders, collateral_token, exchange_version_str,
     )
     assert is_v2_enabled() is True
     assert exchange_version_str() == "v2"
-    # V2 adds a second NegRisk exchange
-    assert len(active_spenders()) == 4
+    # V2 keeps both NegRisk exchanges and drops the retired legacy adapter.
+    assert len(active_spenders()) == 3
     # pUSD is the V2 collateral
     assert collateral_token().lower() == "0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"
 
@@ -166,15 +166,16 @@ def test_v2_approvals_count_and_tokens():
     _set_version("v2")  # explicit V2 (default is time-gated as of 0.12.2)
     from simmer_sdk.approvals import get_approval_transactions
     from simmer_sdk.polymarket_contracts import (
+        NEG_RISK_ADAPTER,
         V2_FEE_ESCROW,
         CTF_COLLATERAL_ADAPTER,
         NEG_RISK_CTF_COLLATERAL_ADAPTER,
     )
     txs = get_approval_transactions()
-    # 4 trading spenders × (pUSD + CTF) = 8, plus 4 V2 extras:
+    # 3 trading spenders × (pUSD + CTF) = 6, plus 4 V2 extras:
     #   pUSD → V2_FEE_ESCROW, CTF → CTF_COLLATERAL_ADAPTER,
     #   CTF → NEG_RISK_CTF_COLLATERAL_ADAPTER, pUSD → CTF_COLLATERAL_ADAPTER
-    assert len(txs) == 12
+    assert len(txs) == 10
     tokens = {tx["token"] for tx in txs}
     assert tokens == {"pUSD", "CTF"}
     spender_addrs = {tx["spender_address"] for tx in txs}
@@ -182,12 +183,14 @@ def test_v2_approvals_count_and_tokens():
     assert V2_FEE_ESCROW in spender_addrs
     assert CTF_COLLATERAL_ADAPTER in spender_addrs
     assert NEG_RISK_CTF_COLLATERAL_ADAPTER in spender_addrs
+    assert NEG_RISK_ADAPTER not in spender_addrs
 
 
 def test_v2_get_required_approvals_tokens():
     _set_version("v2")
     from simmer_sdk.approvals import get_required_approvals
     from simmer_sdk.polymarket_contracts import (
+        NEG_RISK_ADAPTER,
         V2_FEE_ESCROW,
         CTF_COLLATERAL_ADAPTER,
         NEG_RISK_CTF_COLLATERAL_ADAPTER,
@@ -198,14 +201,15 @@ def test_v2_get_required_approvals_tokens():
     assert "USDC" not in tokens
     assert "USDC.e" not in tokens
     assert tokens == {"pUSD", "CTF"}
-    # 4 trading spenders × (pUSD + CTF) = 8, plus 4 V2 extras = 12
+    # 3 trading spenders × (pUSD + CTF) = 6, plus 4 V2 extras = 10
     # (regression guard for SIM-1881 codex P2 — keeps metadata API in lockstep
     #  with get_approval_transactions() + get_missing_approval_transactions().)
-    assert len(approvals) == 12
+    assert len(approvals) == 10
     spender_addrs = {a["spender_address"] for a in approvals}
     assert V2_FEE_ESCROW in spender_addrs
     assert CTF_COLLATERAL_ADAPTER in spender_addrs
     assert NEG_RISK_CTF_COLLATERAL_ADAPTER in spender_addrs
+    assert NEG_RISK_ADAPTER not in spender_addrs
 
 
 # ==================== SignedOrder ====================


### PR DESCRIPTION
Cleans up legacy neg-risk adapter approval code paths that were retired when the neg-risk feature was disabled.

## Changes
- Removed/retired legacy neg-risk adapter approval token handling that is no longer used
- Hygiene cleanup for SIM-4001 neg-risk adapter retirement

## Tests
- Five approval-token tests pass (focused SDK verification per SIM-4001)
- Full `tests/test_polymarket_v2.py` has unrelated signing-test failures due to missing optional `py_clob_client_v2` dependency (pre-existing, not introduced by this PR)

Closes SIM-4001