### PR TITLE
feat: add AXI response output modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Agent-ergonomic SDK output modes (SIM-4047).** `get_markets()`,
+  `get_positions()`, and `get_trades()` now support opt-in
+  `response_mode="summary"`/`"compact"` output with minimal default fields,
+  definitive empty-state messages, and optional `include_hints=True` next-step
+  suggestions. `response_mode="toon"` also emits a TOON string for token-light
+  agent transcripts. `TradeResult` now carries additive `error_code`,
+  `error_hint`, and `next_steps` fields for common failure paths without
+  changing existing success/error semantics.
+
 - **`SimmerClient.readonly()` for validation and status probes.** The default
   live Polymarket constructor still auto-processes pending external-wallet
   risk exits by design, because the server cannot sign for self-custody users.

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1838,11 +1838,16 @@ class SimmerClient:
     def _structured_error(message: Optional[str]) -> Dict[str, str]:
         text = (message or "Unknown error").strip()
         lower = text.lower()
-        if "market_id" in lower or "market not found" in lower or "not found" in lower:
+        # Order matters: match the MOST SPECIFIC subject first. A bare
+        # "not found" test must never run before the position/agent/skill
+        # checks, or it swallows them — agents act on `hint`, so mislabelling
+        # "position not found" as market_not_found sends them to get_markets()
+        # when the real fix is get_positions().
+        if "position" in lower and ("not found" in lower or "no " in lower or "missing" in lower):
             return {
-                "code": "market_not_found",
+                "code": "position_not_found",
                 "message": text,
-                "hint": "Call get_markets(q=..., response_mode='summary') and retry with a returned market id.",
+                "hint": "Call get_positions(response_mode='summary') to confirm held shares before selling.",
             }
         if "insufficient" in lower and ("balance" in lower or "fund" in lower):
             return {
@@ -1862,11 +1867,18 @@ class SimmerClient:
                 "message": text,
                 "hint": "Refresh the market with get_market_by_id() or retry with a less aggressive price/size.",
             }
-        if "position" in lower and ("no " in lower or "missing" in lower):
+        # Market check last among the specific buckets, and deliberately narrow:
+        # "market not found" / "market_id", NOT a bare "not found" (which also
+        # matches agent/skill/order errors that need a different next step).
+        if (
+            "market not found" in lower
+            or "market_id" in lower
+            or ("market" in lower and "not found" in lower)
+        ):
             return {
-                "code": "position_not_found",
+                "code": "market_not_found",
                 "message": text,
-                "hint": "Call get_positions(response_mode='summary') to confirm held shares before selling.",
+                "hint": "Call get_markets(q=..., response_mode='summary') and retry with a returned market id.",
             }
         return {
             "code": "request_failed",

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -10,7 +10,7 @@ import sys
 import time
 import logging
 import requests
-from typing import Optional, List, Dict, Any, Callable
+from typing import Optional, List, Dict, Any, Callable, Sequence, Union
 from dataclasses import dataclass
 from urllib.parse import quote, urlparse
 from datetime import datetime, timezone
@@ -137,6 +137,9 @@ class TradeResult:
     order_id: Optional[str] = None  # CLOB order ID for GTC/GTD orders — use with cancel_order()
     retryable: bool = True  # False when server knows retrying is futile (position cleared on-chain)
     fee_rate_bps: Optional[float] = None  # Taker fee rate in basis points (0 on Polymarket today)
+    error_code: Optional[str] = None  # Machine-readable failure bucket.
+    error_hint: Optional[str] = None  # Actionable next step for agents.
+    next_steps: Optional[List[str]] = None  # Optional contextual follow-up hints.
 
     @property
     def shares_filled(self) -> float:
@@ -1810,8 +1813,151 @@ class SimmerClient:
             json=json,
             timeout=timeout or 30
         )
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            message = self._http_error_message(response, exc)
+            error = self._structured_error(message)
+            exc.simmer_error = error
+            exc.error_code = error["code"]
+            exc.error_hint = error["hint"]
+            raise
         return response.json()
