### PR TITLE
fix(client): get_market_by_id raises on transient errors, None only on 404 (SIM-4025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-17
+
+### Changed
+
+- **`get_market_by_id()` no longer swallows errors.** Previously every exception — timeouts, connection failures, rate limits, server errors — was caught and returned as `None`, indistinguishable from "market not found". Agents polling a market saw its `status`/`outcome`/`resolves_at` appear to flip to null whenever a call transiently failed, which looked like unstable API data. Now `None` is returned **only** on HTTP 404 (the market genuinely doesn't exist); all other failures raise the underlying `requests` exception so callers can retry. If your code relied on the old silent-`None` behavior, wrap the call in `try/except requests.exceptions.RequestException`. (SIM-4025)
+
 ## [0.22.3] - 2026-07-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.22.3"
+version = "0.23.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2824,16 +2824,26 @@ class SimmerClient:
             market_id: Market ID
 
         Returns:
-            Market object or None if not found
+            Market object, or None if the market does not exist (HTTP 404).
+
+        Raises:
+            requests.exceptions.RequestException: on timeouts, connection
+                failures, rate limits, or server errors. Before 0.23.0 these
+                were swallowed and returned as None — indistinguishable from
+                "market not found", which made transient network failures look
+                like markets losing their status/outcome fields. Catch and
+                retry these; only a None return means the market doesn't exist.
         """
         try:
             data = self._request("GET", f"/api/sdk/markets/{market_id}")
-            m = data.get("market")
-            if not m:
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 404:
                 return None
-            return self._parse_market(m)
-        except Exception:
+            raise
+        m = data.get("market")
+        if not m:
             return None
+        return self._parse_market(m)
 
     def find_markets(self, query: str) -> List[Market]:
         """
@@ -3175,7 +3185,13 @@ class SimmerClient:
         if self._looks_like_polymarket_condition_id(market_id):
             return market_id
 
-        market = self.get_market_by_id(market_id)
+        # Transport errors fall through to the context lookup below —
+        # get_market_by_id raises on transient failures since 0.23.0, but this
+        # resolver has a second source and should keep trying it.
+        try:
+            market = self.get_market_by_id(market_id)
+        except requests.exceptions.RequestException:
+            market = None
         if market and market.polymarket_condition_id:
             return market.polymarket_condition_id
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -3185,12 +3185,14 @@ class SimmerClient:
         if self._looks_like_polymarket_condition_id(market_id):
             return market_id
 
-        # Transport errors fall through to the context lookup below —
+        # Fetch/parse errors fall through to the context lookup below —
         # get_market_by_id raises on transient failures since 0.23.0, but this
-        # resolver has a second source and should keep trying it.
+        # resolver has a second source and should keep trying it. Broad catch
+        # is deliberate: a malformed payload (parse KeyError) should also fall
+        # through, matching the pre-0.23.0 fallback semantics.
         try:
             market = self.get_market_by_id(market_id)
-        except requests.exceptions.RequestException:
+        except Exception:
             market = None
         if market and market.polymarket_condition_id:
             return market.polymarket_condition_id

--- a/skills/simmer-skill-builder/references/example-llm-oracle.md
+++ b/skills/simmer-skill-builder/references/example-llm-oracle.md
@@ -150,7 +150,13 @@ def apply_longshot_correction(raw_prob):
 def evaluate_and_trade(market_id, raw_prob, confidence, side, reasoning, live=False):
     """Apply bias correction, size, and execute if edge survives."""
     client = get_client(live=live)
-    market = client.get_market_by_id(market_id)
+    try:
+        market = client.get_market_by_id(market_id)
+    except Exception as e:
+        # SDK >=0.23.0 raises on transient errors (timeout/5xx/429) instead of
+        # returning None — skip this market and let the next cycle retry.
+        print(f"  Market {market_id} fetch failed ({e}), skipping")
+        return None
     if not market:
         print(f"  Market {market_id} not found")
         return None

--- a/skills/simmer-skill-builder/references/simmer-api.md
+++ b/skills/simmer-skill-builder/references/simmer-api.md
@@ -40,7 +40,9 @@ markets = client.get_markets(venue="polymarket", limit=20)
 # Filter by tags (ALL-match, comma-separated)
 markets = client.get_markets(tags="world-cup", limit=50)
 
-# Get single market
+# Get single market. Returns None ONLY if the market doesn't exist (404).
+# SDK >=0.23.0: transient errors (timeout/5xx/429) raise instead of returning
+# None — wrap in try/except and retry if your loop must survive network blips.
 market = client.get_market_by_id("uuid")
 ```
 

--- a/tests/test_get_market_by_id_errors.py
+++ b/tests/test_get_market_by_id_errors.py
@@ -19,7 +19,6 @@ from simmer_sdk.client import SimmerClient
 
 def _make_client():
     client = SimmerClient.__new__(SimmerClient)
-    client.base_url = "https://api.simmer.markets"
     client._request = MagicMock()
     return client
 
@@ -103,3 +102,17 @@ def test_condition_id_resolver_falls_back_to_context_on_transport_error():
     condition_id = client._resolve_polymarket_condition_id("m1")
 
     assert condition_id == "0x" + "ab" * 32
+
+
+def test_condition_id_resolver_falls_back_to_context_on_parse_error():
+    """A malformed 200 body (parse KeyError) must also fall through to the
+    context lookup, matching pre-0.23.0 fallback semantics."""
+    client = _make_client()
+    client.get_market_by_id = MagicMock(side_effect=KeyError("question"))
+    client.get_market_context = MagicMock(
+        return_value={"market": {"polymarket_condition_id": "0x" + "cd" * 32}}
+    )
+
+    condition_id = client._resolve_polymarket_condition_id("m1")
+
+    assert condition_id == "0x" + "cd" * 32

--- a/tests/test_get_market_by_id_errors.py
+++ b/tests/test_get_market_by_id_errors.py
@@ -1,0 +1,105 @@
+"""get_market_by_id error semantics (SIM-4025, 0.23.0).
+
+Before 0.23.0 the method swallowed every exception and returned None, so a
+network timeout or transient 5xx was indistinguishable from "market not
+found". A user polling a resolved market saw its status/outcome fields
+"intermittently go null" when calls silently failed. Since 0.23.0:
+
+- HTTP 404               -> None (market genuinely doesn't exist)
+- timeout / 5xx / 429    -> raises (caller can retry)
+- 200 with market body   -> parsed Market
+"""
+
+import pytest
+import requests
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_client():
+    client = SimmerClient.__new__(SimmerClient)
+    client.base_url = "https://api.simmer.markets"
+    client._request = MagicMock()
+    return client
+
+
+def _http_error(status_code):
+    response = MagicMock()
+    response.status_code = status_code
+    return requests.exceptions.HTTPError(response=response)
+
+
+def test_returns_market_on_success():
+    client = _make_client()
+    client._request.return_value = {
+        "market": {
+            "id": "m1",
+            "question": "Resolved?",
+            "status": "resolved",
+            "current_probability": 0.0,
+            "outcome": False,
+            "resolves_at": "2026-06-30 01:00:00Z",
+        }
+    }
+
+    market = client.get_market_by_id("m1")
+
+    assert market is not None
+    assert market.status == "resolved"
+    assert market.outcome is False
+    assert market.resolves_at == "2026-06-30 01:00:00Z"
+
+
+def test_returns_none_on_404():
+    client = _make_client()
+    client._request.side_effect = _http_error(404)
+
+    assert client.get_market_by_id("missing") is None
+
+
+def test_raises_on_server_error():
+    client = _make_client()
+    client._request.side_effect = _http_error(500)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        client.get_market_by_id("m1")
+
+
+def test_raises_on_rate_limit():
+    client = _make_client()
+    client._request.side_effect = _http_error(429)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        client.get_market_by_id("m1")
+
+
+def test_raises_on_timeout():
+    client = _make_client()
+    client._request.side_effect = requests.exceptions.Timeout("timed out")
+
+    with pytest.raises(requests.exceptions.Timeout):
+        client.get_market_by_id("m1")
+
+
+def test_returns_none_on_empty_market_body():
+    client = _make_client()
+    client._request.return_value = {"market": None}
+
+    assert client.get_market_by_id("m1") is None
+
+
+def test_condition_id_resolver_falls_back_to_context_on_transport_error():
+    """_resolve_polymarket_condition_id keeps its second source when the
+    market fetch fails transiently."""
+    client = _make_client()
+    client.get_market_by_id = MagicMock(
+        side_effect=requests.exceptions.ConnectionError("boom")
+    )
+    client.get_market_context = MagicMock(
+        return_value={"market": {"polymarket_condition_id": "0x" + "ab" * 32}}
+    )
+
+    condition_id = client._resolve_polymarket_condition_id("m1")
+
+    assert condition_id == "0x" + "ab" * 32


### PR DESCRIPTION
## What

`get_market_by_id()` wrapped everything in `try/except Exception: return None` — so timeouts, connection failures, 429s, and 5xxs were returned as `None`, indistinguishable from "market not found".

Live impact (SIM-4024): user yue/lu-bing-ops polled resolved markets and saw `status/outcome/resolves_at` "intermittently go null", concluding our API was unstable. The live API was 100% consistent (8/8 verification calls); the nulls were swallowed client-side transport failures.

## Change

- `None` returned **only** on HTTP 404
- All other failures raise the underlying `requests` exception (caller retries)
- `_resolve_polymarket_condition_id` keeps its second-source fallback by catching `RequestException` at that call site
- Version 0.22.3 → **0.23.0** (behavior change; changelog carries a migration note for callers relying on silent-None)

## Tests

- New `tests/test_get_market_by_id_errors.py`: 404→None, 500/429/timeout→raise, success parse, empty body, resolver fallback
- Full suite: 547 passed; 3 pre-existing OWS-env constructor failures reproduce identically on clean main (local OWS wallet absent — not CI-affecting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYDiq8cZYqdcouCVSqVNeS