### PR TITLE
fix: restore legacy NegRiskAdapter SDK approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **V2 `set_approvals()` restores the legacy NegRiskAdapter approval target (SIM-4379).**
+  Polymarket V2 neg-risk fills still require maker pUSD allowance to
+  `0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296`. The SDK now mirrors the server
+  spender set: CTF Exchange V2, NegRisk Exchange A, NegRisk Exchange B, and the
+  legacy NegRiskAdapter all get pUSD + CTF approvals. The new
+  `NEG_RISK_CTF_COLLATERAL_ADAPTER` remains redemption-only.
+
 - **Hyperliquid action nonces could collide (SIM-4223).** Both HL adapters
   stamped the nonce with a bare wall-clock millisecond. Hyperliquid tracks
   nonces per signing key and accepts each value once, so two actions signed by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.0"
+version = "0.24.1"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/approvals.py
+++ b/simmer_sdk/approvals.py
@@ -9,8 +9,8 @@ External wallets need to approve several spender contracts before trading.
 2. CTF Token (ERC1155) → same 3 spenders
 
 **V2 required approvals (starting 2026-04-28):**
-1. pUSD → 3 V2 spenders (CTF V2, NegRisk A, NegRisk B)
-2. CTF Token (ERC1155) → same 3 spenders
+1. pUSD → 4 V2 spenders (CTF V2, NegRisk A, NegRisk B, legacy NegRiskAdapter)
+2. CTF Token (ERC1155) → same 4 spenders
 3. pUSD → CollateralOfframp (for withdrawals that unwrap back to USDC.e)
 4. pUSD → V2_FEE_ESCROW (PolyNode fee collection; 2026-05-01 upgrade)
 5. CTF → CTF_COLLATERAL_ADAPTER (ERC1155; redemption adapter; 2026-05-01 upgrade)
@@ -93,6 +93,11 @@ _V2_SPENDERS = {
         "name": "Neg Risk Exchange B",
         "description": "Secondary V2 neg-risk exchange (additional multi-outcome capacity)",
     },
+    "legacy_neg_risk_adapter": {
+        "address": NEG_RISK_ADAPTER,
+        "name": "Legacy Neg Risk Adapter",
+        "description": "Legacy NegRiskAdapter still required by V2 neg-risk fills",
+    },
 }
 
 
@@ -163,8 +168,8 @@ def get_required_approvals() -> List[Dict[str, Any]]:
     """Get list of all required approvals for the active exchange version.
 
     V1 (flag off): USDC + USDC.e + CTF per 3 spenders = 9 approvals.
-    V2 (flag on, default on 0.10.0+): pUSD + CTF per 3 trading spenders (6)
-    plus 4 V2 extras (fee escrow + 2 CTF redemption adapters + pUSD adapter) = 10 approvals.
+    V2 (flag on, default on 0.10.0+): pUSD + CTF per 4 trading spenders (8)
+    plus 4 V2 extras (fee escrow + 2 CTF redemption adapters + pUSD adapter) = 12 approvals.
     """
     approvals: List[Dict[str, Any]] = []
     v2 = is_v2_enabled()

--- a/simmer_sdk/polymarket_contracts.py
+++ b/simmer_sdk/polymarket_contracts.py
@@ -40,7 +40,7 @@ POLYMARKET_V2_CUTOVER_UTC = datetime(2026, 4, 28, 11, 0, 0, tzinfo=timezone.utc)
 # ============================================================
 POLYGON_CHAIN_ID = 137
 CONDITIONAL_TOKENS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"  # CTF, unchanged
-NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"   # legacy; retired by PM 2026-07-18
+NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"   # legacy approval target for neg-risk fills
 
 
 # ============================================================
@@ -153,19 +153,21 @@ def active_spenders() -> list[str]:
     """Contract addresses that need token allowances for active trading.
 
     V1: 3 spenders (CTF Exchange, Neg Risk CTF Exchange, legacy Neg Risk Adapter).
-    V2: 3 spenders (CTF Exchange V2, Neg Risk Exchange A/B). The retired
-    legacy NegRiskAdapter is not a V2 active spender; the new collateral
-    adapter is covered by redemption_spenders().
+    V2: 4 spenders (CTF Exchange V2, Neg Risk Exchange A/B, legacy NegRiskAdapter).
+    The new neg-risk collateral adapter is redemption-only and is covered by
+    redemption_spenders().
     """
     addrs = get_active_addresses()
     spenders = [
         addrs.ctf_exchange,
         addrs.neg_risk_exchange_primary,
     ]
-    if addrs.version == "v1":
-        spenders.append(addrs.neg_risk_adapter)
     if addrs.neg_risk_exchange_secondary:
         spenders.append(addrs.neg_risk_exchange_secondary)
+    if addrs.version == "v1":
+        spenders.append(addrs.neg_risk_adapter)
+    else:
+        spenders.append(NEG_RISK_ADAPTER)
     return spenders
 
 

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -43,15 +43,30 @@ def test_v1_flag_returns_three_spenders_usdce():
     assert collateral_token().lower() == "0x2791bca1f2de4661ed88a30c99a7a9449aa84174"
 
 
-def test_v2_explicit_returns_three_spenders_pusd():
+def test_v2_explicit_returns_four_spenders_pusd():
     _set_version("v2")
     from simmer_sdk.polymarket_contracts import (
-        is_v2_enabled, active_spenders, collateral_token, exchange_version_str,
+        is_v2_enabled,
+        active_spenders,
+        collateral_token,
+        exchange_version_str,
+        NEG_RISK_ADAPTER,
+        NEG_RISK_CTF_COLLATERAL_ADAPTER,
+        V2_CTF_EXCHANGE,
+        V2_NEG_RISK_EXCHANGE_A,
+        V2_NEG_RISK_EXCHANGE_B,
     )
     assert is_v2_enabled() is True
     assert exchange_version_str() == "v2"