+
+    @staticmethod
+    def _http_error_message(response: requests.Response, exc: Exception) -> str:
+        try:
+            body = response.json()
+        except ValueError:
+            body = {}
+        if isinstance(body, dict):
+            return str(body.get("error") or body.get("message") or exc)
+        return str(exc)
+
+    @staticmethod
+    def _structured_error(message: Optional[str]) -> Dict[str, str]:
+        text = (message or "Unknown error").strip()
+        lower = text.lower()
+        if "market_id" in lower or "market not found" in lower or "not found" in lower:
+            return {
+                "code": "market_not_found",
+                "message": text,
+                "hint": "Call get_markets(q=..., response_mode='summary') and retry with a returned market id.",
+            }
+        if "insufficient" in lower and ("balance" in lower or "fund" in lower):
+            return {
+                "code": "insufficient_balance",
+                "message": text,
+                "hint": "Call get_portfolio() to check available balance before retrying with a smaller amount.",
+            }
+        if "unauthorized" in lower or "invalid api key" in lower or "credentials" in lower:
+            return {
+                "code": "credentials_invalid",
+                "message": text,
+                "hint": "Check the SDK API key and wallet credentials, then retry after re-authentication.",
+            }
+        if "liquidity" in lower or "not filled" in lower:
+            return {
+                "code": "no_liquidity",
+                "message": text,
+                "hint": "Refresh the market with get_market_by_id() or retry with a less aggressive price/size.",
+            }
+        if "position" in lower and ("no " in lower or "missing" in lower):
+            return {
+                "code": "position_not_found",
+                "message": text,
+                "hint": "Call get_positions(response_mode='summary') to confirm held shares before selling.",
+            }
+        return {
+            "code": "request_failed",
+            "message": text,
+            "hint": "Inspect the request inputs and retry; use include_hints=True for suggested follow-up calls.",
+        }
+
+    @staticmethod
+    def _normalize_fields(fields: Optional[Union[Sequence[str], str]], defaults: Sequence[str]) -> List[str]:
+        if fields is None:
+            return list(defaults)
+        if isinstance(fields, str):
+            return [part.strip() for part in fields.split(",") if part.strip()]
+        return [str(field) for field in fields]
+
+    @staticmethod
+    def _compact_row(row: Any, fields: Sequence[str]) -> Dict[str, Any]:
+        compact: Dict[str, Any] = {}
+        for field in fields:
+            if isinstance(row, dict):
+                compact[field] = row.get(field)
+            else:
+                compact[field] = getattr(row, field, None)
+        return compact
+
+    @staticmethod
+    def _toon(name: str, rows: Sequence[Dict[str, Any]], fields: Sequence[str]) -> str:
+        lines = [f"{name}[{len(rows)}]{{{','.join(fields)}}}:"]
+        for row in rows:
+            values = []
+            for field in fields:
+                value = row.get(field)
+                if isinstance(value, str):
+                    value = '"' + value.replace('"', '\\"') + '"'
+                elif value is None:
+                    value = "null"
+                values.append(str(value))
+            lines.append("  " + ",".join(values))
+        return "\n".join(lines)
+
+    @classmethod
+    def _list_response(
+        cls,
+        *,
+        name: str,
+        items: Sequence[Any],
+        response_mode: Optional[str],
+        fields: Optional[Union[Sequence[str], str]],
+        default_fields: Sequence[str],
+        total: Optional[int] = None,
+        empty_message: str,
+        include_hints: bool = False,
+        hints: Optional[List[str]] = None,
+    ) -> Any:
+        if response_mode in (None, "full"):
+            return list(items)
+        if response_mode not in ("summary", "compact", "toon"):
+            raise ValueError("response_mode must be one of: full, summary, compact, toon")
+
+        selected_fields = cls._normalize_fields(fields, default_fields)
+        compact_items = [cls._compact_row(item, selected_fields) for item in items]
+        count = len(compact_items)
+        resolved_total = count if total is None else total
+        message = (
+            empty_message
+            if count == 0
+            else f"Showing {count} of {resolved_total} {name}."
+        )
+        envelope: Dict[str, Any] = {
+            name: compact_items,
+            "count": count,
+            "total": resolved_total,
+            "message": message,
+        }
+        if response_mode == "toon":
+            envelope["format"] = "toon"
+            envelope["toon"] = cls._toon(name, compact_items, selected_fields)
+        if include_hints:
+            envelope["next_steps"] = hints or []
+        return envelope
+
+    @staticmethod
+    def _trade_next_steps(result: TradeResult) -> List[str]:
+        if result.success:
+            steps = ["Call get_positions(response_mode='summary') to verify exposure."]
+            if result.order_id:
+                steps.append(f"Call cancel_order('{result.order_id}') if you need to cancel the open order.")
+            return steps
+        if result.error_hint:
+            return [result.error_hint]
+        return ["Inspect result.error_code/result.error_hint before retrying the trade."]
 
     def _get_auto_redeem_positions_response(self) -> Optional[Dict[str, Any]]:
         """Fetch resolved positions for auto_redeem with one timeout-only retry.
@@ -1848,7 +1994,10 @@ class SimmerClient:
         venue: Optional[str] = None,
         sort: Optional[str] = None,
         tags: Optional[str] = None,
-    ) -> List[Market]:
+        response_mode: Optional[str] = None,
+        fields: Optional[Union[Sequence[str], str]] = None,
+        include_hints: bool = False,
+    ) -> Any:
         """
         Get available markets.
 
