### PR TITLE
feat(hyperliquid): PmxtSidecarClient + contract tests (A1, SIM-4222)

### DIFF
--- a/simmer_sdk/pmxt_sidecar.py
+++ b/simmer_sdk/pmxt_sidecar.py
@@ -1,0 +1,161 @@
+"""
+pmxt sidecar client — Hyperliquid order CONSTRUCTION only (SIM-4222, A1).
+
+pmxt's role in the Hyperliquid path is deliberately narrow: it *builds* a
+venue-correct unsigned order action; signing and submission stay in the SDK
+(``HyperliquidSigner`` → direct POST to ``api.hyperliquid.xyz``). No key, no
+balance, and no network egress to anything but the local sidecar happens here.
+
+Verified against the published ``pmxt-core`` 2.54.0 dist and two live mainnet
+fills (2026-07-28 builder-attribution gate run — see
+``simmer/_dev/active/_hyperliquid-rd/pmxt-hl-venue-adapter-spec.md``):
+
+- ``POST {sidecar}/api/hyperliquid/buildOrder`` with a bare JSON object body;
+  the generic ``/api/:exchange/:method`` dispatcher passes it as the single
+  ``CreateOrderParams`` argument.
+- ``CreateOrderParams``: ``outcomeId`` is HL's NUMERIC asset id as a string
+  (pmxt ``parseInt``'s it), ``side`` is ``'buy'|'sell'``, ``type: 'market'``
+  maps to tif ``Ioc`` **at the supplied price** (an omitted price silently
+  defaults to ``'0.5'`` — always supply one), ``builder`` is a STRING address
+  and ``builderFee`` a separate int in tenths of a basis point. The nested
+  ``{b, f}`` object is buildOrder's *output* shape, never its input.
+- Response envelope: ``{"success": true, "data": {"exchange", "params",
+  "raw"}}`` where ``raw`` is the unsigned action, msgpack key order already
+  correct (``type, orders, grouping, builder``).
+
+The dispatcher route is NOT in pmxt's OpenAPI, so the shape is treated as
+unstable: every response is validated and every mismatch raises loudly.
+Callers pin the sidecar version and run the contract tests on bumps.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import requests
+
+DEFAULT_TIMEOUT = 15.0
+
+#: The pmxt-core version the contract tests recorded their fixtures against.
+#: Bump deliberately: update fixtures, re-run contract tests, dry-run diff.
+PINNED_PMXT_VERSION = "2.54.0"
+
+
+class PmxtSidecarError(Exception):
+    """Raised when the sidecar is unreachable, errors, or returns an
+    unexpected shape. Never swallowed into a default — a drifted dispatcher
+    must fail loudly, not construct a subtly wrong order."""
+
+
+class PmxtSidecarClient:
+    """Thin client for a self-hosted pmxt sidecar (construction only).
+
+    Args:
+        base_url: sidecar origin, e.g. ``http://127.0.0.1:8080``. Localhost
+            deployment is the intended shape — the sidecar runs next to the
+            agent process, unauthenticated, bound to 127.0.0.1.
+        timeout: per-request timeout in seconds.
+    """
+
+    def __init__(self, base_url: str = "http://127.0.0.1:8080", timeout: float = DEFAULT_TIMEOUT):
+        self.base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    # ---- transport -------------------------------------------------------
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Any:
+        try:
+            resp = requests.post(f"{self.base_url}{path}", json=body, timeout=self._timeout)
+        except requests.RequestException as e:
+            raise PmxtSidecarError(f"sidecar unreachable at {self.base_url}: {e}") from e
+        if resp.status_code != 200:
+            raise PmxtSidecarError(
+                f"sidecar {path} HTTP {resp.status_code}: {resp.text[:300]}"
+            )
+        return resp.json()
+
+    # ---- surface ---------------------------------------------------------
+
+    def health(self) -> bool:
+        """True iff the sidecar answers its health endpoint with status ok."""
+        try:
+            resp = requests.get(f"{self.base_url}/health", timeout=self._timeout)
+        except requests.RequestException as e:
+            raise PmxtSidecarError(f"sidecar unreachable at {self.base_url}: {e}") from e
+        if resp.status_code != 200:
+            return False
+        try:
+            return resp.json().get("status") == "ok"
+        except ValueError:
+            return False
+
+    def build_order(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Build an unsigned HL order action via pmxt. Returns the raw action.
+
+        ``params`` is passed through as ``CreateOrderParams`` verbatim — the
+        caller (``PmxtHyperliquidVenue``) owns constructing it correctly; this
+        layer owns validating what comes back.
+        """
+        body = self._post("/api/hyperliquid/buildOrder", params)
+        if not (isinstance(body, dict) and body.get("success") and isinstance(body.get("data"), dict)):
+            raise PmxtSidecarError(
+                f"buildOrder unexpected envelope (dispatcher drift?): {_head(body)}"
+            )
+        action = body["data"].get("raw")
+        if not isinstance(action, dict):
+            raise PmxtSidecarError(f"buildOrder returned no raw action: {_head(body['data'])}")
+        return action
+
+    # ---- verification ----------------------------------------------------
+
+    @staticmethod
+    def assert_built_action(
+        action: Dict[str, Any],
+        *,
+        asset_id: int,
+        is_buy: bool,
+        builder: Optional[str],
+        builder_fee_tenths_bp: Optional[int],
+    ) -> None:
+        """Assert the built action matches what we asked for, BEFORE signing.
+
+        The 2026-07-28 gate run proved the failure texture here: a wrong input
+        shape produced an error *naming the builder* while the real problem was
+        the whole param mapping. The adapter must never sign an action it has
+        not verified — an exact-object check, not substring matching.
+
+        Raises PmxtSidecarError on any mismatch.
+        """
+        if action.get("type") != "order" or action.get("grouping") != "na":
+            raise PmxtSidecarError(f"unexpected action header: {_head(action)}")
+
+        orders = action.get("orders") or []
+        if len(orders) != 1:
+            raise PmxtSidecarError(f"expected exactly 1 order wire, got {len(orders)}")
+        wire = orders[0]
+        if wire.get("a") != asset_id:
+            raise PmxtSidecarError(f"asset mismatch: wire a={wire.get('a')!r}, wanted {asset_id}")
+        if wire.get("b") != is_buy:
+            raise PmxtSidecarError(f"side mismatch: wire b={wire.get('b')!r}, wanted is_buy={is_buy}")
+
+        if builder is None:
+            if "builder" in action:
+                raise PmxtSidecarError(
+                    f"unexpected builder on action when none requested: {action['builder']!r}"
+                )
+            return
+        want = {"b": builder.lower(), "f": builder_fee_tenths_bp}
+        got = action.get("builder")
+        if got != want:
+            raise PmxtSidecarError(f"builder mismatch: got {got!r}, wanted {want!r}")
+
+
+def _head(obj: Any, limit: int = 300) -> str:
+    """Compact repr for error messages — never dump a full payload."""
+    import json
+
+    try:
+        s = json.dumps(obj)
+    except (TypeError, ValueError):
+        s = repr(obj)
+    return s[:limit]

