### PR TITLE
fix: add SimmerClient readonly constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **`SimmerClient.readonly()` for validation and status probes.** The default
+  live Polymarket constructor still auto-processes pending external-wallet
+  risk exits by design, because the server cannot sign for self-custody users.
+  New `readonly()` construction skips that init-time risk-exit path and guards
+  order/risk-exit submission methods, so API-key checks, preflight, and status
+  scripts can inspect account state without submitting orders. The bundled
+  preflight skill and SDK status scripts now use the readonly path.
+
 ## [0.22.3] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - **`get_market_by_id()` no longer swallows errors.** Previously every exception — timeouts, connection failures, rate limits, server errors — was caught and returned as `None`, indistinguishable from "market not found". Agents polling a market saw its `status`/`outcome`/`resolves_at` appear to flip to null whenever a call transiently failed, which looked like unstable API data. Now `None` is returned **only** on HTTP 404 (the market genuinely doesn't exist); all other failures raise the underlying `requests` exception so callers can retry. If your code relied on the old silent-`None` behavior, wrap the call in `try/except requests.exceptions.RequestException`. (SIM-4025)
->>>>>>> origin/main
 
 ## [0.22.3] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,16 @@ client = SimmerClient(api_key="sk_live_...", venue="sim")
 # Real trading on Polymarket
 client = SimmerClient(api_key="sk_live_...", venue="polymarket")
 