@@ -1875,6 +2024,12 @@ class SimmerClient:
             tags: Comma-separated tag filter (e.g. "world-cup" or "weather,crypto").
                 Keyword-only. Returns markets carrying ALL specified tags. Like ``q``,
                 applied before the result window.
+            response_mode: Optional output wrapper. ``None``/``"full"`` preserves
+                the historical ``List[Market]`` return. ``"summary"``/``"compact"``
+                returns a compact dict with counts and an explicit empty message;
+                ``"toon"`` also includes a TOON string.
+            fields: Compact-mode fields. Defaults to id, question, status, venue.
+            include_hints: Add ``next_steps`` suggestions to compact/TOON output.
 
         Note:
             Unfiltered browse (no ``q``/``tags``) is capped and windowed server-side,
@@ -1904,8 +2059,21 @@ class SimmerClient:
             params["tags"] = tags
 
         data = self._request("GET", "/api/sdk/markets", params=params)
-
-        return [self._parse_market(m) for m in data.get("markets", [])]
+        markets = [self._parse_market(m) for m in data.get("markets", [])]
+        return self._list_response(
+            name="markets",
+            items=markets,
+            response_mode=response_mode,
+            fields=fields,
+            default_fields=("id", "question", "status", "import_source"),
+            total=data.get("total") or data.get("total_count"),
+            empty_message="No markets matched your filters.",
+            include_hints=include_hints,
+            hints=[
+                "Broaden q/tags or pass sort='volume' to find liquid markets.",
+                "Use get_market_by_id(market_id) for full details before trading.",
+            ],
+        )
 
     def get_candles(
         self,
@@ -2112,7 +2280,9 @@ class SimmerClient:
         source: Optional[str] = None,
         skill_slug: Optional[str] = None,
         allow_rebuy: bool = False,
-        signal_data: Optional[dict] = None
+        signal_data: Optional[dict] = None,
+        *,
+        include_hints: bool = False,
     ) -> TradeResult:
         """
         Execute a trade on a market.
@@ -2158,6 +2328,8 @@ class SimmerClient:
                 confidence (float 0-1), signal_source (string). Skill-specific
                 fields are freeform. Example: {"edge": 0.15, "confidence": 0.8,
                 "signal_source": "noaa", "forecast_temp": 35}
+            include_hints: Populate ``next_steps`` and structured error hints on
+                the returned TradeResult.
 
         Returns:
             TradeResult with execution details
@@ -2271,6 +2443,21 @@ class SimmerClient:
                     f"shares rounds to {shares} — too small to place an order"
                 )
 
+        def _failure_result(error: str, skip_reason: Optional[str] = None) -> TradeResult:
+            structured = self._structured_error(error)
+            result = TradeResult(
+                success=False,
+                market_id=market_id,
+                side=side,
+                error=error,
+                skip_reason=skip_reason,
+                error_code=structured["code"],
+                error_hint=structured["hint"],
+            )
+            if include_hints:
+                result.next_steps = self._trade_next_steps(result)
+            return result
+
         # Paper trading: simulate with real prices (no live API calls)
         if not self.live:
             return self._paper_trade(
@@ -2282,12 +2469,9 @@ class SimmerClient:
             held = self._get_held_markets()
             if market_id in held:
                 logger.debug("Rebuy skipped on %s: already hold position", market_id)
-                return TradeResult(
-                    success=False,
-                    market_id=market_id,
-                    side=side,
-                    error="Already hold position on this market. Pass allow_rebuy=True to override.",
-                    skip_reason="rebuy skipped",
+                return _failure_result(
+                    "Already hold position on this market. Pass allow_rebuy=True to override.",
+                    "rebuy skipped",
                 )
         if action == "buy" and source:
             held = self._get_held_markets()
@@ -2300,12 +2484,9 @@ class SimmerClient:
                         "Cross-skill conflict on %s: my_source=%r, other_sources=%r",
                         market_id, source, other_sources
                     )
-                    return TradeResult(
-                        success=False,
-                        market_id=market_id,
-                        side=side,
-                        error=f"Cross-skill conflict: {other_sources} already hold position on this market",
-                        skip_reason="conflicts skipped",
+                    return _failure_result(
+                        f"Cross-skill conflict: {other_sources} already hold position on this market",
+                        "conflicts skipped",
                     )
                 # Same-skill rebuy: already hold from this source
                 if not allow_rebuy and source in market_sources:
@@ -2313,12 +2494,9 @@ class SimmerClient:
                         "Rebuy skipped on %s: already hold position from source=%r",
                         market_id, source
                     )
-                    return TradeResult(
-                        success=False,
-                        market_id=market_id,
-                        side=side,
-                        error=f"Already hold position on this market (source: {source}). Pass allow_rebuy=True to override.",
-                        skip_reason="rebuy skipped",
+                    return _failure_result(
+                        f"Already hold position on this market (source: {source}). Pass allow_rebuy=True to override.",
+                        "rebuy skipped",
                     )
 
         # Validate price if provided
@@ -2428,7 +2606,9 @@ class SimmerClient:
         def _build_result(d):
             _pos = d.get("position") or {}
             _bal = _pos.get("sim_balance") if effective_venue == "sim" else None
-            return TradeResult(
+            _error = d.get("error")
+            _structured = self._structured_error(_error) if _error else {}
+            result = TradeResult(
                 success=d.get("success", False),
                 trade_id=d.get("trade_id"),
                 market_id=d.get("market_id", market_id),
@@ -2441,12 +2621,17 @@ class SimmerClient:
                 cost=d.get("cost", 0),
                 new_price=d.get("new_price", 0),
                 balance=_bal,
-                error=d.get("error"),
+                error=_error,
                 fill_status=d.get("fill_status", "unknown"),
                 order_id=d.get("order_id"),
                 retryable=d.get("retryable", True),
                 fee_rate_bps=d.get("fee_rate_bps"),
+                error_code=d.get("error_code") or _structured.get("code"),
+                error_hint=d.get("error_hint") or d.get("hint") or _structured.get("hint"),
             )
+            if include_hints:
+                result.next_steps = self._trade_next_steps(result)
+            return result
 
         result = _build_result(data)
 
@@ -2808,7 +2993,15 @@ class SimmerClient:
         self._position_holder_ts = _t.time()
         return positions
 
-    def get_positions(self, venue: Optional[str] = None, source: Optional[str] = None) -> List[Position]:
+    def get_positions(
+        self,
+        venue: Optional[str] = None,
+        source: Optional[str] = None,
+        *,
+        response_mode: Optional[str] = None,
+        fields: Optional[Union[Sequence[str], str]] = None,
+        include_hints: bool = False,
+    ) -> Any:
         """
         Get all positions for this agent.
 
