### PR TITLE
release: simmer-sdk 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-22
+
 ### Added
 
 - **Agent-ergonomic SDK output modes (SIM-4047).** `get_markets()`,
@@ -15,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   agent transcripts. `TradeResult` now carries additive `error_code`,
   `error_hint`, and `next_steps` fields for common failure paths without
   changing existing success/error semantics.
+
+- **Bundled skill fix — `polymarket-weather-trader` FOK orders (SIM-4069).**
+  The FAK→GTC override now also covers `FOK`. Weather markets are structurally
+  illiquid and FOK cancels on no-fill exactly like FAK, so FOK-configured runs
+  were generating benign order failures instead of resting orders.
 
 - **`SimmerClient.readonly()` for validation and status probes.** The default
   live Polymarket constructor still auto-processes pending external-wallet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.23.0"
+version = "0.24.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Cuts a release for three changes already merged to `main` but unpublished — none of the feature PRs bumped the version, so PyPI is still on 0.23.0.

## Included

| Change | PR | Ticket |
|---|---|---|
| AXI agent-ergonomic output modes (`response_mode`, `fields`, `include_hints`) + structured `TradeResult.error_code`/`error_hint`/`next_steps` | #286 | SIM-4047 |
| `SimmerClient.readonly()` for validation and status probes | #282 | — |
| `polymarket-weather-trader` FAK→GTC override extended to FOK | #285 | SIM-4069 |

The AXI merge includes the CTO-review fix (`81aa04d`) that reordered the error classifier — previously a bare `"not found"` in the first branch shadowed the position/agent/skill cases into `market_not_found`, so agents acting on `error_hint` were sent to `get_markets()` when the correct recovery was `get_positions()`.

## Semver

**Minor.** Everything is additive: the new kwargs are opt-in and `response_mode=None` preserves the historical `List[Market]` / `List[Position]` returns, so existing callers see identical behavior.

## Note

Merging publishes to PyPI via OIDC trusted publishing. Verify 0.24.0 is actually live on PyPI before treating any downstream work as unblocked — merge alone is not publication.