### PR TITLE
fix: require skill version bumps in governance

### DIFF
--- a/scripts/check-skill-governance.py
+++ b/scripts/check-skill-governance.py
@@ -46,26 +46,113 @@ def load_json(path: Path) -> dict[str, Any]:
         return json.load(fh)
 
 
-def changed_skill_dirs() -> set[Path]:
+def diff_base_ref() -> str:
     base = os.environ.get("GITHUB_BASE_REF")
     if base:
         base_ref = f"origin/{base}"
         try:
-            merge_base = run_git(["merge-base", "HEAD", base_ref])
-            diff = run_git(["diff", "--name-only", f"{merge_base}..HEAD"])
+            return run_git(["merge-base", "HEAD", base_ref])
         except subprocess.CalledProcessError:
-            diff = run_git(["diff", "--name-only", "HEAD~1..HEAD"])
+            return "HEAD~1"
+
+    return "HEAD~1"
+
+
+def changed_paths() -> list[str]:
+    base_ref = diff_base_ref()
+    if os.environ.get("GITHUB_BASE_REF"):
+        diff = run_git(["diff", "--name-only", f"{base_ref}..HEAD"])
     else:
         diff = run_git(["diff", "--name-only", "--cached"])
         if not diff:
-            diff = run_git(["diff", "--name-only", "HEAD~1..HEAD"])
+            diff = run_git(["diff", "--name-only", f"{base_ref}..HEAD"])
+
+    return [line for line in diff.splitlines() if line]
+
+
+def changed_skill_dirs(paths: list[str] | None = None) -> set[Path]:
+    paths = changed_paths() if paths is None else paths
 
     dirs: set[Path] = set()
-    for line in diff.splitlines():
+    for line in paths:
         parts = Path(line).parts
         if len(parts) >= 2 and parts[0] == "skills":
             dirs.add(SKILLS_DIR / parts[1])
     return dirs
+
+
+def extract_skill_metadata_version(text: str) -> str | None:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    in_metadata = False
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            return None
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        is_indented = line[:1].isspace()
+        if not is_indented:
+            in_metadata = stripped == "metadata:"
+            continue
+
+        if in_metadata:
+            key, sep, value = stripped.partition(":")
+            if sep and key == "version":
+                return value.strip().strip("\"'")
+
+    return None
+
+
+def git_file_at_ref(ref: str, path: str) -> str | None:
+    try:
+        return run_git(["show", f"{ref}:{path}"])
+    except subprocess.CalledProcessError:
+        return None
+
+
+def validate_skill_version_bumps(paths: list[str], base_ref: str) -> list[str]:
+    errors: list[str] = []
+
+    changed_slugs = {
+        Path(path).parts[1]
+        for path in paths
+        if len(Path(path).parts) >= 2 and Path(path).parts[0] == "skills"
+    }
+    for slug in sorted(changed_slugs):
+        skill_md = SKILLS_DIR / slug / "SKILL.md"
+        if not skill_md.exists():
+            continue
+
+        current_version = extract_skill_metadata_version(skill_md.read_text(encoding="utf-8"))
+        if current_version is None:
+            errors.append(
+                f"skills/{slug}/SKILL.md is missing metadata.version; add a skill "
+                "version so ClawHub can publish it"
+            )
+            continue
+
+        previous_text = git_file_at_ref(base_ref, f"skills/{slug}/SKILL.md")
+        previous_version = (
+            extract_skill_metadata_version(previous_text)
+            if previous_text is not None
+            else None
+        )
+
+        if previous_version is None:
+            continue
+
+        if current_version == previous_version:
+            display_version = current_version or "missing"
+            errors.append(
+                f"skills/{slug} changed but SKILL.md metadata.version did not change "
+                f"from {display_version}; bump the skill version so ClawHub can publish it"
+            )
+
+    return errors
 
 
 def pr_has_sensitive_approval_marker() -> bool:
@@ -202,14 +289,18 @@ def main() -> int:
     parser.add_argument("--all", action="store_true", help="check every skills/*/clawhub.json")
     args = parser.parse_args()
 
+    paths = [] if args.all else changed_paths()
+    base_ref = None if args.all else diff_base_ref()
     skill_dirs = (
         {path.parent for path in SKILLS_DIR.glob("*/clawhub.json")}
         if args.all
-        else changed_skill_dirs()
+        else changed_skill_dirs(paths)
     )
     pr_approved = pr_has_sensitive_approval_marker()
 
     errors: list[str] = []
