### PR TITLE
Fix OWS constructor test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,25 @@ jobs:
             echo "No tests directory — skipping"
           fi
 
+  ows-constructor-tests:
+    name: OWS Constructor Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install SDK with OWS extra
+        run: pip install -e '.[ows]' pytest
+
+      - name: Run OWS constructor tests
+        run: pytest tests/test_client_constructors.py -q
+
   mcp-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -13,6 +13,9 @@ import logging
 from simmer_sdk.client import SimmerClient
 
 
+TEST_OWS_ADDRESS = "0xABCD1234abcd1234abcd1234abcd1234abcd1234"
+
+
 # ---------------------------------------------------------------------------
 # from_env()
 # ---------------------------------------------------------------------------
@@ -199,12 +202,16 @@ def test_with_ows_wallet_explicit_api_key(monkeypatch):
     monkeypatch.setenv("SIMMER_API_KEY", "env_key")
     monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.ows_utils.get_ows_wallet_address",
+        lambda name: TEST_OWS_ADDRESS,
+    )
 
-    # OWS import will likely fail in test env → _ows_wallet falls back to None,
-    # but the api_key wiring is what we're testing here.
     client = SimmerClient.with_ows_wallet("my-agent", api_key="explicit_key")
 
     assert client.api_key == "explicit_key"
+    assert client._ows_wallet == "my-agent"
+    assert client._wallet_address == TEST_OWS_ADDRESS
 
 
 def test_with_ows_wallet_env_fallback_api_key(monkeypatch):
@@ -212,10 +219,16 @@ def test_with_ows_wallet_env_fallback_api_key(monkeypatch):
     monkeypatch.setenv("SIMMER_API_KEY", "fallback_key")
     monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.ows_utils.get_ows_wallet_address",
+        lambda name: TEST_OWS_ADDRESS,
+    )
 
     client = SimmerClient.with_ows_wallet("my-agent")
 
     assert client.api_key == "fallback_key"
+    assert client._ows_wallet == "my-agent"
+    assert client._wallet_address == TEST_OWS_ADDRESS
 
 
 def test_with_ows_wallet_raises_when_api_key_missing(monkeypatch):
@@ -245,6 +258,10 @@ def test_with_ows_wallet_forwards_kwargs(monkeypatch):
     monkeypatch.setenv("SIMMER_API_KEY", "k")
     monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.ows_utils.get_ows_wallet_address",
+        lambda name: TEST_OWS_ADDRESS,
+    )
 
     client = SimmerClient.with_ows_wallet(
         "my-agent",
@@ -256,3 +273,5 @@ def test_with_ows_wallet_forwards_kwargs(monkeypatch):
     assert client.venue == "polymarket"
     assert client.base_url == "https://example.test"
     assert client.live is False
+    assert client._ows_wallet == "my-agent"
+    assert client._wallet_address == TEST_OWS_ADDRESS


### PR DESCRIPTION
## Summary

- Mock OWS wallet address lookup in `with_ows_wallet()` constructor tests so they exercise the import-present OWS branch without touching a real local vault.
- Assert OWS constructor state (`_ows_wallet` and `_wallet_address`) in the explicit API key, env fallback, and kwargs forwarding tests.
- Add a focused CI job that installs `simmer-sdk[ows]` and runs the constructor test file.

## Verification

- `python3 -m pytest tests/test_client_constructors.py -q`
- `python3.11 -m venv /tmp/simmer-sdk-sim-4137-venv311 && /tmp/simmer-sdk-sim-4137-venv311/bin/pip install -e '.[ows]' pytest && /tmp/simmer-sdk-sim-4137-venv311/bin/pytest tests/test_client_constructors.py -q`\n\nCloses SIM-4137