@@ -2818,6 +3011,12 @@ class SimmerClient:
         Args:
             venue: Filter by venue ("sim" or "polymarket"). If None, returns both.
             source: Filter by trade source (e.g., "weather", "copytrading"). Partial match.
+            response_mode: Optional output wrapper. ``None``/``"full"`` preserves
+                the historical ``List[Position]`` return. ``"summary"``/``"compact"``
+                returns a compact dict with counts and an explicit empty message;
+                ``"toon"`` also includes a TOON string.
+            fields: Compact-mode fields. Defaults to market_id, venue, status, pnl.
+            include_hints: Add ``next_steps`` suggestions to compact/TOON output.
 
         Returns:
             List of Position objects with P&L info
@@ -2832,11 +3031,48 @@ class SimmerClient:
             self._settle_paper_positions()
             paper_positions = self._get_paper_positions()
             if paper_positions:
-                return paper_positions
+                return self._list_response(
+                    name="positions",
+                    items=paper_positions,
+                    response_mode=response_mode,
+                    fields=fields,
+                    default_fields=("market_id", "venue", "status", "pnl"),
+                    empty_message="No open positions matched your filters.",
+                    include_hints=include_hints,
+                    hints=[
+                        "Use get_markets(response_mode='summary') to find tradeable markets.",
+                        "Use trade(market_id=..., side=..., amount=...) to open a position.",
+                    ],
+                )
             if self.venue == "sim" and (venue is None or venue in ("sim", "all")):
