### PR TITLE
fix(hyperliquid): allocate action nonces monotonically per signer (SIM-4223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,29 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   construction and submission are separable and both Hyperliquid adapters share
   one transport and error-handling implementation on the money path.
 - `hyperliquid_signing.now_ms()` no longer requires the `[hyperliquid]` extra.
-  It stamps a nonce with `int(time.time() * 1000)` — identical to the official
-  SDK's `get_timestamp_ms()` — so callers that never build a wire locally don't
-  pull in the SDK just for a timestamp.
+  It returns `int(time.time() * 1000)` — identical to the official SDK's
+  `get_timestamp_ms()` — so callers that never build a wire locally don't pull
+  in the SDK just for a timestamp.
+
+### Fixed
+
+- **Hyperliquid action nonces could collide (SIM-4223).** Both HL adapters
+  stamped the nonce with a bare wall-clock millisecond. Hyperliquid tracks
+  nonces per signing key and accepts each value once, so two actions signed by
+  one key inside the same millisecond collided and only one landed — a paired
+  buy/sell could lose a leg and leave a naked position. This was not only a
+  threading concern: rapid *sequential* orders land in the same millisecond
+  routinely on a fast host.
+
+  Nonces now come from `next_nonce(address)`, which returns
+  `max(now_ms(), last + 1)` under a lock, keyed by signer address so a busy key
+  cannot skew an idle one. Keyed to the *signer*, not the account-of-record,
+  matching HL's per-key accounting under delegated `approveAgent` setups.
+  Remaining bound, documented and unchanged: state is per-process, so give each
+  process its own agent key rather than sharing one across processes.
+
+  No live exposure at fix time — no Hyperliquid trades had been recorded — so
+  this lands before HL execution ships rather than after.
 
 ## [0.24.0] - 2026-07-22
 

--- a/simmer_sdk/hyperliquid_signing.py
+++ b/simmer_sdk/hyperliquid_signing.py
@@ -151,6 +151,16 @@ def next_nonce(address: str) -> int:
       value outruns the clock. HL rejects nonces too far in the future, so a
       sustained rate that high would eventually fail — far above anything the
       SDK does, and it fails closed rather than silently mis-trading.
+    - **Table growth.** One small entry per signing key ever used in the
+      process, never evicted. That is bounded by how many wallets the process
+      trades with (one, or a handful for per-agent cohorts), so it is left
+      unpruned deliberately: eviction logic on the nonce path would be a new
+      failure surface guarding against a size this deployment shape cannot
+      reach.
+
+    Note ``vault_address`` deliberately does NOT select the key. One API wallet
+    shares a single nonce set across its user, vault and subaccount actions, so
+    the signer address is the correct and only partition.
     """
     key = (address or "").lower()
     with _nonce_lock:

--- a/simmer_sdk/hyperliquid_signing.py
+++ b/simmer_sdk/hyperliquid_signing.py
@@ -22,6 +22,7 @@ it lives in the local OWS vault.
 """
 
 import json
+import threading
 import time
 from typing import Any, Dict, Optional, Protocol, runtime_checkable
 
@@ -111,14 +112,51 @@ def build_cancel_action(asset: int, oid: int) -> Dict[str, Any]:
 
 
 def now_ms() -> int:
-    """Millisecond timestamp used as the action nonce.
+    """Millisecond timestamp.
 
     Computed locally rather than via the official SDK's ``get_timestamp_ms``
     (which is the same ``int(time.time() * 1000)``) so that callers who never
     build a wire — e.g. the pmxt-constructed adapter, where pmxt builds the
-    action — do not need the ``[hyperliquid]`` extra just to stamp a nonce.
+    action — do not need the ``[hyperliquid]`` extra just to stamp one.
+
+    Do NOT use this directly as an action nonce; use ``next_nonce`` (below).
     """
     return int(time.time() * 1000)
+
+
+_nonce_lock = threading.Lock()
+_last_nonce_by_address: Dict[str, int] = {}
+
+
+def next_nonce(address: str) -> int:
+    """Allocate a strictly-increasing action nonce for ``address``.
+
+    A bare millisecond timestamp is not a safe nonce. Hyperliquid tracks
+    nonces per signing key and accepts a given value once, so two actions
+    signed by one key inside the same millisecond collide and only one is
+    accepted — a paired buy/sell could lose a leg and leave a naked position.
+    This is not only a threading concern: rapid *sequential* calls land in the
+    same millisecond routinely on a fast host.
+
+    So hand out ``max(now_ms(), last + 1)`` under a lock, keyed by signer
+    address. Keying by address rather than globally matches HL's own per-key
+    accounting and stops a busy key from skewing an idle one's nonces forward.
+
+    Bounds worth knowing:
+
+    - **Cross-process.** State is per-process, so two processes signing with
+      the SAME key can still collide. HL's guidance is a separate API/agent
+      key per process; do that rather than relying on this.
+    - **Sustained overload.** Above ~1000 actions/sec on one key the returned
+      value outruns the clock. HL rejects nonces too far in the future, so a
+      sustained rate that high would eventually fail — far above anything the
+      SDK does, and it fails closed rather than silently mis-trading.
+    """
+    key = (address or "").lower()
+    with _nonce_lock:
+        nonce = max(now_ms(), _last_nonce_by_address.get(key, 0) + 1)
+        _last_nonce_by_address[key] = nonce
+        return nonce
 
 
 def _split_signature(sig_hex: str) -> Dict[str, Any]:

--- a/simmer_sdk/hyperliquid_venue.py
+++ b/simmer_sdk/hyperliquid_venue.py
@@ -25,7 +25,7 @@ from simmer_sdk.hyperliquid_signing import (
     TESTNET_API_URL,
     build_cancel_action,
     build_order_action,
-    now_ms,
+    next_nonce,
     outcome_asset_id,
 )
 
@@ -146,7 +146,7 @@ class HyperliquidVenue:
             cloid=cloid,
             builder=builder,
         )
-        nonce = now_ms()
+        nonce = next_nonce(self.signer_address)
         signature = self._signer.sign_l1_action(
             action, nonce, self.is_mainnet, vault_address=self.vault_address
         )
@@ -156,7 +156,7 @@ class HyperliquidVenue:
         """Cancel a resting order by its venue order id."""
         asset = outcome_asset_id(outcome_id, side)
         action = build_cancel_action(asset, order_id)
-        nonce = now_ms()
+        nonce = next_nonce(self.signer_address)
         signature = self._signer.sign_l1_action(
             action, nonce, self.is_mainnet, vault_address=self.vault_address
         )
@@ -206,7 +206,7 @@ class HyperliquidVenue:
         main key). The agent key can place/cancel orders but cannot withdraw —
         the recommended bot-host setup (P0 finding Q3).
         """
-        nonce = now_ms()
+        nonce = next_nonce(self.signer_address)
         action: Dict[str, Any] = {
             "type": "approveAgent",
             "agentAddress": agent_address,

--- a/simmer_sdk/pmxt_hyperliquid_venue.py
+++ b/simmer_sdk/pmxt_hyperliquid_venue.py
@@ -40,7 +40,7 @@ import re
 from simmer_sdk.hyperliquid_signing import (
     HyperliquidSigner,
     build_cancel_action,
-    now_ms,
+    next_nonce,
 )
 from simmer_sdk.hyperliquid_venue import (
     DEFAULT_TIMEOUT,
@@ -85,17 +85,12 @@ class PmxtHyperliquidVenue:
         sidecar: inject a pre-built ``PmxtSidecarClient`` (tests, custom
             transport). Overrides ``sidecar_url``.
 
-    Keep one venue instance per key and avoid concurrent ``place_order`` calls
-    on the same instance — HL nonces are per-key and monotonic.
-
-    .. warning::
-       The nonce is a wall-clock millisecond (``now_ms``), so two orders signed
-       by the same key inside the same millisecond collide and Hyperliquid
-       accepts only one — a paired buy/sell could leave a naked leg. This is
-       pre-existing and shared with ``HyperliquidVenue`` (both stamp the same
-       way; the official SDK's ``get_timestamp_ms`` is the same expression) and
-       is tracked as SIM-4223 — a signer-scoped monotonic allocator. Until
-       then, do not fan out rapid sequential orders on one key.
+    Keep one venue instance per key — HL nonces are per signing key. Nonces
+    themselves are allocated by ``next_nonce`` (SIM-4223), which is monotonic
+    per signer address and thread-safe, so rapid or concurrent orders on one
+    key no longer collide. The remaining constraint is cross-PROCESS: two
+    processes signing with the same key can still collide, so give each process
+    its own agent key.
     """
 
     venue = "hyperliquid"
@@ -312,7 +307,7 @@ class PmxtHyperliquidVenue:
             want_tif=want_tif,
         )
 
-        nonce = now_ms()
+        nonce = next_nonce(self.signer_address)
         signature = self._signer.sign_l1_action(
             action, nonce, self.is_mainnet, vault_address=self.vault_address
         )
@@ -334,7 +329,7 @@ class PmxtHyperliquidVenue:
                 raise HyperliquidVenueError(f"{name} must be an int, got {value!r}")
 
         action = build_cancel_action(asset_id, order_id)
-        nonce = now_ms()
+        nonce = next_nonce(self.signer_address)
         signature = self._signer.sign_l1_action(
             action, nonce, self.is_mainnet, vault_address=self.vault_address
         )

--- a/tests/test_hyperliquid_nonce.py
+++ b/tests/test_hyperliquid_nonce.py
@@ -1,0 +1,72 @@
+"""Nonce allocation (SIM-4223). No network, no [hyperliquid] extra needed.
+
+A bare wall-clock millisecond is not a safe nonce: HL tracks nonces per signing
+key and accepts each once, so two actions signed by one key inside the same
+millisecond collide and only one lands — a paired buy/sell can lose a leg.
+"""
+
+import threading
+
+from simmer_sdk.hyperliquid_signing import next_nonce, now_ms
+
+ADDR_A = "0x" + "aa" * 20
+ADDR_B = "0x" + "bb" * 20
+
+
+def test_rapid_sequential_calls_never_repeat():
+    """The actual bug: sequential calls land in one millisecond on a fast host.
+    A bare now_ms() returns duplicates here."""
+    nonces = [next_nonce(ADDR_A) for _ in range(2000)]
+    assert len(set(nonces)) == len(nonces), "duplicate nonce issued"
+    assert nonces == sorted(nonces), "nonces not monotonic"
+
+
+def test_bare_timestamp_would_have_collided():
+    """Guards the premise: if now_ms() didn't repeat under this loop, the test
+    above could pass while proving nothing."""
+    stamps = [now_ms() for _ in range(2000)]
+    assert len(set(stamps)) < len(stamps), (
+        "now_ms() did not repeat — this machine is too slow for the test to "
+        "discriminate; the allocator test above is not meaningful here"
+    )
+
+
+def test_addresses_are_tracked_independently():
+    """Keyed per address so a busy key cannot skew an idle key's nonces
+    forward, matching HL's own per-key accounting."""
+    burst = [next_nonce(ADDR_A) for _ in range(500)]
+    fresh = next_nonce(ADDR_B)
+    assert fresh <= max(burst), "idle address inherited a busy address's skew"
+    assert fresh >= now_ms() - 1000
+
+
+def test_address_matching_is_case_insensitive():
+    """Checksummed vs lowercase spellings of one address are one key."""
+    a = next_nonce("0x" + "CD" * 20)
+    b = next_nonce("0x" + "cd" * 20)
+    assert b > a
+
+
+def test_concurrent_allocation_is_unique():
+    """Thread-safe: the lock is what makes read-modify-write atomic."""
+    out = []
+    lock = threading.Lock()
+
+    def worker():
+        got = [next_nonce(ADDR_A) for _ in range(200)]
+        with lock:
+            out.extend(got)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(out)) == len(out), "concurrent callers got a duplicate nonce"
+
+
+def test_nonce_tracks_wall_clock():
+    """Must stay in HL's accepted time window, not drift into the future."""
+    n = next_nonce("0x" + "ef" * 20)
+    assert abs(n - now_ms()) < 5000

--- a/tests/test_pmxt_hyperliquid_venue.py
+++ b/tests/test_pmxt_hyperliquid_venue.py
@@ -240,6 +240,32 @@ def test_signs_the_pmxt_built_action_and_submits_to_hl(monkeypatch):
     assert out["response"]["data"]["statuses"][0]["filled"]["oid"] == 504113172815
 
 
+def test_consecutive_orders_get_distinct_nonces(monkeypatch):
+    """Back-to-back orders land in the same millisecond routinely. A repeated
+    nonce means HL accepts only one of them (SIM-4223)."""
+    calls = []
+    v = _venue(monkeypatch, capture=calls)
+    for _ in range(50):
+        v.place_order(
+            size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market"
+        )
+    nonces = [body["nonce"] for _, body in calls]
+    assert len(set(nonces)) == len(nonces), "two orders shared a nonce"
+    assert nonces == sorted(nonces)
+
+
+def test_nonce_is_keyed_to_the_signer_not_the_account(monkeypatch):
+    """Nonces are per signing key on HL, so an agent-key venue must allocate
+    against the agent address even though reads use main_address."""
+    import simmer_sdk.pmxt_hyperliquid_venue as mod
+
+    seen = []
+    monkeypatch.setattr(mod, "next_nonce", lambda addr: seen.append(addr) or 1)
+    v = _venue(monkeypatch, main_address=MAIN_ADDR)
+    v.place_order(size=0.01, limit_px=1859.3, is_buy=False, asset_id=1, order_type="market")
+    assert seen == [SIGNER_ADDR]
+
+
 def test_msgpack_key_order_survives_to_submission(monkeypatch):
     """Key order is hash-relevant; nothing between build and submit may reorder."""
     calls = []


### PR DESCRIPTION
Both Hyperliquid adapters stamped the action nonce with a bare wall-clock millisecond. HL tracks nonces **per signing key** and accepts each value once, so two actions signed by one key inside the same millisecond collided and only one landed — **a paired buy/sell could lose a leg and leave a naked position**.

The part that makes this more than a threading footnote: **rapid sequential calls land in the same millisecond routinely** on a fast host. A tight loop of 2000 `now_ms()` calls returns a handful of distinct values. A bot placing orders back to back was already exposed, with no concurrency involved.

## Fix

`next_nonce(address)` returns `max(now_ms(), last + 1)` under a lock, keyed by **signer address** rather than globally, so a busy key can't skew an idle key's nonces forward — matching HL's own per-key accounting.

It keys on the **signer, not the account-of-record**: under a delegated `approveAgent` setup the agent key is what HL counts nonces against, while reads still use `main_address`. There's a test pinning that distinction.

## Bounds, documented rather than papered over

- **Cross-process:** state is per-process, so two processes sharing one key can still collide. HL's own guidance is a separate agent key per process — that's the right answer, and this doesn't pretend to solve it.
- **Sustained overload:** above ~1000 actions/sec on one key the counter outruns the clock and would eventually be rejected as too-far-future. Far beyond anything the SDK does, and it fails closed.

## On the tests

`test_bare_timestamp_would_have_collided` is a **premise guard**: it asserts `now_ms()` actually does repeat under the same loop. Without it, the uniqueness test could pass on a slow machine while proving nothing about the allocator.

710 passed, 4 skipped. The nonce tests need no `[hyperliquid]` extra, so they run in CI.

## Context

Found by adversarial review during A2 (#291) and deliberately **not** fixed there — pre-existing, shared by both adapters through one primitive, and worth its own review rather than riding along in an adapter build.

**Zero live exposure at fix time:** `real_trades` has no Hyperliquid rows (polymarket 706K, kalshi 306). This lands before HL execution ships rather than after, which is why it's cheap now.

Closes SIM-4223. Refs SIM-4222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jdTgfDjzMMToPcVdSrDuB