### PR TITLE
fix(mcp): surface the silent skill_slug "unknown" fallback

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "repository": {

--- a/mcp/src/core/state.ts
+++ b/mcp/src/core/state.ts
@@ -103,3 +103,23 @@ export function writeJsonl(workspaceDir: string, data: Record<string, unknown>):
   const jsonlPath = path.join(workspaceDir, "autoresearch.jsonl");
   fs.writeFileSync(jsonlPath, JSON.stringify(data) + "\n");
 }
+
+/**
+ * Warning appended to every run_experiment result when the session has no
+ * skill slug.
+ *
+ * `init_experiment` takes skill_slug as a required param, but if it was never
+ * called (or the jsonl config line is missing) the logger falls back to the
+ * placeholder "unknown". That silently breaks dashboard attribution, API
+ * resume state, and server-side backtest verification of `keep` runs — a user
+ * once logged 45 experiments into the "unknown" bucket with no hint that
+ * anything was wrong. Returns "" when the slug is set.
+ */
+export function skillSlugWarning(skillSlug: string | null): string {
+  if (skillSlug) return "";
+  return (
+    `\n\n⚠️ skill_slug is not set — this run was logged as "unknown".` +
+    `\n   Attribution, resume state, and server-side verification are all broken until you fix it.` +
+    `\n   Call init_experiment with skill_slug (e.g. "polymarket-weather-trader") to correct it.`
+  );
+}

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -102,6 +102,7 @@ import {
   reconstructState,
   appendJsonl,
   writeJsonl,
+  skillSlugWarning,
 } from "./core/state.js";
 import { runCommand } from "./core/runner.js";
 import { gitAutoCommit, gitRevert } from "./core/git.js";
@@ -553,6 +554,9 @@ if (simmer) {
       }
 
       text += `\n(${state.results.length} experiments total)`;
+
+      // Surfaces the silent "unknown" slug fallback (see skillSlugWarning).
+      text += skillSlugWarning(state.skillSlug);
 
       if (status === "keep") {
         const gitResult = await gitAutoCommit(workspaceDir, description, state.metricName, metric, secMetrics);

--- a/mcp/tests/state.test.ts
+++ b/mcp/tests/state.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { reconstructState, defaultState, appendJsonl, writeJsonl } from "../dist/core/state.js";
+import { reconstructState, defaultState, appendJsonl, writeJsonl, skillSlugWarning } from "../dist/core/state.js";
 
 let tmpDir: string;
 
@@ -103,5 +103,22 @@ describe("reconstructState", () => {
     const s = reconstructState(tmpDir);
     assert.equal(s.results.length, 1);
     assert.equal(s.results[0].metric, 10);
+  });
+});
+
+describe("skillSlugWarning", () => {
+  it("warns when the slug is unset — the silent 'unknown' fallback case", () => {
+    const warning = skillSlugWarning(null);
+    assert.ok(warning.includes("skill_slug is not set"), "should name the problem");
+    assert.ok(warning.includes("unknown"), "should say what the run was logged as");
+    assert.ok(warning.includes("init_experiment"), "should name the fix");
+  });
+
+  it("is silent once the slug is set", () => {
+    assert.equal(skillSlugWarning("polymarket-weather-trader"), "");
+  });
+
+  it("treats an empty-string slug as unset", () => {
+    assert.notEqual(skillSlugWarning(""), "");
   });
 });


### PR DESCRIPTION
## Why

`init_experiment` takes `skill_slug` as a required param. But if it was never called — or the `autoresearch.jsonl` config line is missing — `run_experiment` falls back to logging every result under the placeholder slug `"unknown"` and says nothing about it.

That silently breaks three things:

- **Dashboard attribution** — runs group under "unknown" instead of the skill.
- **API resume state** — `getResumeState` is keyed on the slug.
- **Server-side verification** — `run_autoresearch_backtest` gets `skill_slug="unknown"` on `keep` runs and fails.

A Pro user logged **45 experiments into the "unknown" bucket over two days** with no hint anything was wrong. It only surfaced because they opened a support thread about something else. Every one of their rows is mislabeled in prod today.

## What

`run_experiment` now appends a warning to its result whenever the slug is unset, naming both the consequence and the fix. The agent driving the loop reads that output every run, so it self-corrects on the next call.

The POST is **deliberately left alone.** The rows are mislabeled, not worthless, and dropping them would trade a visible problem for an invisible one — which is the exact failure mode this PR exists to fix.

Extracted as `skillSlugWarning` in `core/state.ts` so it's unit-testable. The tool handlers aren't exported and a full protocol test (spawn server, Pro gate, workspace, git) would be disproportionate for a guarded string append.

## Verification

- 3 new cases in `state.test.ts`: unset warns and names the fix, set is silent, empty string counts as unset.
- Full MCP suite: **135 pass / 0 fail**, including `version-consistency` against the bump.
- Version `3.4.7` → `3.4.8` so the publish workflow ships it (auto-fires on merge for `mcp/**`).

## Note on location

The obvious-looking `simmer-autoresearch/` directory in the `simmer` repo is a **deprecated location** ("Do not modify code here", SIM-2045). The live source is `simmer-sdk/mcp/`, which is what this changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gy6yqECseJGEFEYY476wC9