-                return paper_positions
+                return self._list_response(
+                    name="positions",
+                    items=paper_positions,
+                    response_mode=response_mode,
+                    fields=fields,
+                    default_fields=("market_id", "venue", "status", "pnl"),
+                    empty_message="No open positions matched your filters.",
+                    include_hints=include_hints,
+                    hints=[
+                        "Use get_markets(response_mode='summary') to find tradeable markets.",
+                        "Use trade(market_id=..., side=..., amount=...) to open a position.",
+                    ],
+                )
 
-        return self._get_api_positions(venue=venue, source=source)
+        positions = self._get_api_positions(venue=venue, source=source)
+        return self._list_response(
+            name="positions",
+            items=positions,
+            response_mode=response_mode,
+            fields=fields,
+            default_fields=("market_id", "venue", "status", "pnl"),
+            empty_message="No open positions matched your filters.",
+            include_hints=include_hints,
+            hints=[
+                "Use get_markets(response_mode='summary') to find tradeable markets.",
+                "Use trade(market_id=..., side=..., amount=...) to open a position.",
+            ],
+        )
 
     _HELD_MARKETS_TTL = 30  # seconds
     _HOLDER_CACHE_TTL = 30  # seconds — same as held-markets TTL
@@ -3422,6 +3658,9 @@ class SimmerClient:
         since: Optional[str] = None,
         until: Optional[str] = None,
         include_failed: bool = False,
+        response_mode: Optional[str] = None,
+        fields: Optional[Union[Sequence[str], str]] = None,
+        include_hints: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
         Get trade history across venues.
@@ -3445,6 +3684,13 @@ class SimmerClient:
                 trade_failure_taxonomy) and ``failure_reason`` (a sanitized
                 human-readable message — never contains raw API responses).
                 superseded rows are always excluded. Default: False.
+            response_mode: Optional output wrapper. ``None``/``"full"`` preserves
+                the historical response dict with additive ``message`` metadata.
+                ``"summary"``/``"compact"`` returns only selected trade fields;
+                ``"toon"`` also includes a TOON string.
+            fields: Compact-mode trade fields. Defaults to trade_id, side, venue,
+                status, cost.
+            include_hints: Add ``next_steps`` suggestions.
 
         Returns:
             Dict containing:
@@ -3497,7 +3743,34 @@ class SimmerClient:
             params["until"] = until
         if include_failed:
             params["include_failed"] = "true"