--- a/tests/test_pmxt_sidecar.py
+++ b/tests/test_pmxt_sidecar.py
@@ -1,0 +1,191 @@
+"""Contract tests for PmxtSidecarClient (SIM-4222, A1). No network.
+
+The FIXTURE_* payloads are RECORDED RESPONSES from a real pmxt-core 2.54.0
+sidecar during the 2026-07-28 builder-attribution gate run (which ended in two
+live attributed mainnet fills). They are the contract: if a pmxt version bump
+changes any of these shapes, these tests are the tripwire — update the pin,
+re-record, and dry-run diff per the version-bump policy in
+``simmer/_dev/active/_hyperliquid-rd/pmxt-hl-venue-adapter-spec.md``.
+"""
+
+import json
+
+import pytest
+
+from simmer_sdk.pmxt_sidecar import (
+    PINNED_PMXT_VERSION,
+    PmxtSidecarClient,
+    PmxtSidecarError,
+)
+
+BUILDER = "0xB42D8926BF2Db204Ad27A11817eB2EF2A9f5EF13"
+
+# Recorded from pmxt-core 2.54.0, 2026-07-28 (params echoed by the dispatcher;
+# raw is the unsigned action that went on to sign + fill on mainnet).
+FIXTURE_BUILD_ORDER = {
+    "success": True,
+    "data": {
+        "exchange": "Hyperliquid",
+        "params": {
+            "marketId": "ETH",
+            "outcomeId": "1",
+            "side": "sell",
+            "type": "market",
+            "amount": 0.01,
+            "price": 1859.3,
+            "builder": BUILDER,
+            "builderFee": 10,
+        },
+        "raw": {
+            "type": "order",
+            "orders": [
+                {
+                    "a": 1,
+                    "b": False,
+                    "p": "1859.3",
+                    "s": "0.01",
+                    "r": False,
+                    "t": {"limit": {"tif": "Ioc"}},
+                }
+            ],
+            "grouping": "na",
+            "builder": {"b": BUILDER.lower(), "f": 10},
+        },
+    },
+}
+
+FIXTURE_HEALTH = {"status": "ok", "timestamp": 1785219085579}
+
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+def _client(monkeypatch, response, capture=None, status=200):
+    def _fake_post(url, json=None, timeout=None):
+        if capture is not None:
+            capture.append((url, json))
+        return _FakeResp(status, response)
+
+    def _fake_get(url, timeout=None):
+        return _FakeResp(status, response)
+
+    monkeypatch.setattr("simmer_sdk.pmxt_sidecar.requests.post", _fake_post)
+    monkeypatch.setattr("simmer_sdk.pmxt_sidecar.requests.get", _fake_get)
+    return PmxtSidecarClient("http://127.0.0.1:8080")
+
+
+# ---- envelope contract ----------------------------------------------------
+
+
+def test_build_order_unwraps_recorded_envelope(monkeypatch):
+    capture = []
+    c = _client(monkeypatch, FIXTURE_BUILD_ORDER, capture)
+    action = c.build_order(FIXTURE_BUILD_ORDER["data"]["params"])
+    assert action == FIXTURE_BUILD_ORDER["data"]["raw"]
+    # bare-object body on the dispatcher route — not wrapped in {"args": [...]}
+    url, body = capture[0]
+    assert url.endswith("/api/hyperliquid/buildOrder")
+    assert body == FIXTURE_BUILD_ORDER["data"]["params"]
+
+
+def test_build_order_preserves_msgpack_key_order(monkeypatch):
+    """Key order (type, orders, grouping, builder) is hash-relevant; the client
+    must return the action untouched, in dispatcher order."""
+    c = _client(monkeypatch, FIXTURE_BUILD_ORDER)
+    action = c.build_order({})
+    assert list(action.keys()) == ["type", "orders", "grouping", "builder"]
+    assert list(action["orders"][0].keys()) == ["a", "b", "p", "s", "r", "t"]
+
+
+def test_build_order_rejects_missing_success(monkeypatch):
+    c = _client(monkeypatch, {"data": FIXTURE_BUILD_ORDER["data"]})
+    with pytest.raises(PmxtSidecarError, match="envelope"):
+        c.build_order({})
+
+
+def test_build_order_rejects_missing_raw(monkeypatch):
+    c = _client(monkeypatch, {"success": True, "data": {"exchange": "Hyperliquid"}})
+    with pytest.raises(PmxtSidecarError, match="raw action"):
+        c.build_order({})
+
+
+def test_build_order_rejects_http_error(monkeypatch):
+    c = _client(monkeypatch, {"error": "boom"}, status=500)
+    with pytest.raises(PmxtSidecarError, match="HTTP 500"):
+        c.build_order({})
+
+
+def test_health_ok(monkeypatch):
+    c = _client(monkeypatch, FIXTURE_HEALTH)
+    assert c.health() is True
+
+
+def test_health_bad_status(monkeypatch):
+    c = _client(monkeypatch, {"status": "degraded"})
+    assert c.health() is False
+
+
+# ---- assert_built_action (the pre-sign gate) ------------------------------
+
+RAW = FIXTURE_BUILD_ORDER["data"]["raw"]
+
+
+def _assert_ok(action=RAW, **overrides):
+    kw = dict(asset_id=1, is_buy=False, builder=BUILDER, builder_fee_tenths_bp=10)
+    kw.update(overrides)
+    PmxtSidecarClient.assert_built_action(action, **kw)
+
+
+def test_assert_accepts_the_recorded_action():
+    _assert_ok()
+
+
+def test_assert_rejects_wrong_asset():
+    with pytest.raises(PmxtSidecarError, match="asset mismatch"):
+        _assert_ok(asset_id=2)
+
+
+def test_assert_rejects_wrong_side():
+    with pytest.raises(PmxtSidecarError, match="side mismatch"):
+        _assert_ok(is_buy=True)
+
+
+def test_assert_rejects_wrong_builder_address():
+    with pytest.raises(PmxtSidecarError, match="builder mismatch"):
+        _assert_ok(builder="0x" + "11" * 20)
+
+
+def test_assert_rejects_wrong_fee():
+    """f is tenths of a basis point; a 10x unit slip is the canonical mistake."""
+    with pytest.raises(PmxtSidecarError, match="builder mismatch"):
+        _assert_ok(builder_fee_tenths_bp=100)
+
+
+def test_assert_rejects_unexpected_builder_when_none_requested():
+    with pytest.raises(PmxtSidecarError, match="unexpected builder"):
+        _assert_ok(builder=None, builder_fee_tenths_bp=None)
+
+
+def test_assert_accepts_builderless_action_when_none_requested():
+    builderless = {k: v for k, v in RAW.items() if k != "builder"}
+    PmxtSidecarClient.assert_built_action(
+        builderless, asset_id=1, is_buy=False, builder=None, builder_fee_tenths_bp=None
+    )
+
+
+def test_assert_rejects_multi_order_actions():
+    doubled = dict(RAW, orders=[RAW["orders"][0], RAW["orders"][0]])
+    with pytest.raises(PmxtSidecarError, match="exactly 1 order"):
+        _assert_ok(action=doubled)
+
+
+def test_pinned_version_is_recorded():
+    """The pin the fixtures were recorded against — bump deliberately."""
+    assert PINNED_PMXT_VERSION == "2.54.0"


### PR DESCRIPTION
First slice of the PmxtHyperliquidVenue adapter (spec: simmer `_dev/active/_hyperliquid-rd/pmxt-hl-venue-adapter-spec.md`, gate PASS 2026-07-28).

**What:** construction-only client for a self-hosted pmxt sidecar — `build_order` (envelope validation, fail-loud on dispatcher drift), `health`, and `assert_built_action` (the pre-sign gate: exact builder `{b,f}` + order-wire match).

**Contract tests:** fixtures are recorded responses from a real pmxt-core 2.54.0 sidecar during the builder-attribution gate run that produced two live attributed mainnet fills. Live re-run against that sidecar reproduces the fixture byte-identically (key order included — msgpack-hash-relevant).

**Not in this slice:** the venue adapter itself (A2), HIP-4 asset-id resolution (A3). No signing, no keys, no network beyond localhost.

16 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gvMvHMVFkhtB8Z2MLBHyt