+# Read-only validation/status client. Does not process constructor-time risk exits.
+client = SimmerClient.readonly(api_key="sk_live_...", venue="polymarket")
+
 # Override venue for a single trade
 client.trade(market_id, side="yes", amount=10.0, venue="polymarket")
 ```
 
 `TRADING_VENUE` environment variable is read at client init — OpenClaw skills use this to select venue at startup without code changes.
+
+> **Constructor side effect:** for live Polymarket clients with `WALLET_PRIVATE_KEY` or `OWS_WALLET`, regular `SimmerClient(...)` construction checks pending risk alerts and may submit stop-loss/take-profit exit orders. This is intentional for self-custody safety: Simmer's server cannot sign those exits. Use `SimmerClient.readonly(...)` for API-key validation, preflight/status checks, and other non-trading paths.
 
 > **Spread caveat:** $SIM fills instantly (AMM, no spread). Real venues have orderbook spreads of 2–5%. Target edges >5% in $SIM before graduating to real money.
 
@@ -217,6 +222,7 @@ print(report["summary"]["pnl"], report["summary"]["hit_rate"])
 | `link_wallet()` | Link external EVM wallet for Polymarket |
 | `set_approvals()` | Set Polymarket token approvals |
 | `activate_polymarket_dw(agent_id=None)` | Set Polymarket Deposit Wallet on-chain CLOB approvals — user-primary (no arg) or per-agent (`agent_id=...`). See note. |
+| `readonly()` | Constructor for validation/status clients that must not process constructor-time risk exits or submit orders |
 | `troubleshoot()` | Look up any error and get a fix (no auth required) |
 
 > **Per-agent wallets (Elite tier):** activating a per-agent (Elite dedicated) wallet takes **two** calls, approvals first: `activate_polymarket_dw(agent_id=...)` sets the deposit wallet's on-chain CLOB approvals, then `update_agent_wallet_creds(...)` caches the CLOB creds. OWS callers use `update_agent_wallet_creds(ows_wallet_name="...")`; raw-key callers with `WALLET_PRIVATE_KEY` use `update_agent_wallet_creds(agent_id="...")`. **Both approvals and cached creds are required before trading** — caching creds alone does not set on-chain allowances, so trades fail at the relayer with "insufficient allowance". See the `simmer-wallet-setup` skill for the full flow. (`set_approvals()` is the user-primary EOA path and is a no-op for per-agent deposit wallets.)

--- a/mcp/bundled-skills/preflight/preflight.py
+++ b/mcp/bundled-skills/preflight/preflight.py
@@ -66,7 +66,7 @@ def run(
         return 2
 
     try:
-        client = SimmerClient(api_key=api_key, venue=_venue)
+        client = SimmerClient.readonly(api_key=api_key, venue=_venue)
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 2

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -685,7 +685,7 @@ class SimmerClient:
         return cls(api_key=api_key, ows_wallet=name, **kwargs)
 
     def _assert_not_readonly(self, method: str) -> None:
-        if self._readonly:
+        if getattr(self, "_readonly", False):
             raise RuntimeError(
                 f"SimmerClient.readonly() cannot call {method} because it may "
                 "submit orders or mutate account state. Construct a regular "

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -255,6 +255,7 @@ class SimmerClient:
         live: bool = True,
         starting_balance: float = 10_000.0,
         _ignore_env_wallets: bool = False,
+        _readonly: bool = False,
     ):
         """
         Initialize the Simmer client.
@@ -281,6 +282,9 @@ class SimmerClient:
                 realistic P&L. Positions auto-settle when markets resolve.
             starting_balance: Virtual starting capital for paper trading
                 (default: 10,000). Only used when live=False.
+            _readonly: Internal flag used by SimmerClient.readonly(). Read-only
+                clients preserve venue/read behavior but never auto-process
+                risk exits or submit orders.
             private_key: Optional EVM wallet private key for Polymarket trading.
                 When provided, orders are signed locally instead of server-side.
                 This enables trading with your own Polymarket wallet.
@@ -324,6 +328,7 @@ class SimmerClient:
             venue = "sim"
 
         self.api_key = api_key
+        self._readonly = _readonly
         # base_url resolution: explicit arg > SIMMER_API_URL env > production.
         # Additive (SIM-3070): lets harnesses redirect unmodified skills.
         if base_url is None:
@@ -532,8 +537,16 @@ class SimmerClient:
                 venue, starting_balance
             )
 
-        # Auto-process risk alerts on init (external wallets only)
-        if self.live and (self._private_key or self._ows_wallet) and venue in ("polymarket",):
+        # Auto-process risk alerts on init (external wallets only). This is the
+        # default safety net for live self-custody agents; SimmerClient.readonly()
+        # opts out explicitly for validation/probe paths that must never submit
+        # orders as a construction side effect.
+        if (
+            not self._readonly
+            and self.live
+            and (self._private_key or self._ows_wallet)
+            and venue in ("polymarket",)
+        ):
             try:
                 self._process_risk_alerts()
             except Exception as e:
@@ -594,6 +607,36 @@ class SimmerClient:
         return cls(api_key=api_key, **kwargs)
 
     @classmethod
+    def readonly(cls, api_key: Optional[str] = None, **kwargs) -> "SimmerClient":
+        """Construct a client for validation and read-only API paths.
+
+        ``readonly()`` preserves normal venue selection and read endpoint
+        behavior, but it disables constructor-time risk-exit processing and
+        rejects order and risk-exit submission calls. Use this for API-key
+        checks, status probes, and preflight-style validation where
+        construction must not submit orders.
+
+        Args:
+            api_key: Optional SDK API key. If omitted, reads ``SIMMER_API_KEY``.
+            **kwargs: Optional keyword arguments forwarded to ``__init__``
+                (e.g. ``venue``, ``base_url``, ``live``).
+
+        Raises:
+            RuntimeError: If no API key is provided and ``SIMMER_API_KEY`` is
+                unset or empty.
+        """
+        if api_key is None:
+            api_key = os.environ.get("SIMMER_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "No api_key provided and SIMMER_API_KEY environment variable "
+                "is not set. Get an API key at simmer.markets/dashboard → SDK "
+                "tab, then either pass api_key=... or export SIMMER_API_KEY."
+            )
+        kwargs["_readonly"] = True
+        return cls(api_key=api_key, **kwargs)
+
+    @classmethod
     def with_ows_wallet(
         cls,
         name: str,
@@ -640,6 +683,14 @@ class SimmerClient:
                 "tab, then either pass api_key=... or export SIMMER_API_KEY."
             )
         return cls(api_key=api_key, ows_wallet=name, **kwargs)
+
+    def _assert_not_readonly(self, method: str) -> None:
+        if self._readonly:
+            raise RuntimeError(
+                f"SimmerClient.readonly() cannot call {method} because it may "
+                "submit orders or mutate account state. Construct a regular "
+                "SimmerClient for trading."
+            )
 
     def _validate_and_set_wallet(self, private_key: str) -> None:
         """Validate private key format and derive wallet address."""
@@ -867,6 +918,7 @@ class SimmerClient:
 
         If alerts is provided, processes those directly. Otherwise fetches from /api/sdk/risk-alerts.
         """
+        self._assert_not_readonly("_process_risk_alerts()")
         if alerts is None:
             try:
                 response = self._request("GET", "/api/sdk/risk-alerts")
@@ -888,6 +940,20 @@ class SimmerClient:
             alert_venue = alert.get("venue")  # None for legacy alerts — falls back to client default
 
             try:
+                fresh_shares = self._risk_exit_fresh_shares(market_id, side, alert_venue)
+                if fresh_shares is None or fresh_shares <= 0:
+                    print(
+                        f"[SimmerSDK] Risk exit skipped for {market_id[:8]}... {side}: "
+                        "no matching live Polymarket position"
+                    )
+                    continue
+                if fresh_shares < shares:
+                    print(
+                        f"[SimmerSDK] Risk exit size adjusted for {market_id[:8]}... {side}: "
+                        f"alert={shares:.5f}, live_position={fresh_shares:.5f}"
+                    )
+                    shares = fresh_shares
+
                 # 1. Cancel open orders on this market (Polymarket only — token_id based)
                 if token_id:
                     self._cancel_orders_for_token(token_id)
@@ -921,6 +987,46 @@ class SimmerClient:
                 print(f"[SimmerSDK] Risk exit failed for {market_id[:8]}... {side}: {e}")
                 # Alert persists in Redis — will retry next cycle
 
+    def _risk_exit_fresh_shares(
+        self,
+        market_id: str,
+        side: str,
+        alert_venue: Optional[str],
+    ) -> Optional[float]:
+        """Return fresh held shares for a risk exit, or None if it is unsafe.
+
+        Risk alerts are async and can be stale. Before signing a sell, re-read
+        live positions and confirm the alert still matches a Polymarket holding.
+        """
+        if alert_venue not in (None, "polymarket"):
+            logger.warning(
+                "Risk exit alert for %s %s has unsupported venue=%r",
+                market_id,
+                side,
+                alert_venue,
+            )
+            return None
+
+        try:
+            positions = self.get_positions(venue="polymarket")
+        except Exception as exc:
+            logger.warning(
+                "Risk exit position re-check failed for %s %s: %s",
+                market_id,
+                side,
+                exc,
+            )
+            return None
+
+        for pos in positions:
+            if getattr(pos, "market_id", None) != market_id:
+                continue
+            if getattr(pos, "venue", None) not in (None, "polymarket"):
+                continue
+            shares = getattr(pos, f"shares_{side}", 0) or 0
+            return float(shares)
+        return None
+
     def get_briefing(self, since: str = None, process_risk_alerts: bool = True,
                      skill_versions: dict = None) -> dict:
         """Fetch the agent briefing and optionally process any triggered risk alerts.
@@ -952,6 +1058,7 @@ class SimmerClient:
         # Process triggered risk alerts if present and requested
         triggered = response.get("triggered_risk_alerts")
         if process_risk_alerts and triggered and self._private_key:
+            self._assert_not_readonly("get_briefing(process_risk_alerts=True)")
             self._process_risk_alerts(alerts=triggered)
 
         # Log skill update nudges
@@ -1295,6 +1402,8 @@ class SimmerClient:
 
         Returns the dry-run plan, or ``{status, tx_hash, rfq_id}`` on a fill.
         """
+        if not dry_run:
+            self._assert_not_readonly("place_combo(dry_run=False)")
         from simmer_sdk import combo as _combo
 
         if len(leg_position_ids) < 2:
@@ -2094,6 +2203,7 @@ class SimmerClient:
             client = SimmerClient(api_key="sk_live_...", venue="kalshi")
             result = client.trade(market_id, "yes", 10.0)  # Signs locally with Solana key
         """
+        self._assert_not_readonly("trade()")
         effective_venue = venue or self.venue
         if effective_venue not in self.VENUES:
             raise ValueError(f"Invalid venue '{effective_venue}'. Must be one of: {self.VENUES}")
@@ -3771,6 +3881,7 @@ class SimmerClient:
             # Stop-loss only
             client.set_monitor("market-id", "no", stop_loss_pct=0.30)
         """
+        self._assert_not_readonly("set_monitor()")
         payload: Dict[str, Any] = {"side": side}
         if stop_loss_pct is not None:
             payload["stop_loss_pct"] = stop_loss_pct
@@ -3808,6 +3919,7 @@ class SimmerClient:
         Example:
             client.delete_monitor("market-id", "yes")
         """
+        self._assert_not_readonly("delete_monitor()")
         return self._request("DELETE", f"/api/sdk/positions/{market_id}/monitor", params={"side": side})
 
     # ==========================================
@@ -4137,6 +4249,7 @@ class SimmerClient:
                     result = client.redeem(p['market_id'], p['redeemable_side'])
                     print(f"Redeemed: {result['tx_hash']}")
         """
+        self._assert_not_readonly("redeem()")
         # External + DW dispatch (added 0.17.0). Position lives on the deposit
         # wallet contract, so msg.sender of the redeem call must be the DW.
         # The legacy unsigned-tx path (returned for non-DW external wallets)
@@ -4354,6 +4467,7 @@ class SimmerClient:
                 else:
                     print(f"Failed {r['market_id']} {r['side']}: {r['error']}")
         """
+        self._assert_not_readonly("auto_redeem()")
         results = []
 
         # Refresh auto_redeem + cohort cache from /agents/me (5-min TTL, shared
@@ -4477,6 +4591,7 @@ class SimmerClient:
             )
             print(f"Created alert {alert['id']}")
         """
+        self._assert_not_readonly("create_alert()")
         return self._request("POST", "/api/sdk/alerts", json={
             "market_id": market_id,
             "side": side,

--- a/skills/polymarket-copytrading/scripts/status.py
+++ b/skills/polymarket-copytrading/scripts/status.py
@@ -27,7 +27,7 @@ def get_client(api_key: str):
             print("Error: simmer-sdk not installed. Run: pip install simmer-sdk")
             sys.exit(1)
         venue = os.environ.get("TRADING_VENUE", "polymarket")
-        _client = SimmerClient(api_key=api_key, venue=venue)
+        _client = SimmerClient.readonly(api_key=api_key, venue=venue)
     return _client
 
 def api_request(api_key: str, endpoint: str) -> dict:

--- a/skills/polymarket-weather-trader/scripts/status.py
+++ b/skills/polymarket-weather-trader/scripts/status.py
@@ -31,7 +31,7 @@ def main():
         sys.exit(1)
 
     try:
-        client = SimmerClient.from_env()
+        client = SimmerClient.readonly()
     except Exception as e:
         print(f"Error: {e}")
         print("   Set SIMMER_API_KEY or get your key from: https://simmer.markets/dashboard")

--- a/skills/preflight/preflight.py
+++ b/skills/preflight/preflight.py
@@ -66,7 +66,7 @@ def run(
         return 2
 
     try:
-        client = SimmerClient(api_key=api_key, venue=_venue)
+        client = SimmerClient.readonly(api_key=api_key, venue=_venue)
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 2

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -117,6 +117,78 @@ def test_from_env_forwards_kwargs(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# readonly()
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_skips_constructor_risk_exits_for_live_polymarket_wallet(monkeypatch):
+    """readonly() construction must not fetch/process pending risk exits."""
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", "0x" + "a" * 64)
+    monkeypatch.setattr(
+        "simmer_sdk.client.SimmerClient._validate_and_set_wallet",
+        lambda self, key: setattr(self, "_wallet_address", "0x" + "1" * 40),
+    )
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+
+    called = []
+
+    def fail_if_called(self, alerts=None):
+        called.append(alerts)
+        raise AssertionError("readonly construction processed risk alerts")
+
+    monkeypatch.setattr(
+        "simmer_sdk.client.SimmerClient._process_risk_alerts",
+        fail_if_called,
+    )
+
+    client = SimmerClient.readonly(api_key="sk_live_test", venue="polymarket")
+
+    assert client.venue == "polymarket"
+    assert client._readonly is True
+    assert called == []
+
+
+def test_default_constructor_still_processes_risk_exits_for_live_polymarket_wallet(monkeypatch):
+    """The external-wallet safety net stays default-on for regular clients."""
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", "0x" + "a" * 64)
+    monkeypatch.setattr(
+        "simmer_sdk.client.SimmerClient._validate_and_set_wallet",
+        lambda self, key: setattr(self, "_wallet_address", "0x" + "1" * 40),
+    )
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+
+    called = []
+    monkeypatch.setattr(
+        "simmer_sdk.client.SimmerClient._process_risk_alerts",
+        lambda self, alerts=None: called.append(alerts),
+    )
+
+    client = SimmerClient(api_key="sk_live_test", venue="polymarket")
+
+    assert client._readonly is False
+    assert called == [None]
+
+
+def test_readonly_rejects_trade_calls(monkeypatch):
+    """A readonly client should fail closed if accidentally used to trade."""
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+
+    client = SimmerClient.readonly(api_key="sk_live_test")
+
+    with pytest.raises(RuntimeError, match="readonly"):
+        client.trade("market-id", "yes", amount=1.0)
+
+
+# ---------------------------------------------------------------------------
 # with_ows_wallet()
 # ---------------------------------------------------------------------------
 

--- a/tests/test_risk_alerts.py
+++ b/tests/test_risk_alerts.py
@@ -1,0 +1,85 @@
+from simmer_sdk.client import Position, SimmerClient
+
+
+def _client(monkeypatch):
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+    return SimmerClient(api_key="sk_test", venue="polymarket")
+
+
+def _position(market_id="m1", *, yes=0.0, no=0.0, venue="polymarket"):
+    return Position(
+        market_id=market_id,
+        question="Question?",
+        shares_yes=yes,
+        shares_no=no,
+        current_value=0.0,
+        pnl=0.0,
+        status="active",
+        venue=venue,
+    )
+
+
+def test_risk_alert_skips_trade_when_position_recheck_finds_no_matching_position(monkeypatch):
+    client = _client(monkeypatch)
+    monkeypatch.setattr(client, "get_positions", lambda venue=None: [])
+
+    trades = []
+    monkeypatch.setattr(client, "trade", lambda **kwargs: trades.append(kwargs))
+
+    client._process_risk_alerts(alerts=[{
+        "market_id": "m1",
+        "side": "yes",
+        "shares": 10,
+        "exit_reason": "stop_loss",
+        "venue": "polymarket",
+    }])
+
+    assert trades == []
+
+
+def test_risk_alert_rechecks_position_and_caps_sell_size_to_live_shares(monkeypatch):
+    client = _client(monkeypatch)
+    monkeypatch.setattr(
+        client,
+        "get_positions",
+        lambda venue=None: [_position(yes=3.25)],
+    )
+
+    trades = []
+    monkeypatch.setattr(client, "trade", lambda **kwargs: trades.append(kwargs) or {"success": True})
+    monkeypatch.setattr(client, "delete_monitor", lambda market_id, side: None)
+    monkeypatch.setattr(client, "_request", lambda *args, **kwargs: {})
+
+    client._process_risk_alerts(alerts=[{
+        "market_id": "m1",
+        "side": "yes",
+        "shares": 10,
+        "exit_reason": "stop_loss",
+        "venue": "polymarket",
+    }])
+
+    assert len(trades) == 1
+    assert trades[0]["shares"] == 3.25
+    assert trades[0]["venue"] == "polymarket"
+
+
+def test_risk_alert_skips_non_polymarket_alerts(monkeypatch):
+    client = _client(monkeypatch)
+
+    trades = []
+    monkeypatch.setattr(client, "trade", lambda **kwargs: trades.append(kwargs))
+
+    client._process_risk_alerts(alerts=[{
+        "market_id": "m1",
+        "side": "yes",
+        "shares": 10,
+        "exit_reason": "stop_loss",
+        "venue": "sim",
+    }])
+
+    assert trades == []


### PR DESCRIPTION
## Summary
- add `SimmerClient.readonly()` for validation/status clients that must not process constructor-time risk exits
- keep default live Polymarket constructor risk-exit processing unchanged
- re-check live Polymarket position/venue consistency before risk-alert exits submit sells
- move preflight/status skill paths onto readonly construction

## Verification
- `python3 -m py_compile simmer_sdk/client.py skills/preflight/preflight.py mcp/bundled-skills/preflight/preflight.py skills/polymarket-copytrading/scripts/status.py skills/polymarket-weather-trader/scripts/status.py tests/test_client_constructors.py tests/test_risk_alerts.py`
- `python3 -m pytest tests/test_client_constructors.py tests/test_risk_alerts.py skills/preflight/tests/test_preflight.py`
- `python3 -m pytest mcp/bundled-skills/preflight/tests/test_preflight.py`

Closes SIM-4020