### PR TITLE
fix(weather-trader): extend FAK→GTC override to cover FOK order type

### DIFF
--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Added `EGLC` (London City Airport) to the international station coordinate map so Polymarket London weather markets that cite the official London City station can route to Open-Meteo instead of fail-closing as an unsupported station. This does not change markets whose Simmer/SDK metadata lacks usable `resolution_criteria`; those still fail closed.
+- `order_type=FOK` (Fill Or Kill) is now overridden to GTC, the same way `FAK` has been since v1.20.0. Weather markets are structurally illiquid — both FOK and FAK orders are cancelled immediately with no fill, creating a retry-loop that burns attempts on every run. The warning message now names the actual configured type (`FAK` or `FOK`) so it's actionable.
 
 ## [1.22.2] - 2026-05-24
 

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -64,7 +64,7 @@ CONFIG_SCHEMA = {
     "slippage_max":      {"env": "SIMMER_WEATHER_SLIPPAGE_MAX",      "default": 0.15,  "type": float},
     "min_liquidity":     {"env": "SIMMER_WEATHER_MIN_LIQUIDITY",     "default": 0.0,   "type": float},
     "order_type":        {"env": "SIMMER_WEATHER_ORDER_TYPE",        "default": "GTC", "type": str,
-                          "help": "Order type: GTC (default, limit order that waits for fill) or FAK (cancel if not filled immediately). FAK is automatically overridden to GTC because weather markets are structurally illiquid — FAK orders are rejected immediately with no fill."},
+                          "help": "Order type: GTC (default, limit order that waits for fill), FAK, or FOK (cancel if not filled immediately). FAK and FOK are automatically overridden to GTC because weather markets are structurally illiquid — immediate-cancel orders are rejected with no fill."},
     "vol_targeting":     {"env": "SIMMER_WEATHER_VOL_TARGETING",     "default": False, "type": bool,
                           "help": "Enable volatility targeting: scale position sizes by target_vol / realized_vol."},
     "target_vol":        {"env": "SIMMER_WEATHER_TARGET_VOL",        "default": 0.20,  "type": float,
@@ -95,13 +95,14 @@ _config = load_config(CONFIG_SCHEMA, __file__, slug="polymarket-weather-trader")
 
 NOAA_API_BASE = "https://api.weather.gov"
 _configured_order_type = (_config.get("order_type") or "GTC").upper()
-if _configured_order_type == "FAK":
-    # FAK (Fill And Kill) fails on weather markets because liquidity is structurally
-    # thin — the order gets cancelled immediately with no fill. Force GTC so limit
-    # orders queue on the book and wait for a counterparty. Users who set
-    # SIMMER_WEATHER_ORDER_TYPE=FAK or order_type=FAK in config.json get this override.
+if _configured_order_type in ("FAK", "FOK"):
+    # FAK (Fill And Kill) and FOK (Fill Or Kill) both fail on weather markets because
+    # liquidity is structurally thin — the order gets cancelled immediately with no fill.
+    # Force GTC so limit orders queue on the book and wait for a counterparty. Users who
+    # set SIMMER_WEATHER_ORDER_TYPE=FAK/FOK or order_type=FAK/FOK in config.json get
+    # this override.
     print(
-        "[weather-trader] WARNING: order_type=FAK is not suitable for weather markets "
+        f"[weather-trader] WARNING: order_type={_configured_order_type} is not suitable for weather markets "
         "(thin liquidity → immediate cancel). Overriding to GTC. "
         "Set SIMMER_WEATHER_ORDER_TYPE=GTC to silence this warning."
     )


### PR DESCRIPTION
Agent `d724c0f0` racked up 57 benign FOK-order failures on a single weather market in 6.5 hours (July 17) — 29 at \$0.24 and 28 at \$0.20. Weather markets are structurally illiquid; FOK orders cancel immediately with no fill, exactly like FAK. The existing FAK→GTC override didn't catch FOK.

## Changes
- `skills/polymarket-weather-trader/weather_trader.py`: extend `if _configured_order_type == "FAK"` to `in ("FAK", "FOK")`; make warning message dynamic so it prints the actual configured type
- `skills/polymarket-weather-trader/CHANGELOG.md`: add Unreleased entry

## Tests
- No skill harness changes; logic change is a single `==` → `in (...)` at module load
- Covered by inspection: FAK path still overrides, FOK now overrides the same way, GTC/any other value untouched
- Not user-facing in the trade-outcome sense — this only prevents agents with `order_type=FOK` from sending doomed orders to thin-book weather markets

Closes SIM-4069