+    if paths and base_ref is not None:
+        errors.extend(validate_skill_version_bumps(paths, base_ref))
     for skill_dir in sorted(skill_dirs):
         errors.extend(validate_skill(skill_dir, pr_approved))
 

--- a/tests/test_skill_governance.py
+++ b/tests/test_skill_governance.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_skill_governance", ROOT / "scripts" / "check-skill-governance.py"
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+check_skill_governance = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = check_skill_governance
+SPEC.loader.exec_module(check_skill_governance)
+
+
+def skill_md(version: str) -> str:
+    return f"""---
+name: weather
+metadata:
+  author: Simmer
+  version: "{version}"
+---
+# Weather
+"""
+
+
+def write_skill(tmp_path: Path, version: str) -> None:
+    skill_dir = tmp_path / "skills" / "weather"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(skill_md(version), encoding="utf-8")
+
+
+def patch_repo(monkeypatch, tmp_path: Path, previous_version: str | None) -> None:
+    monkeypatch.setattr(check_skill_governance, "ROOT", tmp_path)
+    monkeypatch.setattr(check_skill_governance, "SKILLS_DIR", tmp_path / "skills")
+
+    def fake_run_git(args: list[str]) -> str:
+        if args[:1] == ["show"]:
+            if previous_version is None:
+                raise subprocess.CalledProcessError(128, ["git", *args])
+            return skill_md(previous_version)
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(check_skill_governance, "run_git", fake_run_git)
+
+
+def test_skill_file_change_requires_metadata_version_bump(tmp_path, monkeypatch) -> None:
+    write_skill(tmp_path, "1.2.3")
+    patch_repo(monkeypatch, tmp_path, previous_version="1.2.3")
+
+    errors = check_skill_governance.validate_skill_version_bumps(
+        ["skills/weather/weather_trader.py"],
+        "base-ref",
+    )
+
+    assert errors == [
+        "skills/weather changed but SKILL.md metadata.version did not change from 1.2.3; "
+        "bump the skill version so ClawHub can publish it"
+    ]
+
+
+def test_skill_file_change_allows_metadata_version_bump(tmp_path, monkeypatch) -> None:
+    write_skill(tmp_path, "1.2.4")
+    patch_repo(monkeypatch, tmp_path, previous_version="1.2.3")
+
+    assert (
+        check_skill_governance.validate_skill_version_bumps(
+            ["skills/weather/weather_trader.py", "skills/weather/SKILL.md"],
+            "base-ref",
+        )
+        == []
+    )
+
+
+def test_new_skill_does_not_need_prior_version_bump(tmp_path, monkeypatch) -> None:
+    write_skill(tmp_path, "0.1.0")
+    patch_repo(monkeypatch, tmp_path, previous_version=None)
+
+    assert (
+        check_skill_governance.validate_skill_version_bumps(
+            ["skills/weather/SKILL.md", "skills/weather/clawhub.json"],
+            "base-ref",
+        )
+        == []
+    )
+
+
+def test_non_skill_file_does_not_require_version_bump(tmp_path, monkeypatch) -> None:
+    write_skill(tmp_path, "1.2.3")
+    patch_repo(monkeypatch, tmp_path, previous_version="1.2.3")
+
+    assert (
+        check_skill_governance.validate_skill_version_bumps(
+            ["README.md", "src/simmer_sdk/client.py"],
+            "base-ref",
+        )
+        == []
+    )
+
+
+def test_changed_skill_requires_current_metadata_version(tmp_path, monkeypatch) -> None:
+    skill_dir = tmp_path / "skills" / "weather"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: weather\n---\n", encoding="utf-8")
+    patch_repo(monkeypatch, tmp_path, previous_version="1.2.3")
+
+    errors = check_skill_governance.validate_skill_version_bumps(
+        ["skills/weather/weather_trader.py"],
+        "base-ref",
+    )
+
+    assert errors == [
+        "skills/weather/SKILL.md is missing metadata.version; add a skill version "
+        "so ClawHub can publish it"
+    ]


### PR DESCRIPTION
## Summary

- Fail skill-governance when a PR changes files under `skills/<slug>/` without changing that skill's `SKILL.md` `metadata.version`.
- Require changed skills to keep a current `metadata.version` so ClawHub publishes have a deliverable version.
- Add focused tests for unchanged versions, bumped versions, new skills, non-skill diffs, and missing current versions.

## Verification

- `python3 -m pytest tests/test_skill_governance.py`
- `python3 scripts/check-skill-governance.py`
- `GITHUB_BASE_REF=main python3 scripts/check-skill-governance.py`
- `python3 -m py_compile scripts/check-skill-governance.py tests/test_skill_governance.py`

Closes SIM-4138