-        return self._request("GET", "/api/sdk/trades", params=params)
+        data = self._request("GET", "/api/sdk/trades", params=params)
+        trades = list(data.get("trades") or [])
+        total = data.get("total_count", len(trades))
+        if response_mode in (None, "full"):
+            data.setdefault(
+                "message",
+                "No trades matched your filters." if not trades else f"Showing {len(trades)} of {total} trades.",
+            )
+            if include_hints:
+                data["next_steps"] = [
+                    "Use get_positions(response_mode='summary') to compare current exposure.",
+                    "Pass include_failed=True to inspect failed/cancelled trade attempts.",
+                ]
+            return data
+        return self._list_response(
+            name="trades",
+            items=trades,
+            response_mode=response_mode,
+            fields=fields,
+            default_fields=("trade_id", "side", "venue", "status", "cost"),
+            total=total,
+            empty_message="No trades matched your filters.",
+            include_hints=include_hints,
+            hints=[
+                "Use get_positions(response_mode='summary') to compare current exposure.",
+                "Pass include_failed=True to inspect failed/cancelled trade attempts.",
+            ],
+        )
 
     def get_outcomes(
         self,

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2028,7 +2028,7 @@ class SimmerClient:
                 the historical ``List[Market]`` return. ``"summary"``/``"compact"``
                 returns a compact dict with counts and an explicit empty message;
                 ``"toon"`` also includes a TOON string.
-            fields: Compact-mode fields. Defaults to id, question, status, venue.
+            fields: Compact-mode fields. Defaults to id, question, status, import_source.
             include_hints: Add ``next_steps`` suggestions to compact/TOON output.
 
         Note:

--- a/tests/test_axi_response_output.py
+++ b/tests/test_axi_response_output.py
@@ -141,3 +141,49 @@ def test_trade_result_structures_common_failure_with_hint():
     assert result.error_code == "market_not_found"
     assert "get_markets" in result.error_hint
     assert result.next_steps == [result.error_hint]
+
+
+# ---------------------------------------------------------------------------
+# _structured_error branch ordering (CTO review, SIM-4047)
+# ---------------------------------------------------------------------------
+# Agents ACT on error_hint, so a mislabelled bucket routes them to the wrong
+# recovery call. The original ordering tested a bare "not found" first, which
+# shadowed position/agent/skill errors into market_not_found.
+
+import pytest
+from simmer_sdk.client import SimmerClient
+
+
+@pytest.mark.parametrize("message,expected_code", [
+    # position errors must NOT be swallowed by the market branch
+    ("position not found", "position_not_found"),
+    ("Position not found for this market", "position_not_found"),
+    ("No position found for this market", "position_not_found"),
+    ("Missing position", "position_not_found"),
+    # genuine market errors
+    ("Market not found", "market_not_found"),
+    ("market_id is required", "market_not_found"),
+    ("Unknown market not found in catalog", "market_not_found"),
+    # unrelated subjects must fall through to the generic bucket, not market
+    ("Agent not found", "request_failed"),
+    ("Skill not found", "request_failed"),
+    ("Order not found", "request_failed"),
+    # other buckets unchanged
+    ("Insufficient balance", "insufficient_balance"),
+    ("insufficient funds for this trade", "insufficient_balance"),
+    ("Unauthorized", "credentials_invalid"),
+    ("Invalid API key", "credentials_invalid"),
+    ("No liquidity available", "no_liquidity"),
+    ("Order not filled", "no_liquidity"),
+    ("", "request_failed"),
+    (None, "request_failed"),
+])
+def test_structured_error_buckets_by_most_specific_subject(message, expected_code):
+    assert SimmerClient._structured_error(message)["code"] == expected_code
+
+
+def test_structured_error_hint_points_at_the_matching_recovery_call():
+    """The hint must name the call that actually resolves that bucket."""
+    assert "get_positions" in SimmerClient._structured_error("position not found")["hint"]
+    assert "get_markets" in SimmerClient._structured_error("Market not found")["hint"]
+    assert "get_portfolio" in SimmerClient._structured_error("Insufficient balance")["hint"]

--- a/tests/test_axi_response_output.py
+++ b/tests/test_axi_response_output.py
@@ -1,0 +1,143 @@
+"""AXI response ergonomics for agent-facing SDK calls (SIM-4047)."""
+
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+
+
+def _client() -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client._request = MagicMock()
+    client._assert_not_readonly = MagicMock()
+    client._get_held_markets = MagicMock(return_value={})
+    client._agent_id = "agent-1"
+    client._ows_wallet = None
+    client._wallet_address = None
+    client._private_key = None
+    client._held_markets_cache = None
+    client.live = True
+    client.venue = "polymarket"
+    return client
+
+
+def test_get_markets_summary_is_compact_and_definitive_empty_state():
+    client = _client()
+    client._request.return_value = {"markets": [], "total": 0}
+
+    result = client.get_markets(q="unlikely", response_mode="summary", include_hints=True)
+
+    assert result == {
+        "markets": [],
+        "count": 0,
+        "total": 0,
+        "message": "No markets matched your filters.",
+        "next_steps": [
+            "Broaden q/tags or pass sort='volume' to find liquid markets.",
+            "Use get_market_by_id(market_id) for full details before trading.",
+        ],
+    }
+
+
+def test_get_markets_toon_uses_minimal_default_fields():
+    client = _client()
+    client._request.return_value = {
+        "markets": [
+            {
+                "id": "m1",
+                "question": "Will BTC close above 100k?",
+                "status": "active",
+                "current_probability": 0.61,
+                "import_source": "polymarket",
+                "resolution_criteria": "Verbose criteria omitted from compact mode.",
+            }
+        ],
+        "total": 1200,
+    }
+
+    result = client.get_markets(response_mode="toon")
+
+    assert result["count"] == 1
+    assert result["total"] == 1200
+    assert result["markets"] == [
+        {
+            "id": "m1",
+            "question": "Will BTC close above 100k?",
+            "status": "active",
+            "import_source": "polymarket",
+        }
+    ]
+    assert result["format"] == "toon"
+    assert result["toon"].startswith("markets[1]{id,question,status,import_source}:")
+    assert "resolution_criteria" not in result["toon"]
+
+
+def test_get_positions_summary_keeps_default_list_mode_unchanged():
+    client = _client()
+    client._position_holder_cache = {}
+    client._position_holder_ts = 0.0
+    client._paper_portfolio = None
+    client._request.return_value = {
+        "positions": [
+            {
+                "market_id": "m1",
+                "question": "Question",
+                "shares_yes": 2,
+                "shares_no": 0,
+                "current_value": 1.2,
+                "pnl": 0.2,
+                "status": "active",
+                "venue": "polymarket",
+            }
+        ]
+    }
+
+    full = client.get_positions()
+    summary = client.get_positions(response_mode="summary")
+
+    assert full[0].market_id == "m1"
+    assert summary["positions"] == [
+        {"market_id": "m1", "venue": "polymarket", "status": "active", "pnl": 0.2}
+    ]
+
+
+def test_get_trades_adds_message_and_compact_mode():
+    client = _client()
+    client._request.return_value = {
+        "trades": [
+            {
+                "trade_id": "t1",
+                "side": "yes",
+                "venue": "sim",
+                "status": "filled",
+                "cost": 10.0,
+                "shares": 20.0,
+            }
+        ],
+        "total_count": 9,
+    }
+
+    full = client.get_trades()
+    compact = client.get_trades(response_mode="summary", include_hints=True)
+
+    assert full["message"] == "Showing 1 of 9 trades."
+    assert compact["trades"] == [
+        {"trade_id": "t1", "side": "yes", "venue": "sim", "status": "filled", "cost": 10.0}
+    ]
+    assert compact["next_steps"]
+
+
+def test_trade_result_structures_common_failure_with_hint():
+    client = _client()
+    client._request.return_value = {
+        "success": False,
+        "market_id": "bad-market",
+        "side": "yes",
+        "error": "market_id not found",
+    }
+
+    result = client.trade("bad-market", "yes", amount=10, include_hints=True)
+
+    assert result.success is False
+    assert result.error_code == "market_not_found"
+    assert "get_markets" in result.error_hint
+    assert result.next_steps == [result.error_hint]


### PR DESCRIPTION
## Summary
- add opt-in summary/compact/TOON response modes for markets, positions, and trades
- add definitive empty-state messages and optional next-step hints
- add structured TradeResult error_code/error_hint/next_steps fields for common failures

## Verification
- PYTHONPATH=. pytest tests/test_axi_response_output.py tests/test_failed_trade_logging.py tests/test_get_positions_live_false.py -q
- python3 -m py_compile simmer_sdk/client.py

Closes SIM-4047