### PR TITLE
feat(hyperliquid): PmxtHyperliquidVenue — pmxt-constructed orders (A2, SIM-4222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Hyperliquid trading with pmxt-constructed orders (SIM-4222).**
+  `PmxtHyperliquidVenue` implements `VenueAdapter` against a self-hosted,
+  construction-only pmxt sidecar: pmxt builds the unsigned action, the SDK
+  verifies it, signs it locally (`HyperliquidSigner` — raw key or OWS), and
+  submits directly to Hyperliquid. No key ever reaches the sidecar and pmxt is
+  not in the money path. What it buys is outsourced construction maintenance
+  (asset universe, wire encoding, protocol drift); `HyperliquidVenue` stays as
+  the native anti-corruption fallback — same signer, same submit, same reads.
+  Built on `PmxtSidecarClient` (added in #290), which owns the envelope
+  validation and the `assert_built_action` pre-sign gate.
+
+  Every order is verified against what was asked for *before* it reaches the
+  key: asset, side, price, size, tif, and an exact match on the builder
+  `{b, f}` object. A drifted sidecar fails loudly rather than producing a
+  subtly wrong or silently unattributed order. `preflight()` runs the same gate
+  at startup so drift surfaces before the first trade, not during it.
+
+  `reduce_only`, `cloid`, and post-only (`Alo`) are **not supported on this
+  path** — pmxt's `buildOrder` hardcodes `r: false`, emits no `c`, and reaches
+  only `Gtc`/`Ioc`. Each raises rather than being silently dropped; use
+  `HyperliquidVenue` for those. The pmxt version is pinned (2.54.0) because the
+  dispatcher route is not in pmxt's OpenAPI; bumps re-record the contract-test
+  fixtures.
+
+### Changed
+
+- `HyperliquidVenue._post_action` is now the public `submit_action`, so
+  construction and submission are separable and both Hyperliquid adapters share
+  one transport and error-handling implementation on the money path.
+- `hyperliquid_signing.now_ms()` no longer requires the `[hyperliquid]` extra.
+  It stamps a nonce with `int(time.time() * 1000)` — identical to the official
+  SDK's `get_timestamp_ms()` — so callers that never build a wire locally don't
+  pull in the SDK just for a timestamp.
+
 ## [0.24.0] - 2026-07-22
 
 ### Added

--- a/simmer_sdk/hyperliquid_signing.py
+++ b/simmer_sdk/hyperliquid_signing.py
@@ -22,6 +22,7 @@ it lives in the local OWS vault.
 """
 
 import json
+import time
 from typing import Any, Dict, Optional, Protocol, runtime_checkable
 
 # HIP-4 asset encoding (matches simmer_v3/hyperliquid_client.py):
@@ -110,8 +111,14 @@ def build_cancel_action(asset: int, oid: int) -> Dict[str, Any]:
 
 
 def now_ms() -> int:
-    """Millisecond timestamp used as the action nonce."""
-    return _hl_signing().get_timestamp_ms()
+    """Millisecond timestamp used as the action nonce.
+
+    Computed locally rather than via the official SDK's ``get_timestamp_ms``
+    (which is the same ``int(time.time() * 1000)``) so that callers who never
+    build a wire — e.g. the pmxt-constructed adapter, where pmxt builds the
+    action — do not need the ``[hyperliquid]`` extra just to stamp a nonce.
+    """
+    return int(time.time() * 1000)
 
 
 def _split_signature(sig_hex: str) -> Dict[str, Any]:

--- a/simmer_sdk/hyperliquid_venue.py
+++ b/simmer_sdk/hyperliquid_venue.py
@@ -83,7 +83,14 @@ class HyperliquidVenue:
             )
         return resp.json()
 
-    def _post_action(self, action: Dict[str, Any], signature: Dict[str, Any], nonce: int) -> Any:
+    def submit_action(self, action: Dict[str, Any], signature: Dict[str, Any], nonce: int) -> Any:
+        """Submit an already-signed action to ``/exchange``.
+
+        Public because construction and submission are separable: the
+        pmxt-constructed adapter (``PmxtHyperliquidVenue``, SIM-4222) builds its
+        action elsewhere but submits through this exact path, so there is one
+        transport + error-handling implementation on the money path.
+        """
         payload: Dict[str, Any] = {
             "action": action,
             "nonce": nonce,
@@ -143,7 +150,7 @@ class HyperliquidVenue:
         signature = self._signer.sign_l1_action(
             action, nonce, self.is_mainnet, vault_address=self.vault_address
         )
-        return self._post_action(action, signature, nonce)
+        return self.submit_action(action, signature, nonce)
 
     def cancel_order(self, *, order_id: int, outcome_id: int, side: str = "yes") -> Dict[str, Any]:
         """Cancel a resting order by its venue order id."""
@@ -153,7 +160,7 @@ class HyperliquidVenue:
         signature = self._signer.sign_l1_action(
             action, nonce, self.is_mainnet, vault_address=self.vault_address
         )
-        return self._post_action(action, signature, nonce)
+        return self.submit_action(action, signature, nonce)
 
     def get_positions(self, address: Optional[str] = None) -> List[Dict[str, Any]]:
         """Open positions for ``address`` (defaults to this adapter's address).
@@ -222,4 +229,4 @@ class HyperliquidVenue:
         # over agentName="" so this stays valid.
         if not agent_name:
             del action["agentName"]
-        return self._post_action(action, signature, nonce)
+        return self.submit_action(action, signature, nonce)

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -376,7 +376,30 @@ class PmxtHyperliquidVenue:
         )
         wire = action["orders"][0]
 
-        got_tif = ((wire.get("t") or {}).get("limit") or {}).get("tif")
+        # "Never sign an action we have not verified" means the whole action,
+        # not just the fields we happen to check. An upstream addition — a
+        # generated cloid, a trigger/TP-SL leg — would otherwise be signed
+        # blind. Pinned version + contract tests make an exact key set the
+        # right strictness: a bump re-records fixtures, drift refuses to trade.
+        # This adapter always requests builder attribution, so the key set is
+        # fixed. Comparing lists also re-checks msgpack key ORDER, which is
+        # hash-relevant.
+        if list(action.keys()) != ["type", "orders", "grouping", "builder"]:
+            raise PmxtSidecarError(
+                f"unexpected action fields: got {list(action.keys())}, "
+                "wanted ['type', 'orders', 'grouping', 'builder']"
+            )
+        if list(wire.keys()) != ["a", "b", "p", "s", "r", "t"]:
+            raise PmxtSidecarError(
+                f"unexpected order-wire fields: got {list(wire.keys())}, "
+                "wanted ['a', 'b', 'p', 's', 'r', 't']"
+            )
+        if list((wire.get("t") or {}).keys()) != ["limit"]:
+            raise PmxtSidecarError(
+                f"unexpected order type — only plain limit orders are built here: {wire.get('t')!r}"
+            )
+
+        got_tif = (wire["t"]["limit"] or {}).get("tif")
         if got_tif != want_tif:
             raise PmxtSidecarError(f"tif mismatch: wire {got_tif!r}, wanted {want_tif!r}")
 

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -32,10 +32,16 @@ being silently dropped — a reduce-only flag that quietly becomes ``False`` on
 a closing order is a money-path bug. Use ``HyperliquidVenue`` for those.
 """
 
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Optional
+import math
 import re
 
-from simmer_sdk.hyperliquid_signing import HyperliquidSigner, now_ms
+from simmer_sdk.hyperliquid_signing import (
+    HyperliquidSigner,
+    build_cancel_action,
+    now_ms,
+)
 from simmer_sdk.hyperliquid_venue import (
     DEFAULT_TIMEOUT,
     HyperliquidVenue,
@@ -81,6 +87,15 @@ class PmxtHyperliquidVenue:
 
     Keep one venue instance per key and avoid concurrent ``place_order`` calls
     on the same instance — HL nonces are per-key and monotonic.
+
+    .. warning::
+       The nonce is a wall-clock millisecond (``now_ms``), so two orders signed
+       by the same key inside the same millisecond collide and Hyperliquid
+       accepts only one — a paired buy/sell could leave a naked leg. This is
+       pre-existing and shared with ``HyperliquidVenue`` (both stamp the same
+       way; the official SDK's ``get_timestamp_ms`` is the same expression) and
+       is tracked as its own fix — a signer-scoped monotonic allocator. Until
+       then, do not fan out rapid sequential orders on one key.
     """
 
     venue = "hyperliquid"
@@ -241,6 +256,23 @@ class PmxtHyperliquidVenue:
                 "cloid is not supported via pmxt construction (pmxt emits no 'c' "
                 "field); use HyperliquidVenue for client order ids"
             )
+        # Validate locally so the failure names the bad argument. Without this
+        # a string asset_id survives into pmxt (which parseInt's it) and comes
+        # back as an int, surfacing as a confusing "asset mismatch" from the
+        # gate instead of "you passed the wrong type".
+        if not isinstance(asset_id, int) or isinstance(asset_id, bool):
+            raise HyperliquidVenueError(
+                f"asset_id must be an int (HL's numeric asset id), got {asset_id!r}"
+            )
+        # isfinite is load-bearing: NaN fails every comparison, so a bare
+        # `size <= 0` would wave it through and it would serialize into the
+        # order as JSON `NaN`.
+        if not _is_positive_number(size):
+            raise HyperliquidVenueError(f"size must be a positive finite number, got {size!r}")
+        if not _is_positive_number(limit_px):
+            raise HyperliquidVenueError(
+                f"limit_px must be a positive finite number, got {limit_px!r}"
+            )
 
         order_type, want_tif = self._resolve_order_type(order_type, tif)
 
@@ -273,10 +305,9 @@ class PmxtHyperliquidVenue:
 
         Cancels are built natively — pmxt's construction surface adds nothing
         here (no builder attribution, no wire subtleties), so this goes through
-        the native cancel path with a raw asset id.
+        the native cancel path with a raw asset id. ``build_cancel_action`` is a
+        plain dict builder, so this needs no ``[hyperliquid]`` extra either.
         """
-        from simmer_sdk.hyperliquid_signing import build_cancel_action
-
         action = build_cancel_action(asset_id, order_id)
         nonce = now_ms()
         signature = self._signer.sign_l1_action(
@@ -367,7 +398,11 @@ class PmxtHyperliquidVenue:
         pmxt's ``floatToWire`` raises rather than rounding — a wire value that
         differs from what we asked is drift, not normalization.
         """
-        self._sidecar.assert_built_action(
+        # Called on the CLASS, not through ``self._sidecar``. The sidecar is an
+        # injectable transport seam; routing the gate through it would let an
+        # injected object replace verification policy with a no-op and put
+        # unverified actions in front of the key.
+        PmxtSidecarClient.assert_built_action(
             action,
             asset_id=asset_id,
             is_buy=is_buy,
@@ -413,11 +448,25 @@ class PmxtHyperliquidVenue:
             raise PmxtSidecarError(f"unexpected reduce_only on wire: r={wire.get('r')!r}")
 
 
+def _is_positive_number(x: Any) -> bool:
+    """True for a real, finite, strictly-positive number (NaN/inf excluded)."""
+    if not isinstance(x, (int, float)) or isinstance(x, bool):
+        return False
+    return math.isfinite(x) and x > 0
+
+
 def _wire_equals(wire_value: Any, requested: float) -> bool:
-    """True iff a wire string equals the requested number exactly."""
+    """True iff a wire string is the requested number, compared in DECIMAL.
+
+    Not ``float(wire) == float(requested)``: binary floats collapse distinct
+    decimal strings, so a drifted wire price of ``"0.10000000000000001"`` would
+    compare equal to a requested ``0.1`` and be signed. Decimal comparison is
+    what "exact" has to mean for a gate whose job is catching drift, while
+    still accepting genuine restyling like ``"1859.30"`` for ``1859.3``.
+    """
     if not isinstance(wire_value, str):
         return False
     try:
-        return float(wire_value) == float(requested)
-    except (TypeError, ValueError):
+        return Decimal(wire_value) == Decimal(str(requested))
+    except (TypeError, ValueError, InvalidOperation):
         return False

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -1,0 +1,400 @@
+"""
+Hyperliquid venue adapter with pmxt-constructed orders (SIM-4222, A2).
+
+Same venue, different *construction locus*. The chain:
+
+    pmxt sidecar buildOrder    → constructs the venue-correct unsigned action
+      → assert_built_action    → verify it is what we asked for, BEFORE signing
+      → HyperliquidSigner      → signs locally (raw key or OWS); no key ever
+                                 goes near pmxt
+      → HL /exchange           → we submit directly; pmxt is not in the money
+                                 path and takes no toll
+
+What pmxt buys is **outsourced construction maintenance** — asset universe,
+wire encoding, perps/spot/HIP-4 coverage, and future HL protocol drift handled
+upstream instead of by us. That is the whole rent-vs-build trade, so this
+adapter stays deliberately thin: it maps our arguments onto pmxt's
+``CreateOrderParams``, verifies the result, and delegates everything else
+(signing, submission, reads) to the same code paths ``HyperliquidVenue`` uses.
+
+``HyperliquidVenue`` remains the anti-corruption fallback: same signer, same
+submit, same reads, native construction. If pmxt drifts or goes away, callers
+swap the class they construct.
+
+Verified against pmxt-core 2.54.0 (published dist read + a live sidecar,
+2026-07-28) and two attributed mainnet fills from the builder-attribution gate
+run. See ``simmer/_dev/active/_hyperliquid-rd/pmxt-hl-venue-adapter-spec.md``.
+
+Deliberate capability gaps (pmxt's ``buildOrder`` cannot express these — it
+hardcodes ``r: false``, never emits ``c``, and reaches only ``Gtc``/``Ioc``):
+``reduce_only``, ``cloid``, and post-only (``Alo``). Each raises rather than
+being silently dropped — a reduce-only flag that quietly becomes ``False`` on
+a closing order is a money-path bug. Use ``HyperliquidVenue`` for those.
+"""
+
+from typing import Any, Dict, List, Optional
+import re
+
+from simmer_sdk.hyperliquid_signing import HyperliquidSigner, now_ms
+from simmer_sdk.hyperliquid_venue import (
+    DEFAULT_TIMEOUT,
+    HyperliquidVenue,
+    HyperliquidVenueError,
+)
+from simmer_sdk.pmxt_sidecar import PmxtSidecarClient, PmxtSidecarError
+
+#: Builder fee in TENTHS of a basis point. 10 = 1bp, the rate the gate run
+#: filled at. The user-side approval ceiling is 10bp (``maxBuilderFee=100``),
+#: so this is raisable to 100 without re-prompting users — a pricing decision.
+DEFAULT_BUILDER_FEE_TENTHS_BP = 10
+
+#: pmxt order ``type`` → the tif it produces (read from pmxt-core 2.54.0
+#: ``dist/exchanges/hyperliquid/index.js``; confirmed live). Only these two
+#: are reachable through pmxt construction.
+_TIF_BY_ORDER_TYPE = {"limit": "Gtc", "market": "Ioc"}
+_ORDER_TYPE_BY_TIF = {v: k for k, v in _TIF_BY_ORDER_TYPE.items()}
+
+_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+
+class PmxtHyperliquidVenue:
+    """``VenueAdapter`` implementation that builds orders via a pmxt sidecar.
+
+    Args:
+        signer: a ``HyperliquidSigner`` (RawKey or OWS). Signs locally; the key
+            never reaches the sidecar, which is construction-only and holds no
+            credentials.
+        builder_address: the PUBLIC Simmer builder address for attribution. The
+            builder's private key is not used at order time and must never be
+            configured here — orders are signed by the trader's key, and the
+            builder is named only by address inside the signed action.
+        sidecar_url: origin of the local pmxt sidecar (127.0.0.1, next to the
+            agent process — not a shared service).
+        builder_fee_tenths_bp: fee in tenths of a basis point (10 = 1bp).
+        main_address: the account-of-record for reads and fill recording.
+            Under HL's delegated ``approveAgent`` setup the signer is a
+            trade-only agent key whose address is NOT the account — always set
+            this when signing with an agent key.
+        is_mainnet / base_url / vault_address / timeout: as ``HyperliquidVenue``.
+        sidecar: inject a pre-built ``PmxtSidecarClient`` (tests, custom
+            transport). Overrides ``sidecar_url``.
+
+    Keep one venue instance per key and avoid concurrent ``place_order`` calls
+    on the same instance — HL nonces are per-key and monotonic.
+    """
+
+    venue = "hyperliquid"
+
+    #: Where the unsigned action comes from. Signing/submission/reads are
+    #: identical to the native adapter; this is the only axis that differs.
+    construction = "pmxt"
+
+    def __init__(
+        self,
+        signer: HyperliquidSigner,
+        *,
+        builder_address: str,
+        sidecar_url: str = "http://127.0.0.1:8080",
+        builder_fee_tenths_bp: int = DEFAULT_BUILDER_FEE_TENTHS_BP,
+        is_mainnet: bool = True,
+        base_url: Optional[str] = None,
+        vault_address: Optional[str] = None,
+        main_address: Optional[str] = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        sidecar: Optional[PmxtSidecarClient] = None,
+    ):
+        if not isinstance(builder_address, str) or not _ADDRESS_RE.match(builder_address):
+            # Mirrors pmxt's own validation, but locally and before any network
+            # call. Also the guard that a private key can never be passed here:
+            # a 32-byte key is 64 hex chars and fails this 40-char match.
+            raise ValueError(
+                f"builder_address must be a 0x-prefixed 20-byte address, got {builder_address!r}"
+            )
+        if not isinstance(builder_fee_tenths_bp, int) or isinstance(builder_fee_tenths_bp, bool):
+            raise ValueError("builder_fee_tenths_bp must be an int (tenths of a basis point)")
+        if builder_fee_tenths_bp < 0:
+            raise ValueError("builder_fee_tenths_bp must be non-negative")
+
+        self.builder_address = builder_address
+        self.builder_fee_tenths_bp = builder_fee_tenths_bp
+
+        # Composition, not inheritance: `place_order` takes a raw HL asset id
+        # where the native adapter takes a HIP-4 outcome id, so the two are not
+        # substitutable on that method. Everything else is shared by delegation.
+        self._native = HyperliquidVenue(
+            signer,
+            is_mainnet=is_mainnet,
+            base_url=base_url,
+            vault_address=vault_address,
+            main_address=main_address,
+            timeout=timeout,
+        )
+        self._signer = signer
+        self._sidecar = sidecar or PmxtSidecarClient(sidecar_url, timeout=timeout)
+
+    # ---- identity (mirrors the native adapter) ---------------------------
+
+    @property
+    def address(self) -> str:
+        """Account-of-record — what positions/balances/fills belong to."""
+        return self._native.address
+
+    @property
+    def signer_address(self) -> str:
+        """The signing key's address. Equals ``address`` only for raw-key
+        setups; under ``approveAgent`` it is the agent key, not the account."""
+        return self._native.signer_address
+
+    @property
+    def is_mainnet(self) -> bool:
+        return self._native.is_mainnet
+
+    @property
+    def base_url(self) -> str:
+        return self._native.base_url
+
+    @property
+    def vault_address(self) -> Optional[str]:
+        return self._native.vault_address
+
+    # ---- startup handshake ------------------------------------------------
+
+    def preflight(self, *, asset_id: int = 1, probe_price: float = 1000.0) -> None:
+        """Verify the sidecar is up and still speaks the contract we pinned.
+
+        Runs the health check plus one real ``buildOrder`` whose result is put
+        through the same pre-sign gate a live order would face — so a drifted
+        dispatcher is caught at startup rather than on the first trade. Call
+        before trading; it is deliberately not run in ``__init__`` (no network
+        in a constructor).
+
+        Raises ``PmxtSidecarError`` if the sidecar is down or the shape drifted.
+        """
+        if not self._sidecar.health():
+            raise PmxtSidecarError(f"pmxt sidecar unhealthy at {self._sidecar.base_url}")
+        params = self._build_params(
+            asset_id=asset_id,
+            is_buy=True,
+            size=0.01,
+            limit_px=probe_price,
+            order_type="limit",
+            market_id=None,
+        )
+        action = self._sidecar.build_order(params)
+        self._assert_built(
+            action,
+            asset_id=asset_id,
+            is_buy=True,
+            size=0.01,
+            limit_px=probe_price,
+            want_tif="Gtc",
+        )
+
+    # ---- VenueAdapter core ------------------------------------------------
+
+    def place_order(
+        self,
+        *,
+        size: float,
+        limit_px: float,
+        is_buy: bool,
+        asset_id: int,
+        order_type: str = "limit",
+        tif: Optional[str] = None,
+        market_id: Optional[str] = None,
+        reduce_only: bool = False,
+        cloid: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Place an order built by pmxt, signed and submitted by us.
+
+        Args:
+            size: order size in the asset's units.
+            limit_px: limit price. Always sent — pmxt silently defaults an
+                omitted price to ``'0.5'``, which would be catastrophic on a
+                perp, so this argument is required even for market orders
+                (where it acts as the IOC's price bound).
+            is_buy: True to buy, False to sell.
+            asset_id: HL's NUMERIC asset id (e.g. 1 = ETH perp). This is not
+                the HIP-4 outcome id the native adapter takes; HIP-4 asset-id
+                resolution is A3 and unwired here.
+            order_type: ``"limit"`` (tif Gtc, rests) or ``"market"`` (tif Ioc
+                at ``limit_px``). pmxt reaches no other tif.
+            tif: optional native-parity alias — ``"Gtc"``/``"Ioc"``. Must agree
+                with ``order_type`` if both are given. ``"Alo"`` is unsupported.
+            market_id: optional venue symbol (e.g. ``"ETH"``). pmxt echoes it
+                back but ``buildOrder`` does not use it; ``asset_id`` is what
+                addresses the market.
+            reduce_only / cloid: NOT supported on this construction path (pmxt
+                hardcodes ``r: false`` and emits no ``c``). Raises rather than
+                dropping them silently — use ``HyperliquidVenue`` instead.
+
+        Returns the parsed ``/exchange`` response. On a resting order the
+        ``oid`` is under ``response.data.statuses[i]``.
+        """
+        if reduce_only:
+            raise HyperliquidVenueError(
+                "reduce_only is not supported via pmxt construction (pmxt hardcodes "
+                "r=false); use HyperliquidVenue for reduce-only orders"
+            )
+        if cloid is not None:
+            raise HyperliquidVenueError(
+                "cloid is not supported via pmxt construction (pmxt emits no 'c' "
+                "field); use HyperliquidVenue for client order ids"
+            )
+
+        order_type, want_tif = self._resolve_order_type(order_type, tif)
+
+        params = self._build_params(
+            asset_id=asset_id,
+            is_buy=is_buy,
+            size=size,
+            limit_px=limit_px,
+            order_type=order_type,
+            market_id=market_id,
+        )
+        action = self._sidecar.build_order(params)
+        self._assert_built(
+            action,
+            asset_id=asset_id,
+            is_buy=is_buy,
+            size=size,
+            limit_px=limit_px,
+            want_tif=want_tif,
+        )
+
+        nonce = now_ms()
+        signature = self._signer.sign_l1_action(
+            action, nonce, self.is_mainnet, vault_address=self.vault_address
+        )
+        return self._native.submit_action(action, signature, nonce)
+
+    def cancel_order(self, *, order_id: int, asset_id: int) -> Dict[str, Any]:
+        """Cancel a resting order by venue order id.
+
+        Cancels are built natively — pmxt's construction surface adds nothing
+        here (no builder attribution, no wire subtleties), so this goes through
+        the native cancel path with a raw asset id.
+        """
+        from simmer_sdk.hyperliquid_signing import build_cancel_action
+
+        action = build_cancel_action(asset_id, order_id)
+        nonce = now_ms()
+        signature = self._signer.sign_l1_action(
+            action, nonce, self.is_mainnet, vault_address=self.vault_address
+        )
+        return self._native.submit_action(action, signature, nonce)
+
+    def get_positions(self, address: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Open positions for ``address`` (defaults to the account-of-record)."""
+        return self._native.get_positions(address)
+
+    def get_balances(self, address: Optional[str] = None) -> Dict[str, Any]:
+        """Collateral summary for ``address`` (defaults to account-of-record)."""
+        return self._native.get_balances(address)
+
+    # ---- HL-specific extras (delegated) -----------------------------------
+
+    def get_open_orders(self, address: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Resting open orders for ``address``."""
+        return self._native.get_open_orders(address)
+
+    # ---- internals --------------------------------------------------------
+
+    @staticmethod
+    def _resolve_order_type(order_type: str, tif: Optional[str]) -> tuple:
+        """Normalize (order_type, tif) to a single pmxt type + expected tif."""
+        if order_type not in _TIF_BY_ORDER_TYPE:
+            raise HyperliquidVenueError(
+                f"order_type must be one of {sorted(_TIF_BY_ORDER_TYPE)}, got {order_type!r}"
+            )
+        want_tif = _TIF_BY_ORDER_TYPE[order_type]
+        if tif is None:
+            return order_type, want_tif
+        if tif not in _ORDER_TYPE_BY_TIF:
+            raise HyperliquidVenueError(
+                f"tif {tif!r} is not reachable via pmxt construction "
+                f"(only {sorted(_ORDER_TYPE_BY_TIF)}); use HyperliquidVenue"
+            )
+        if tif != want_tif:
+            raise HyperliquidVenueError(
+                f"conflicting order_type={order_type!r} (tif {want_tif}) and tif={tif!r}"
+            )
+        return order_type, want_tif
+
+    def _build_params(
+        self,
+        *,
+        asset_id: int,
+        is_buy: bool,
+        size: float,
+        limit_px: float,
+        order_type: str,
+        market_id: Optional[str],
+    ) -> Dict[str, Any]:
+        """Map our arguments onto pmxt ``CreateOrderParams``.
+
+        ``builder`` is a STRING address and ``builderFee`` a separate int; the
+        nested ``{b, f}`` object is buildOrder's OUTPUT shape, never its input.
+        """
+        params: Dict[str, Any] = {
+            "outcomeId": str(asset_id),
+            "side": "buy" if is_buy else "sell",
+            "type": order_type,
+            "amount": size,
+            "price": limit_px,
+            "builder": self.builder_address,
+            "builderFee": self.builder_fee_tenths_bp,
+        }
+        if market_id is not None:
+            params["marketId"] = market_id
+        return params
+
+    def _assert_built(
+        self,
+        action: Dict[str, Any],
+        *,
+        asset_id: int,
+        is_buy: bool,
+        size: float,
+        limit_px: float,
+        want_tif: str,
+    ) -> None:
+        """Verify the built action matches the order we asked for, pre-signing.
+
+        Layered on A1's ``assert_built_action`` (header/asset/side/builder) with
+        the economic terms it does not cover: price, size and tif. Prices and
+        sizes are compared for EXACT numeric equality, which is safe because
+        pmxt's ``floatToWire`` raises rather than rounding — a wire value that
+        differs from what we asked is drift, not normalization.
+        """
+        self._sidecar.assert_built_action(
+            action,
+            asset_id=asset_id,
+            is_buy=is_buy,
+            builder=self.builder_address,
+            builder_fee_tenths_bp=self.builder_fee_tenths_bp,
+        )
+        wire = action["orders"][0]
+
+        got_tif = ((wire.get("t") or {}).get("limit") or {}).get("tif")
+        if got_tif != want_tif:
+            raise PmxtSidecarError(f"tif mismatch: wire {got_tif!r}, wanted {want_tif!r}")
+
+        # `p` catches the omitted-price footgun (pmxt defaults to '0.5').
+        if not _wire_equals(wire.get("p"), limit_px):
+            raise PmxtSidecarError(f"price mismatch: wire p={wire.get('p')!r}, wanted {limit_px}")
+        if not _wire_equals(wire.get("s"), size):
+            raise PmxtSidecarError(f"size mismatch: wire s={wire.get('s')!r}, wanted {size}")
+
+        if wire.get("r") is not False:
+            raise PmxtSidecarError(f"unexpected reduce_only on wire: r={wire.get('r')!r}")
+
+
+def _wire_equals(wire_value: Any, requested: float) -> bool:
+    """True iff a wire string equals the requested number exactly."""
+    if not isinstance(wire_value, str):
+        return False
+    try:
+        return float(wire_value) == float(requested)
+    except (TypeError, ValueError):
+        return False

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -264,6 +264,11 @@ class PmxtHyperliquidVenue:
             raise HyperliquidVenueError(
                 f"asset_id must be an int (HL's numeric asset id), got {asset_id!r}"
             )
+        # Must be a real bool: a truthy non-bool would pick a side by accident
+        # and then satisfy the gate's type-exact check anyway, because the gate
+        # compares the wire against this same value and `True == 1.0`.
+        if not isinstance(is_buy, bool):
+            raise HyperliquidVenueError(f"is_buy must be a bool, got {is_buy!r}")
         # isfinite is load-bearing: NaN fails every comparison, so a bare
         # `size <= 0` would wave it through and it would serialize into the
         # order as JSON `NaN`.
@@ -308,6 +313,13 @@ class PmxtHyperliquidVenue:
         the native cancel path with a raw asset id. ``build_cancel_action`` is a
         plain dict builder, so this needs no ``[hyperliquid]`` extra either.
         """
+        # Nothing downstream validates these — they go straight into the signed
+        # wire, so a string order_id would be signed and only then rejected by
+        # HL. `bool` is excluded explicitly since it is an int subclass.
+        for name, value in (("asset_id", asset_id), ("order_id", order_id)):
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise HyperliquidVenueError(f"{name} must be an int, got {value!r}")
+
         action = build_cancel_action(asset_id, order_id)
         nonce = now_ms()
         signature = self._signer.sign_l1_action(
@@ -433,8 +445,12 @@ class PmxtHyperliquidVenue:
             raise PmxtSidecarError(
                 f"unexpected order type — only plain limit orders are built here: {wire.get('t')!r}"
             )
+        if list((wire["t"]["limit"] or {}).keys()) != ["tif"]:
+            raise PmxtSidecarError(
+                f"unexpected fields inside the limit order type: {wire['t']['limit']!r}"
+            )
 
-        got_tif = (wire["t"]["limit"] or {}).get("tif")
+        got_tif = wire["t"]["limit"].get("tif")
         if got_tif != want_tif:
             raise PmxtSidecarError(f"tif mismatch: wire {got_tif!r}, wanted {want_tif!r}")
 
@@ -446,6 +462,11 @@ class PmxtHyperliquidVenue:
 
         if wire.get("r") is not False:
             raise PmxtSidecarError(f"unexpected reduce_only on wire: r={wire.get('r')!r}")
+
+
+#: pmxt's ``floatToWire`` does ``x.toFixed(8)`` before stringifying, so eight
+#: decimal places is exactly the normalization it is entitled to apply.
+_WIRE_QUANTUM = Decimal("1e-8")
 
 
 def _is_positive_number(x: Any) -> bool:
@@ -463,10 +484,17 @@ def _wire_equals(wire_value: Any, requested: float) -> bool:
     compare equal to a requested ``0.1`` and be signed. Decimal comparison is
     what "exact" has to mean for a gate whose job is catching drift, while
     still accepting genuine restyling like ``"1859.30"`` for ``1859.3``.
+
+    But comparing decimals *exactly* rejects pmxt's legitimate 8dp rounding: an
+    ordinary arithmetic-derived price (``0.1 + 0.2``, for which pmxt emits
+    ``"0.3"``) would be refused, and mid-price arithmetic produces those
+    constantly. So quantize the REQUEST to pmxt's own 8dp and require the wire
+    to match that exactly — legitimate rounding passes, drift beyond it fails.
     """
     if not isinstance(wire_value, str):
         return False
     try:
-        return Decimal(wire_value) == Decimal(str(requested))
-    except (TypeError, ValueError, InvalidOperation):
+        want = Decimal(str(requested)).quantize(_WIRE_QUANTUM)
+        return Decimal(wire_value) == want
+    except (TypeError, ValueError, InvalidOperation, ArithmeticError):
         return False

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -94,7 +94,7 @@ class PmxtHyperliquidVenue:
        accepts only one — a paired buy/sell could leave a naked leg. This is
        pre-existing and shared with ``HyperliquidVenue`` (both stamp the same
        way; the official SDK's ``get_timestamp_ms`` is the same expression) and
-       is tracked as its own fix — a signer-scoped monotonic allocator. Until
+       is tracked as SIM-4223 — a signer-scoped monotonic allocator. Until
        then, do not fan out rapid sequential orders on one key.
     """
 

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -32,7 +32,7 @@ being silently dropped — a reduce-only flag that quietly becomes ``False`` on
 a closing order is a money-path bug. Use ``HyperliquidVenue`` for those.
 """
 
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, localcontext
 from typing import Any, Dict, List, Optional
 import math
 import re
@@ -278,6 +278,19 @@ class PmxtHyperliquidVenue:
             raise HyperliquidVenueError(
                 f"limit_px must be a positive finite number, got {limit_px!r}"
             )
+        # Reject up front anything pmxt's own floatToWire would refuse to
+        # build, so the gate downstream is comparing exactly-representable
+        # values and the caller gets an error naming the real problem.
+        if not _is_wire_representable(size):
+            raise HyperliquidVenueError(
+                f"size {size!r} is not representable on the HL wire "
+                "(pmxt rounds to 8 decimal places)"
+            )
+        if not _is_wire_representable(limit_px):
+            raise HyperliquidVenueError(
+                f"limit_px {limit_px!r} is not representable on the HL wire "
+                "(pmxt rounds to 8 decimal places)"
+            )
 
         order_type, want_tif = self._resolve_order_type(order_type, tif)
 
@@ -476,6 +489,26 @@ def _is_positive_number(x: Any) -> bool:
     return math.isfinite(x) and x > 0
 
 
+def _is_wire_representable(x: float) -> bool:
+    """True iff ``x`` survives pmxt's ``floatToWire`` unchanged.
+
+    pmxt rounds to 8dp and then *throws* if that moved the value by 1e-12 or
+    more. Mirroring that rule here means anything reaching the gate is exactly
+    representable on the wire, so the gate's comparison is a true equality
+    rather than a tolerance. Without it, a drifted sidecar could return
+    ``"0.00000001"`` for a requested ``1.4e-8`` — a 29% smaller value — and the
+    quantized comparison would accept it even though real pmxt would have
+    refused to build it at all.
+    """
+    try:
+        with localcontext() as ctx:
+            ctx.prec = 60
+            rounded = float(Decimal(str(x)).quantize(_WIRE_QUANTUM))
+    except (TypeError, ValueError, InvalidOperation, ArithmeticError):
+        return False
+    return abs(rounded - x) < 1e-12 and rounded > 0
+
+
 def _wire_equals(wire_value: Any, requested: float) -> bool:
     """True iff a wire string is the requested number, compared in DECIMAL.
 
@@ -494,7 +527,18 @@ def _wire_equals(wire_value: Any, requested: float) -> bool:
     if not isinstance(wire_value, str):
         return False
     try:
-        want = Decimal(str(requested)).quantize(_WIRE_QUANTUM)
-        return Decimal(wire_value) == want
+        # Widen the context: the default 28 significant digits makes quantizing
+        # a large integer price raise, which would false-reject rather than
+        # merely be strict.
+        with localcontext() as ctx:
+            ctx.prec = 60
+            want = Decimal(str(requested)).quantize(_WIRE_QUANTUM)
+            got = Decimal(wire_value)
+        # A wire value of zero or less is never a valid price or size. pmxt
+        # will happily emit "0" for a positive-but-tiny request (5e-13 rounds
+        # to 0 within its own 1e-12 tolerance), and that must not be signed.
+        if want <= 0 or got <= 0:
+            return False
+        return got == want
     except (TypeError, ValueError, InvalidOperation, ArithmeticError):
         return False

--- a/simmer_sdk/pmxt_sidecar.py
+++ b/simmer_sdk/pmxt_sidecar.py
@@ -132,10 +132,15 @@ class PmxtSidecarClient:
         orders = action.get("orders") or []
         if len(orders) != 1:
             raise PmxtSidecarError(f"expected exactly 1 order wire, got {len(orders)}")
+        # Types are checked exactly, not just values: Python's `==` treats
+        # `1.0 == 1` and `1 == True` as equal, but msgpack encodes them
+        # differently, so a type-drifted action would pass this gate and then
+        # fail opaquely at submit with a signature/hash error. Catch it here,
+        # where the message says what actually changed.
         wire = orders[0]
-        if wire.get("a") != asset_id:
+        if type(wire.get("a")) is not int or wire["a"] != asset_id:
             raise PmxtSidecarError(f"asset mismatch: wire a={wire.get('a')!r}, wanted {asset_id}")
-        if wire.get("b") != is_buy:
+        if type(wire.get("b")) is not bool or wire["b"] != is_buy:
             raise PmxtSidecarError(f"side mismatch: wire b={wire.get('b')!r}, wanted is_buy={is_buy}")
 
         if builder is None:
@@ -146,7 +151,12 @@ class PmxtSidecarClient:
             return
         want = {"b": builder.lower(), "f": builder_fee_tenths_bp}
         got = action.get("builder")
-        if got != want:
+        if (
+            not isinstance(got, dict)
+            or list(got.keys()) != ["b", "f"]
+            or type(got.get("f")) is not int
+            or got != want
+        ):
             raise PmxtSidecarError(f"builder mismatch: got {got!r}, wanted {want!r}")
 
 

--- a/tests/test_pmxt_hyperliquid_venue.py
+++ b/tests/test_pmxt_hyperliquid_venue.py
@@ -329,6 +329,29 @@ def test_rejects_missing_builder(monkeypatch):
     _expect_rejected_before_signing(monkeypatch, stripped, "builder mismatch")
 
 
+def test_rejects_unexpected_wire_field(monkeypatch):
+    """An upstream addition (a generated cloid, a trigger leg) must not be
+    signed blind just because the fields we check happen to be right."""
+    _expect_rejected_before_signing(
+        monkeypatch, _mutated(c="0x" + "aa" * 16), "unexpected order-wire fields"
+    )
+
+
+def test_rejects_unexpected_action_field(monkeypatch):
+    extra = dict(FIXTURE_RAW, expiresAfter=123)
+    _expect_rejected_before_signing(monkeypatch, extra, "unexpected action fields")
+
+
+def test_rejects_non_limit_order_type(monkeypatch):
+    """A trigger/TP-SL order shape reaching the signer would be a different
+    order from the one requested."""
+    _expect_rejected_before_signing(
+        monkeypatch,
+        _mutated(t={"trigger": {"isMarket": True, "triggerPx": "1800", "tpsl": "sl"}}),
+        "only plain limit orders",
+    )
+
+
 def test_rejects_multi_order_action(monkeypatch):
     doubled = dict(FIXTURE_RAW, orders=[FIXTURE_RAW["orders"][0]] * 2)
     _expect_rejected_before_signing(monkeypatch, doubled, "exactly 1 order")

--- a/tests/test_pmxt_hyperliquid_venue.py
+++ b/tests/test_pmxt_hyperliquid_venue.py
@@ -61,8 +61,11 @@ class _StubSigner:
 class _StubSidecar:
     """Stands in for PmxtSidecarClient; records params, returns a fixed action.
 
-    Uses the REAL ``assert_built_action`` so the pre-sign gate under test is the
-    shipped one, not a stub.
+    Deliberately exposes a NO-OP ``assert_built_action``. The sidecar is an
+    injectable transport seam, so if the venue ever dispatches the pre-sign gate
+    through the instance instead of calling the class, every gate test in this
+    file goes green while verifying nothing. This stub is what keeps that
+    regression impossible to miss.
     """
 
     base_url = "http://127.0.0.1:8080"
@@ -79,7 +82,9 @@ class _StubSidecar:
         self.params.append(params)
         return self._action
 
-    assert_built_action = staticmethod(PmxtSidecarClient.assert_built_action)
+    @staticmethod
+    def assert_built_action(*args, **kwargs):
+        return None
 
 
 class _FakeResp:
@@ -357,6 +362,60 @@ def test_rejects_multi_order_action(monkeypatch):
     _expect_rejected_before_signing(monkeypatch, doubled, "exactly 1 order")
 
 
+def test_gate_is_not_bypassable_via_the_injected_sidecar(monkeypatch):
+    """The sidecar is a transport seam; it must not be able to supply the
+    verification policy. `_StubSidecar.assert_built_action` is a no-op, so if
+    the venue dispatched the gate through the instance this would pass a
+    two-BUY-orders-on-the-wrong-asset action straight to the signer."""
+    hostile = dict(
+        FIXTURE_RAW,
+        orders=[
+            dict(FIXTURE_RAW["orders"][0], a=2, b=True),
+            dict(FIXTURE_RAW["orders"][0], a=2, b=True),
+        ],
+    )
+    _expect_rejected_before_signing(monkeypatch, hostile, "exactly 1 order")
+
+
+def test_rejects_type_drifted_asset(monkeypatch):
+    """`1.0 == 1` in Python but encodes differently in msgpack — catch it at
+    the gate, not as an opaque signature failure at submit."""
+    _expect_rejected_before_signing(monkeypatch, _mutated(a=1.0), "asset mismatch")
+
+
+def test_rejects_type_drifted_side(monkeypatch):
+    """`0 == False`, so an int side must not sneak past the bool check."""
+    _expect_rejected_before_signing(monkeypatch, _mutated(b=0), "side mismatch")
+
+
+def test_rejects_type_drifted_builder_fee(monkeypatch):
+    """`10.0 == 10` — an "exact" builder match must mean exact."""
+    floaty = dict(FIXTURE_RAW, builder={"b": BUILDER.lower(), "f": 10.0})
+    _expect_rejected_before_signing(monkeypatch, floaty, "builder mismatch")
+
+
+def test_rejects_sub_ulp_price_drift(monkeypatch):
+    """float('0.10000000000000001') == 0.1, so a float comparison would sign
+    a price we never asked for. The gate compares decimals."""
+    calls = []
+    v = _venue(monkeypatch, action=_mutated(p="0.10000000000000001"), capture=calls)
+    with pytest.raises(PmxtSidecarError, match="price mismatch"):
+        v.place_order(size=0.01, limit_px=0.1, is_buy=False, asset_id=1, order_type="market")
+    assert v._signer.calls == []
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_rejects_non_finite_size_and_price(monkeypatch, bad):
+    """NaN fails every comparison, so a bare `<= 0` guard would wave it
+    through and serialize into the order as JSON NaN."""
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="finite"):
+        v.place_order(size=bad, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    with pytest.raises(HyperliquidVenueError, match="finite"):
+        v.place_order(size=0.01, limit_px=bad, is_buy=False, asset_id=1, order_type="market")
+    assert v._sidecar.params == []
+
+
 def test_price_comparison_is_exact_not_stringwise(monkeypatch):
     """pmxt's floatToWire raises rather than rounding, so '1859.30' == 1859.3
     is a legitimate equality — compare numerically, not as strings."""
@@ -395,6 +454,29 @@ def test_alo_post_only_is_rejected(monkeypatch):
     v = _venue(monkeypatch)
     with pytest.raises(HyperliquidVenueError, match="not reachable"):
         v.place_order(size=0.01, limit_px=1859.3, is_buy=True, asset_id=1, tif="Alo")
+
+
+@pytest.mark.parametrize(
+    "kw,match",
+    [
+        ({"asset_id": "1"}, "asset_id must be an int"),
+        ({"asset_id": True}, "asset_id must be an int"),
+        ({"size": 0}, "size must be a positive"),
+        ({"size": -1.0}, "size must be a positive"),
+        ({"limit_px": 0}, "limit_px must be a positive"),
+        ({"limit_px": -5.0}, "limit_px must be a positive"),
+    ],
+)
+def test_bad_arguments_fail_with_a_naming_error(monkeypatch, kw, match):
+    """The failure should name the bad argument, not surface later as an
+    inscrutable gate mismatch."""
+    v = _venue(monkeypatch)
+    args = dict(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    args.update(kw)
+    with pytest.raises(HyperliquidVenueError, match=match):
+        v.place_order(**args)
+    assert v._sidecar.params == [], "bad arguments reached the sidecar"
+    assert v._signer.calls == []
 
 
 def test_unknown_order_type_is_rejected(monkeypatch):
@@ -466,7 +548,6 @@ def test_reads_accept_explicit_address_override(monkeypatch):
 
 
 def test_cancel_builds_natively_and_submits(monkeypatch):
-    pytest.importorskip("hyperliquid", reason="cancel wire construction uses the HL SDK")
     calls = []
     v = _venue(monkeypatch, capture=calls)
     v.cancel_order(order_id=999, asset_id=1)

--- a/tests/test_pmxt_hyperliquid_venue.py
+++ b/tests/test_pmxt_hyperliquid_venue.py
@@ -1,0 +1,490 @@
+"""Unit tests for PmxtHyperliquidVenue (SIM-4222, A2). No network.
+
+Both hops are mocked: the pmxt sidecar (construction) and HL ``/exchange``
+(submission). A stub signer stands in for ``HyperliquidSigner`` so these run
+without the ``[hyperliquid]`` extra — CI installs the SDK bare, so unlike
+``test_hyperliquid_venue.py`` (which skips) this file actually executes there.
+
+FIXTURE_RAW is the action recorded from a real pmxt-core 2.54.0 sidecar during
+the 2026-07-28 builder-attribution gate run — the same action that signed and
+filled on mainnet with the fee accruing to our builder.
+"""
+
+import json
+
+import pytest
+
+from simmer_sdk.hyperliquid_venue import HyperliquidVenueError
+from simmer_sdk.pmxt_hyperliquid_venue import PmxtHyperliquidVenue
+from simmer_sdk.pmxt_sidecar import PmxtSidecarClient, PmxtSidecarError
+from simmer_sdk.venue_adapter import VenueAdapter
+
+BUILDER = "0xB42D8926BF2Db204Ad27A11817eB2EF2A9f5EF13"
+SIGNER_ADDR = "0x" + "11" * 20
+MAIN_ADDR = "0x" + "ab" * 20
+SIG = {"r": "0x1", "s": "0x2", "v": 27}
+
+# Recorded: market sell, 0.01 ETH @ 1859.3, builder fee 10 tenths-bp (1bp).
+FIXTURE_RAW = {
+    "type": "order",
+    "orders": [
+        {
+            "a": 1,
+            "b": False,
+            "p": "1859.3",
+            "s": "0.01",
+            "r": False,
+            "t": {"limit": {"tif": "Ioc"}},
+        }
+    ],
+    "grouping": "na",
+    "builder": {"b": BUILDER.lower(), "f": 10},
+}
+
+
+class _StubSigner:
+    """Minimal HyperliquidSigner: an address and a signature."""
+
+    address = SIGNER_ADDR
+
+    def __init__(self):
+        self.calls = []
+
+    def sign_l1_action(self, action, nonce, is_mainnet, vault_address=None, expires_after=None):
+        self.calls.append((action, nonce, is_mainnet, vault_address))
+        return SIG
+
+    def sign_user_action(self, action, payload_types, primary_type, is_mainnet):
+        return SIG
+
+
+class _StubSidecar:
+    """Stands in for PmxtSidecarClient; records params, returns a fixed action.
+
+    Uses the REAL ``assert_built_action`` so the pre-sign gate under test is the
+    shipped one, not a stub.
+    """
+
+    base_url = "http://127.0.0.1:8080"
+
+    def __init__(self, action=None, healthy=True):
+        self._action = action if action is not None else FIXTURE_RAW
+        self._healthy = healthy
+        self.params = []
+
+    def health(self):
+        return self._healthy
+
+    def build_order(self, params):
+        self.params.append(params)
+        return self._action
+
+    assert_built_action = staticmethod(PmxtSidecarClient.assert_built_action)
+
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+def _venue(monkeypatch, *, action=None, exchange_response=None, capture=None, **kw):
+    """Venue with both hops mocked; `capture` records HL /exchange posts."""
+    resp = exchange_response if exchange_response is not None else {"status": "ok", "response": {}}
+
+    def _fake_post(url, json=None, timeout=None):
+        if capture is not None:
+            capture.append((url, json))
+        return _FakeResp(200, resp)
+
+    monkeypatch.setattr("simmer_sdk.hyperliquid_venue.requests.post", _fake_post)
+    kw.setdefault("builder_address", BUILDER)
+    return PmxtHyperliquidVenue(_StubSigner(), sidecar=_StubSidecar(action), **kw)
+
+
+# ---- protocol + identity --------------------------------------------------
+
+
+def test_conforms_to_venue_adapter_protocol(monkeypatch):
+    v = _venue(monkeypatch)
+    assert isinstance(v, VenueAdapter)
+    assert v.venue == "hyperliquid"  # same venue; construction locus is internal
+    assert v.construction == "pmxt"
+
+
+def test_main_address_is_account_of_record(monkeypatch):
+    v = _venue(monkeypatch, main_address=MAIN_ADDR)
+    assert v.address == MAIN_ADDR
+    assert v.signer_address == SIGNER_ADDR
+
+
+def test_address_defaults_to_signer_for_raw_key_setups(monkeypatch):
+    v = _venue(monkeypatch)
+    assert v.address == SIGNER_ADDR
+
+
+def test_testnet_base_url(monkeypatch):
+    v = _venue(monkeypatch, is_mainnet=False)
+    assert v.base_url == "https://api.hyperliquid-testnet.xyz"
+    assert v.is_mainnet is False
+
+
+# ---- builder configuration ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "not-an-address",
+        "0x123",
+        "B42D8926BF2Db204Ad27A11817eB2EF2A9f5EF13",  # missing 0x
+        "0x" + "11" * 32,  # a 32-byte private key must never pass as an address
+        None,
+        12345,
+    ],
+)
+def test_rejects_invalid_builder_address(bad):
+    with pytest.raises(ValueError, match="builder_address"):
+        PmxtHyperliquidVenue(_StubSigner(), builder_address=bad, sidecar=_StubSidecar())
+
+
+def test_rejects_negative_builder_fee():
+    with pytest.raises(ValueError, match="non-negative"):
+        PmxtHyperliquidVenue(
+            _StubSigner(), builder_address=BUILDER, builder_fee_tenths_bp=-1,
+            sidecar=_StubSidecar(),
+        )
+
+
+def test_rejects_non_int_builder_fee():
+    with pytest.raises(ValueError, match="must be an int"):
+        PmxtHyperliquidVenue(
+            _StubSigner(), builder_address=BUILDER, builder_fee_tenths_bp=1.0,
+            sidecar=_StubSidecar(),
+        )
+
+
+def test_default_builder_fee_is_one_bp(monkeypatch):
+    """10 tenths-bp = 1bp — the rate the gate run filled at."""
+    assert _venue(monkeypatch).builder_fee_tenths_bp == 10
+
+
+# ---- param mapping (our args → pmxt CreateOrderParams) --------------------
+
+
+def test_place_order_maps_params_to_pmxt_contract(monkeypatch):
+    v = _venue(monkeypatch)
+    v.place_order(
+        size=0.01, limit_px=1859.3, is_buy=False, asset_id=1,
+        order_type="market", market_id="ETH",
+    )
+    assert v._sidecar.params[0] == {
+        "outcomeId": "1",  # numeric asset id AS A STRING — pmxt parseInt's it
+        "side": "sell",
+        "type": "market",
+        "amount": 0.01,
+        "price": 1859.3,
+        "builder": BUILDER,  # string address, not the {b,f} object
+        "builderFee": 10,  # separate int, tenths of a basis point
+        "marketId": "ETH",
+    }
+
+
+def test_price_is_always_sent(monkeypatch):
+    """An omitted price silently defaults to '0.5' in pmxt — catastrophic on a
+    perp. limit_px is required, so `price` is present on every build."""
+    v = _venue(monkeypatch)
+    v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    assert v._sidecar.params[0]["price"] == 1859.3
+
+
+def test_market_id_omitted_when_not_given(monkeypatch):
+    v = _venue(monkeypatch)
+    v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    assert "marketId" not in v._sidecar.params[0]
+
+
+# ---- signing + submission -------------------------------------------------
+
+
+def test_signs_the_pmxt_built_action_and_submits_to_hl(monkeypatch):
+    calls = []
+    resp = {"status": "ok", "response": {"type": "order", "data": {"statuses": [{"filled": {"oid": 504113172815}}]}}}
+    v = _venue(monkeypatch, capture=calls, exchange_response=resp)
+
+    out = v.place_order(
+        size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market"
+    )
+
+    # signed exactly the action pmxt built — no post-build mutation
+    signed_action, nonce, is_mainnet, vault = v._signer.calls[0]
+    assert signed_action is FIXTURE_RAW
+    assert is_mainnet is True
+    assert nonce > 0
+
+    url, body = calls[0]
+    assert url == "https://api.hyperliquid.xyz/exchange"
+    assert body["action"] == FIXTURE_RAW
+    assert body["action"]["builder"] == {"b": BUILDER.lower(), "f": 10}
+    assert body["signature"] == SIG
+    assert body["nonce"] == nonce
+    assert out["response"]["data"]["statuses"][0]["filled"]["oid"] == 504113172815
+
+
+def test_msgpack_key_order_survives_to_submission(monkeypatch):
+    """Key order is hash-relevant; nothing between build and submit may reorder."""
+    calls = []
+    v = _venue(monkeypatch, capture=calls)
+    v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    action = calls[0][1]["action"]
+    assert list(action.keys()) == ["type", "orders", "grouping", "builder"]
+    assert list(action["orders"][0].keys()) == ["a", "b", "p", "s", "r", "t"]
+
+
+def test_vault_address_threads_through_signing_and_submit(monkeypatch):
+    calls = []
+    vault = "0x" + "cd" * 20
+    v = _venue(monkeypatch, capture=calls, vault_address=vault)
+    v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    assert v._signer.calls[0][3] == vault
+    assert calls[0][1]["vaultAddress"] == vault
+
+
+def test_exchange_error_raises(monkeypatch):
+    v = _venue(monkeypatch, exchange_response={"status": "err", "response": "Insufficient margin"})
+    with pytest.raises(HyperliquidVenueError, match="Insufficient margin"):
+        v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+
+
+# ---- the pre-sign gate ----------------------------------------------------
+#
+# Every case here must fail BEFORE signing: an unverified action must never
+# reach the key.
+
+
+def _mutated(**wire_changes):
+    wire = dict(FIXTURE_RAW["orders"][0], **wire_changes)
+    return dict(FIXTURE_RAW, orders=[wire])
+
+
+def _expect_rejected_before_signing(monkeypatch, action, match):
+    calls = []
+    v = _venue(monkeypatch, action=action, capture=calls)
+    with pytest.raises(PmxtSidecarError, match=match):
+        v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    assert v._signer.calls == [], "signed an action that failed verification"
+    assert calls == [], "submitted an action that failed verification"
+
+
+def test_rejects_wrong_asset(monkeypatch):
+    _expect_rejected_before_signing(monkeypatch, _mutated(a=2), "asset mismatch")
+
+
+def test_rejects_wrong_side(monkeypatch):
+    _expect_rejected_before_signing(monkeypatch, _mutated(b=True), "side mismatch")
+
+
+def test_rejects_wrong_price(monkeypatch):
+    _expect_rejected_before_signing(monkeypatch, _mutated(p="1860.0"), "price mismatch")
+
+
+def test_rejects_defaulted_price(monkeypatch):
+    """pmxt's '0.5' default for an omitted price is the canonical footgun."""
+    _expect_rejected_before_signing(monkeypatch, _mutated(p="0.5"), "price mismatch")
+
+
+def test_rejects_wrong_size(monkeypatch):
+    _expect_rejected_before_signing(monkeypatch, _mutated(s="1.0"), "size mismatch")
+
+
+def test_rejects_wrong_tif(monkeypatch):
+    """A market order that came back Gtc would rest instead of crossing."""
+    _expect_rejected_before_signing(
+        monkeypatch, _mutated(t={"limit": {"tif": "Gtc"}}), "tif mismatch"
+    )
+
+
+def test_rejects_reduce_only_flipped_on(monkeypatch):
+    _expect_rejected_before_signing(monkeypatch, _mutated(r=True), "reduce_only")
+
+
+def test_rejects_wrong_builder_address(monkeypatch):
+    imposter = dict(FIXTURE_RAW, builder={"b": "0x" + "99" * 20, "f": 10})
+    _expect_rejected_before_signing(monkeypatch, imposter, "builder mismatch")
+
+
+def test_rejects_wrong_builder_fee(monkeypatch):
+    """f is tenths of a bp; a 10x unit slip is the canonical mistake."""
+    fat = dict(FIXTURE_RAW, builder={"b": BUILDER.lower(), "f": 100})
+    _expect_rejected_before_signing(monkeypatch, fat, "builder mismatch")
+
+
+def test_rejects_missing_builder(monkeypatch):
+    """Silently unattributed orders are the whole reason this adapter exists."""
+    stripped = {k: v for k, v in FIXTURE_RAW.items() if k != "builder"}
+    _expect_rejected_before_signing(monkeypatch, stripped, "builder mismatch")
+
+
+def test_rejects_multi_order_action(monkeypatch):
+    doubled = dict(FIXTURE_RAW, orders=[FIXTURE_RAW["orders"][0]] * 2)
+    _expect_rejected_before_signing(monkeypatch, doubled, "exactly 1 order")
+
+
+def test_price_comparison_is_exact_not_stringwise(monkeypatch):
+    """pmxt's floatToWire raises rather than rounding, so '1859.30' == 1859.3
+    is a legitimate equality — compare numerically, not as strings."""
+    calls = []
+    v = _venue(monkeypatch, action=_mutated(p="1859.30"), capture=calls)
+    v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    assert len(calls) == 1
+
+
+# ---- unsupported capabilities fail loudly ---------------------------------
+
+
+def test_reduce_only_is_rejected_not_dropped(monkeypatch):
+    """pmxt hardcodes r=false. Silently dropping this on a closing order would
+    be a money-path bug, so it raises and points at the native adapter."""
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="reduce_only"):
+        v.place_order(
+            size=0.01, limit_px=1859.3, is_buy=False, asset_id=1,
+            order_type="market", reduce_only=True,
+        )
+    assert v._signer.calls == []
+
+
+def test_cloid_is_rejected_not_dropped(monkeypatch):
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="cloid"):
+        v.place_order(
+            size=0.01, limit_px=1859.3, is_buy=False, asset_id=1,
+            order_type="market", cloid="0x" + "aa" * 16,
+        )
+
+
+def test_alo_post_only_is_rejected(monkeypatch):
+    """Alo is unreachable through pmxt construction."""
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="not reachable"):
+        v.place_order(size=0.01, limit_px=1859.3, is_buy=True, asset_id=1, tif="Alo")
+
+
+def test_unknown_order_type_is_rejected(monkeypatch):
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="order_type"):
+        v.place_order(size=0.01, limit_px=1859.3, is_buy=True, asset_id=1, order_type="stop")
+
+
+def test_conflicting_order_type_and_tif_is_rejected(monkeypatch):
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="conflicting"):
+        v.place_order(
+            size=0.01, limit_px=1859.3, is_buy=True, asset_id=1,
+            order_type="market", tif="Gtc",
+        )
+
+
+def test_tif_alias_accepted_when_consistent(monkeypatch):
+    calls = []
+    v = _venue(monkeypatch, capture=calls)
+    v.place_order(
+        size=0.01, limit_px=1859.3, is_buy=False, asset_id=1,
+        order_type="market", tif="Ioc",
+    )
+    assert len(calls) == 1
+
+
+# ---- reads delegate to the account-of-record ------------------------------
+
+
+def test_reads_use_main_address(monkeypatch):
+    calls = []
+    state = {"assetPositions": [{"position": {"coin": "ETH"}}], "marginSummary": {"accountValue": "100.5"}, "withdrawable": "42.0"}
+
+    def _fake_post(url, json=None, timeout=None):
+        calls.append((url, json))
+        return _FakeResp(200, state)
+
+    monkeypatch.setattr("simmer_sdk.hyperliquid_venue.requests.post", _fake_post)
+    v = PmxtHyperliquidVenue(
+        _StubSigner(), builder_address=BUILDER, main_address=MAIN_ADDR, sidecar=_StubSidecar()
+    )
+
+    assert v.get_positions() == state["assetPositions"]
+    assert v.get_balances()["account_value"] == "100.5"
+    v.get_open_orders()
+
+    for _, body in calls:
+        assert body["user"] == MAIN_ADDR, "read keyed to the signer, not the account"
+
+
+def test_reads_accept_explicit_address_override(monkeypatch):
+    calls = []
+
+    def _fake_post(url, json=None, timeout=None):
+        calls.append((url, json))
+        return _FakeResp(200, {"assetPositions": []})
+
+    monkeypatch.setattr("simmer_sdk.hyperliquid_venue.requests.post", _fake_post)
+    v = PmxtHyperliquidVenue(
+        _StubSigner(), builder_address=BUILDER, main_address=MAIN_ADDR, sidecar=_StubSidecar()
+    )
+    other = "0x" + "ef" * 20
+    v.get_positions(other)
+    assert calls[0][1]["user"] == other
+
+
+# ---- cancel ---------------------------------------------------------------
+
+
+def test_cancel_builds_natively_and_submits(monkeypatch):
+    pytest.importorskip("hyperliquid", reason="cancel wire construction uses the HL SDK")
+    calls = []
+    v = _venue(monkeypatch, capture=calls)
+    v.cancel_order(order_id=999, asset_id=1)
+    assert calls[0][1]["action"] == {"type": "cancel", "cancels": [{"a": 1, "o": 999}]}
+    assert v._sidecar.params == [], "cancel must not touch the sidecar"
+
+
+# ---- preflight ------------------------------------------------------------
+
+
+def test_preflight_passes_against_recorded_contract(monkeypatch):
+    """A Gtc probe must come back Gtc; the fixture is Ioc, so preflight needs
+    its own action shaped like a limit order."""
+    probe = {
+        "type": "order",
+        "orders": [{"a": 1, "b": True, "p": "1000.0", "s": "0.01", "r": False, "t": {"limit": {"tif": "Gtc"}}}],
+        "grouping": "na",
+        "builder": {"b": BUILDER.lower(), "f": 10},
+    }
+    v = _venue(monkeypatch, action=probe)
+    v.preflight()
+    assert v._sidecar.params[0]["type"] == "limit"
+
+
+def test_preflight_fails_on_unhealthy_sidecar():
+    v = PmxtHyperliquidVenue(
+        _StubSigner(), builder_address=BUILDER, sidecar=_StubSidecar(healthy=False)
+    )
+    with pytest.raises(PmxtSidecarError, match="unhealthy"):
+        v.preflight()
+
+
+def test_preflight_fails_on_drifted_shape(monkeypatch):
+    """Startup handshake is the tripwire for an undocumented dispatcher that
+    changed under us — catch it before the first trade, not during."""
+    drifted = {
+        "type": "order",
+        "orders": [{"a": 1, "b": True, "p": "1000.0", "s": "0.01", "r": False, "t": {"limit": {"tif": "Gtc"}}}],
+        "grouping": "na",
+        # builder dropped upstream → orders would fill unattributed
+    }
+    v = _venue(monkeypatch, action=drifted)
+    with pytest.raises(PmxtSidecarError, match="builder mismatch"):
+        v.preflight()

--- a/tests/test_pmxt_hyperliquid_venue.py
+++ b/tests/test_pmxt_hyperliquid_venue.py
@@ -441,6 +441,39 @@ def test_rejects_drift_beyond_8dp_rounding(monkeypatch):
     _expect_rejected_before_signing(monkeypatch, _mutated(p="1859.4"), "price mismatch")
 
 
+def test_rejects_requests_pmxt_could_not_build(monkeypatch):
+    """pmxt's floatToWire throws if 8dp rounding moves a value by >= 1e-12.
+    Mirroring that means a drifted sidecar cannot return "0.00000001" for a
+    requested 1.4e-8 — a 29% smaller value — and have it accepted."""
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="not representable"):
+        v.place_order(size=1.4e-8, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    with pytest.raises(HyperliquidVenueError, match="not representable"):
+        v.place_order(size=0.01, limit_px=1.4e-8, is_buy=False, asset_id=1, order_type="market")
+    assert v._sidecar.params == []
+
+
+def test_rejects_positive_but_sub_wire_precision_values(monkeypatch):
+    """pmxt emits "0" for 5e-13 (inside its own 1e-12 tolerance). A zero price
+    must never be signed just because the request was nominally positive."""
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="not representable"):
+        v.place_order(size=0.01, limit_px=5e-13, is_buy=False, asset_id=1, order_type="market")
+
+
+def test_rejects_zero_wire_value_from_the_sidecar(monkeypatch):
+    _expect_rejected_before_signing(monkeypatch, _mutated(p="0"), "price mismatch")
+
+
+def test_large_integer_price_is_not_falsely_rejected(monkeypatch):
+    """Decimal's default 28-digit context would raise while quantizing a large
+    integer price, turning a valid order into a refusal."""
+    calls = []
+    v = _venue(monkeypatch, action=_mutated(p="100000000000000000000"), capture=calls)
+    v.place_order(size=0.01, limit_px=1e20, is_buy=False, asset_id=1, order_type="market")
+    assert len(calls) == 1
+
+
 def test_rejects_unexpected_fields_inside_the_limit_type(monkeypatch):
     _expect_rejected_before_signing(
         monkeypatch,

--- a/tests/test_pmxt_hyperliquid_venue.py
+++ b/tests/test_pmxt_hyperliquid_venue.py
@@ -417,12 +417,59 @@ def test_rejects_non_finite_size_and_price(monkeypatch, bad):
 
 
 def test_price_comparison_is_exact_not_stringwise(monkeypatch):
-    """pmxt's floatToWire raises rather than rounding, so '1859.30' == 1859.3
-    is a legitimate equality — compare numerically, not as strings."""
+    """'1859.30' for 1859.3 is a legitimate restyle — compare numerically."""
     calls = []
     v = _venue(monkeypatch, action=_mutated(p="1859.30"), capture=calls)
     v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
     assert len(calls) == 1
+
+
+def test_accepts_pmxts_legitimate_8dp_rounding(monkeypatch):
+    """An arithmetic-derived price is the common case, not the exotic one:
+    0.1 + 0.2 is 0.30000000000000004, and pmxt's toFixed(8) legitimately emits
+    '0.3'. The gate must not reject its own pinned version's normalization."""
+    calls = []
+    v = _venue(monkeypatch, action=_mutated(p="0.3", s="0.3"), capture=calls)
+    v.place_order(
+        size=0.1 + 0.2, limit_px=0.1 + 0.2, is_buy=False, asset_id=1, order_type="market"
+    )
+    assert len(calls) == 1, "rejected a price pmxt is entitled to produce"
+
+
+def test_rejects_drift_beyond_8dp_rounding(monkeypatch):
+    """Tolerating 8dp rounding must not tolerate anything past it."""
+    _expect_rejected_before_signing(monkeypatch, _mutated(p="1859.4"), "price mismatch")
+
+
+def test_rejects_unexpected_fields_inside_the_limit_type(monkeypatch):
+    _expect_rejected_before_signing(
+        monkeypatch,
+        _mutated(t={"limit": {"tif": "Ioc", "unexpected": True}}),
+        "unexpected fields inside the limit",
+    )
+
+
+def test_rejects_non_bool_is_buy(monkeypatch):
+    """A truthy non-bool would pick a side by accident and then satisfy the
+    type-exact wire check anyway, since True == 1.0."""
+    v = _venue(monkeypatch)
+    with pytest.raises(HyperliquidVenueError, match="is_buy must be a bool"):
+        v.place_order(size=0.01, limit_px=1859.3, is_buy=1.0, asset_id=1, order_type="market")
+    assert v._sidecar.params == []
+
+
+@pytest.mark.parametrize(
+    "kw", [{"order_id": "999"}, {"order_id": True}, {"asset_id": "1"}, {"asset_id": True}]
+)
+def test_cancel_validates_wire_types(monkeypatch, kw):
+    """Cancel args go straight into the signed wire with nothing downstream to
+    catch them."""
+    v = _venue(monkeypatch)
+    args = dict(order_id=999, asset_id=1)
+    args.update(kw)
+    with pytest.raises(HyperliquidVenueError, match="must be an int"):
+        v.cancel_order(**args)
+    assert v._signer.calls == []
 
 
 # ---- unsupported capabilities fail loudly ---------------------------------


### PR DESCRIPTION
A2 of the pmxt Hyperliquid adapter. Turns the 2026-07-28 builder-attribution
gate pass (two live mainnet ETH-perp fills through stock pmxt-core 2.54.0, fees
accrued on-ledger to our builder) into the `VenueAdapter` implementation.

## The chain

```
pmxt sidecar buildOrder  → constructs the venue-correct unsigned action
  → assert_built_action  → verify it is what we asked for, BEFORE signing
  → HyperliquidSigner    → signs locally (raw key or OWS); no key near pmxt
  → HL /exchange         → we submit directly; pmxt takes no toll
```

What pmxt buys is **outsourced construction maintenance** — asset universe,
wire encoding, perps/spot/HIP-4 coverage, future HL protocol drift. That is the
whole rent-vs-build trade, so the adapter stays thin. `HyperliquidVenue` remains
the native anti-corruption fallback: same signer, same submit, same reads.

## Design

**Composes, doesn't fork.** Uses A1's `PmxtSidecarClient` (#290) for
construction and composes `HyperliquidVenue` for signing/submit/reads.
Composition rather than inheritance because `place_order` takes a raw HL asset
id where the native adapter takes a HIP-4 outcome id — the two are not
substitutable on that method. To keep one transport implementation on the money
path, `HyperliquidVenue._post_action` becomes the public `submit_action`.

**The pre-sign gate is the load-bearing part.** A1 checks
header/asset/side/builder; A2 adds the economic terms it doesn't cover — price,
size, tif, `reduce_only`. Exact numeric equality is correct here because both
pmxt's `floatToWire` and the HL SDK's `float_to_wire` raise rather than round
(verified in both sources), so a differing wire value is drift, not
normalization. The price check also catches pmxt's omitted-price default of
`'0.5'`, which would be catastrophic on a perp. `preflight()` runs the same gate
at startup against a live `buildOrder`, so a drifted undocumented dispatcher
surfaces before the first trade rather than during it.

## Capability gaps — raised, not silently dropped

Found by reading pmxt-core 2.54.0's `buildOrder` and confirmed against a live
sidecar: it hardcodes `r: false`, never emits `c`, and reaches only
`Gtc`/`Ioc`. So `reduce_only`, `cloid` and `Alo` raise and point at the native
adapter. A reduce-only flag that quietly becomes `False` on a closing order is a
money-path bug. **This belongs in the spec's open-items table** (follow-up —
the spec lives in the `simmer` repo).

## Non-negotiables from the spec

- Action asserted before signing — exact builder `{b, f}` match plus wire terms.
- `main_address` is the account-of-record; the signer address is never assumed
  to be the account (under `approveAgent` it isn't).
- One venue instance per key; no concurrent `place_order` (HL nonces).
- The builder key appears nowhere — only the public `HL_BUILDER_ADDRESS`. The
  address-format guard also rejects a 32-byte private key by construction.

## Verification

- **59 unit tests pass in a bare env with no `[hyperliquid]` extra** — the CI
  condition. The native adapter's tests skip there; these run.
- Full suite green: **673 passed, 4 skipped**.
- **Live integration check** against a pinned pmxt-core 2.54.0 sidecar
  reproduces the gate-run action byte-for-byte with the builder attached, and
  a deliberately mismatched fee is caught pre-signing.

Every gate test asserts the signer was **never called** — an unverified action
must not reach the key.

## Not in scope

A3 (HIP-4 asset-id resolution), A4 (sidecar deploy story), server slices S1–S6,
and `client.py` wiring.

Refs SIM-4222, SIM-3151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jdTgfDjzMMToPcVdSrDuB