### PR TITLE
fix: check DW approvals in SDK warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.2 (2026-08-07)
+
+- **Approvals warning now checks the deposit wallet, and stops handing DW users a no-op fix (SIM-4344).** `_warn_approvals_once()` called `check_approvals()` with no address, so it always checked the signer EOA. For deposit-wallet users approvals live on the DW, so the EOA is correctly empty and the warning fired every session on healthy accounts. It also told everyone to run `set_approvals()`, which signs from the EOA and does nothing for a DW user. Two customers chased this as a real fault while debugging unrelated rejections (SIM-4351, SIM-4377). Now checks the DW when `_uses_deposit_wallet`, and recommends `activate_polymarket_dw()` for that cohort. The remediation string matters more after this fix, not less: the warning no longer cries wolf, so users will act on it.
+
 ## 0.24.1 (2026-08-06)
 
 - **Restore the legacy NegRiskAdapter to V2 trading spenders (SIM-4377).** Polymarket's 2026-07-18 adapter retirement covers relayer calls targeting the adapter, not the pUSD/CTF allowances where it is the spender — the CLOB still gates every neg-risk fill on that allowance. `set_approvals()` now grants the full 12-tx V2 set again (was 10 after #281); wallets approved without it were silently locked out of neg-risk markets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.1"
+version = "0.24.2"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1779,10 +1779,19 @@ class SimmerClient:
             )
             status = self.check_approvals(address=approvals_address)
             if not status.get("all_set", False):
+                # Remediation differs by cohort. `set_approvals()` signs from the
+                # EOA, which for a deposit-wallet user holds nothing — pointing
+                # them there sends them to a no-op at the exact moment they are
+                # debugging a real rejection (SIM-4344 / SIM-4351).
+                if self._uses_deposit_wallet and self._deposit_wallet_address:
+                    remedy = "Run client.activate_polymarket_dw() to set them."
+                else:
+                    remedy = "Run client.set_approvals() to set them."
                 logger.warning(
                     "Polymarket approvals may be missing for wallet %s. "
-                    "Trade may fail. Use client.set_approvals() to set them.",
-                    approvals_address[:10] + "..."
+                    "Trade may fail. %s",
+                    approvals_address[:10] + "...",
+                    remedy,
                 )
         except Exception as e:
             logger.debug("Could not check approvals: %s", e)

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -1772,12 +1772,17 @@ class SimmerClient:
         self._approvals_checked = True
 
         try:
-            status = self.check_approvals()
+            approvals_address = (
+                self._deposit_wallet_address
+                if self._uses_deposit_wallet and self._deposit_wallet_address
+                else self._wallet_address
+            )
+            status = self.check_approvals(address=approvals_address)
             if not status.get("all_set", False):
                 logger.warning(
                     "Polymarket approvals may be missing for wallet %s. "
                     "Trade may fail. Use client.set_approvals() to set them.",
-                    self._wallet_address[:10] + "..."
+                    approvals_address[:10] + "..."
                 )
         except Exception as e:
             logger.debug("Could not check approvals: %s", e)

--- a/tests/test_warn_approvals_dw.py
+++ b/tests/test_warn_approvals_dw.py
@@ -1,5 +1,6 @@
 """Tests for the once-per-session approvals warning address selection."""
 
+import logging
 from unittest.mock import MagicMock
 
 from simmer_sdk.client import SimmerClient
@@ -33,3 +34,33 @@ def test_warn_approvals_checks_eoa_for_non_dw_users():
     client._warn_approvals_once()
 
     client.check_approvals.assert_called_once_with(address=EOA)
+
+
+def test_warn_approvals_points_dw_users_at_activate_polymarket_dw(caplog):
+    """DW users must NOT be told to run set_approvals().
+
+    `set_approvals()` signs from the EOA, which holds nothing for a
+    deposit-wallet user — the warning would send them to a no-op while they
+    are debugging a real rejection (SIM-4344 / SIM-4351).
+    """
+    client = _make_client(uses_dw=True)
+    client.check_approvals = MagicMock(return_value={"all_set": False})
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client._warn_approvals_once()
+
+    msg = caplog.text
+    assert "activate_polymarket_dw()" in msg
+    assert "set_approvals()" not in msg
+
+
+def test_warn_approvals_points_eoa_users_at_set_approvals(caplog):
+    client = _make_client(uses_dw=False)
+    client.check_approvals = MagicMock(return_value={"all_set": False})
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client._warn_approvals_once()
+
+    msg = caplog.text
+    assert "set_approvals()" in msg
+    assert "activate_polymarket_dw()" not in msg

--- a/tests/test_warn_approvals_dw.py
+++ b/tests/test_warn_approvals_dw.py
@@ -1,0 +1,35 @@
+"""Tests for the once-per-session approvals warning address selection."""
+
+from unittest.mock import MagicMock
+
+from simmer_sdk.client import SimmerClient
+
+
+EOA = "0xAAAA000000000000000000000000000000000001"
+DW = "0xDEAD000000000000000000000000000000000001"
+
+
+def _make_client(*, uses_dw: bool) -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client._wallet_address = EOA
+    client._uses_deposit_wallet = uses_dw
+    client._deposit_wallet_address = DW if uses_dw else None
+    client._approvals_checked = False
+    client.check_approvals = MagicMock(return_value={"all_set": True})
+    return client
+
+
+def test_warn_approvals_checks_deposit_wallet_for_dw_users():
+    client = _make_client(uses_dw=True)
+
+    client._warn_approvals_once()
+
+    client.check_approvals.assert_called_once_with(address=DW)
+
+
+def test_warn_approvals_checks_eoa_for_non_dw_users():
+    client = _make_client(uses_dw=False)
+
+    client._warn_approvals_once()
+
+    client.check_approvals.assert_called_once_with(address=EOA)


### PR DESCRIPTION
## Summary

- Make `_warn_approvals_once()` check the deposit wallet address for DW users instead of falling back to the signer EOA.
- Keep non-DW users on the existing EOA approval check.
- Add focused regression tests for both address-selection branches.

## Verification

- `python3 -m pytest tests/test_warn_approvals_dw.py tests/test_set_approvals_dw.py`

Closes SIM-4344