-    # V2 keeps both NegRisk exchanges and drops the retired legacy adapter.
-    assert len(active_spenders()) == 3
+    # V2 keeps both NegRisk exchanges and the legacy adapter approval target.
+    spenders = {addr.lower() for addr in active_spenders()}
+    assert spenders == {
+        V2_CTF_EXCHANGE.lower(),
+        V2_NEG_RISK_EXCHANGE_A.lower(),
+        V2_NEG_RISK_EXCHANGE_B.lower(),
+        NEG_RISK_ADAPTER.lower(),
+    }
+    assert NEG_RISK_CTF_COLLATERAL_ADAPTER.lower() not in spenders
     # pUSD is the V2 collateral
     assert collateral_token().lower() == "0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"
 
@@ -166,33 +181,33 @@ def test_v2_approvals_count_and_tokens():
     _set_version("v2")  # explicit V2 (default is time-gated as of 0.12.2)
     from simmer_sdk.approvals import get_approval_transactions
     from simmer_sdk.polymarket_contracts import (
-        NEG_RISK_ADAPTER,
         V2_FEE_ESCROW,
         CTF_COLLATERAL_ADAPTER,
+        NEG_RISK_ADAPTER,
         NEG_RISK_CTF_COLLATERAL_ADAPTER,
     )
     txs = get_approval_transactions()
-    # 3 trading spenders × (pUSD + CTF) = 6, plus 4 V2 extras:
+    # 4 trading spenders × (pUSD + CTF) = 8, plus 4 V2 extras:
     #   pUSD → V2_FEE_ESCROW, CTF → CTF_COLLATERAL_ADAPTER,
     #   CTF → NEG_RISK_CTF_COLLATERAL_ADAPTER, pUSD → CTF_COLLATERAL_ADAPTER
-    assert len(txs) == 10
+    assert len(txs) == 12
     tokens = {tx["token"] for tx in txs}
     assert tokens == {"pUSD", "CTF"}
     spender_addrs = {tx["spender_address"] for tx in txs}
-    # Verify the 4 new extras are present (regression guard for SIM-1881)
+    # Verify legacy NegRiskAdapter approval is active and the V2 extras remain.
+    assert NEG_RISK_ADAPTER in spender_addrs
     assert V2_FEE_ESCROW in spender_addrs
     assert CTF_COLLATERAL_ADAPTER in spender_addrs
     assert NEG_RISK_CTF_COLLATERAL_ADAPTER in spender_addrs
-    assert NEG_RISK_ADAPTER not in spender_addrs
 
 
 def test_v2_get_required_approvals_tokens():
     _set_version("v2")
     from simmer_sdk.approvals import get_required_approvals
     from simmer_sdk.polymarket_contracts import (
-        NEG_RISK_ADAPTER,
         V2_FEE_ESCROW,
         CTF_COLLATERAL_ADAPTER,
+        NEG_RISK_ADAPTER,
         NEG_RISK_CTF_COLLATERAL_ADAPTER,
     )
     approvals = get_required_approvals()
@@ -201,15 +216,15 @@ def test_v2_get_required_approvals_tokens():
     assert "USDC" not in tokens
     assert "USDC.e" not in tokens
     assert tokens == {"pUSD", "CTF"}
-    # 3 trading spenders × (pUSD + CTF) = 6, plus 4 V2 extras = 10
+    # 4 trading spenders × (pUSD + CTF) = 8, plus 4 V2 extras = 12
     # (regression guard for SIM-1881 codex P2 — keeps metadata API in lockstep
     #  with get_approval_transactions() + get_missing_approval_transactions().)
-    assert len(approvals) == 10
+    assert len(approvals) == 12
     spender_addrs = {a["spender_address"] for a in approvals}
+    assert NEG_RISK_ADAPTER in spender_addrs
     assert V2_FEE_ESCROW in spender_addrs
     assert CTF_COLLATERAL_ADAPTER in spender_addrs
     assert NEG_RISK_CTF_COLLATERAL_ADAPTER in spender_addrs
-    assert NEG_RISK_ADAPTER not in spender_addrs
 
 
 # ==================== SignedOrder ====================


### PR DESCRIPTION
## Summary
- Restore legacy NegRiskAdapter as a V2 active approval spender in `simmer_sdk.polymarket_contracts.active_spenders()`.
- Add the same spender to SDK approval generation/metadata so `set_approvals()` produces pUSD + CTF approvals for it.
- Bump `simmer-sdk` to `0.24.1` and add changelog notes for the approval-set change.

## Verification
- `python3 -m pytest tests/test_polymarket_v2.py::test_v2_explicit_returns_four_spenders_pusd tests/test_polymarket_v2.py::test_v2_approvals_count_and_tokens tests/test_polymarket_v2.py::test_v2_get_required_approvals_tokens tests/test_batch_validation.py`
- `SIMMER_POLYMARKET_EXCHANGE_VERSION=v2 python3 - <<'PY' ...` confirmed 12 approval txs, legacy adapter gets `['CTF', 'pUSD']`, and `NEG_RISK_CTF_COLLATERAL_ADAPTER` is not in `active_spenders()`.

Note: running the full `tests/test_polymarket_v2.py` module in this workspace still fails in the unrelated signing tests because `py_clob_client_v2` is not installed locally.

Closes SIM-4379
