### PR TITLE
feat(mcp): emit readOnlyHint/destructiveHint from mutates flag (SIM-4369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **MCP tool annotations: all 21 `simmer-mcp` tools now emit `readOnlyHint`/`destructiveHint`.**
+  Previously `annotations` was `null` on every tool, causing MCP clients that gate on annotations
+  (e.g. plan-mode / read-only mode) to fall back to name-based heuristics. Because Simmer tools
+  use a `simmer_` prefix rather than `get`/`list`, the heuristic misclassified five read-only tools
+  as writes and blocked them in plan mode. Annotations are now derived from the existing `mutates`
+  flag: `mutates:false` → `readOnlyHint:true`; `mutates:true` → `destructiveHint:true`.
+  `simmer_trade` carries an explicit override (`destructiveHint:true`) even though it is
+  registered `mutates:false` for paper-safe gate semantics — so clients correctly treat it as a
+  potential write regardless of the default dry-run mode.
+
 - **Hyperliquid trading with pmxt-constructed orders (SIM-4222).**
   `PmxtHyperliquidVenue` implements `VenueAdapter` against a self-hosted,
   construction-only pmxt sidecar: pmxt builds the unsigned action, the SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   use a `simmer_` prefix rather than `get`/`list`, the heuristic misclassified five read-only tools
   as writes and blocked them in plan mode. Annotations are now derived from the existing `mutates`
   flag: `mutates:false` → `readOnlyHint:true`; `mutates:true` → `destructiveHint:true`.
-  `simmer_trade` carries an explicit override (`destructiveHint:true`) even though it is
-  registered `mutates:false` for paper-safe gate semantics — so clients correctly treat it as a
-  potential write regardless of the default dry-run mode.
+  Tools whose `mutates:false` exists only to keep them usable without `SIMMER_MCP_ALLOW_LIVE`,
+  but which do modify the caller's environment, carry an explicit override to
+  `readOnlyHint:false, destructiveHint:true`: `simmer_trade` (can place live orders),
+  `run_experiment` (executes a shell command in the workspace), `log_experiment` (git
+  commit/revert on the working tree) and `init_experiment` (archives prior results, POSTs to
+  the API). `backtest_experiment` is simulated only and stays read-only. `mutates` continues to
+  govern the execution gate; `annotations` governs the wire protocol.
 
 - **Hyperliquid trading with pmxt-constructed orders (SIM-4222).**
   `PmxtHyperliquidVenue` implements `VenueAdapter` against a self-hosted,

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -219,6 +219,7 @@ server.tool(
   "list_skills",
   "List core Simmer skills bundled in this MCP server. Situational strategy skills install on demand from ClawHub.",
   {},
+  { readOnlyHint: true },
   async () => {
     const list = listSkills(skills);
     return {
@@ -234,6 +235,7 @@ server.tool(
   "get_skill_docs",
   "Get the full SKILL.md documentation for a specific Simmer skill. Includes description, parameters, usage examples, and troubleshooting tips.",
   { slug: z.string().describe("Skill slug (e.g. 'polymarket-fast-loop')") },
+  { readOnlyHint: true },
   async ({ slug }) => {
     const r = getSkillDocs(skills, slug);
     return r;
@@ -244,6 +246,7 @@ server.tool(
   "troubleshoot_error",
   "Look up a Simmer API error and get a fix. Pass the error message or JSON response from a failed API call. Returns a matched fix or falls back to docs.",
   { error_text: z.string().describe("The error message or response body from a failed Simmer API call") },
+  { readOnlyHint: true },
   async ({ error_text }) => {
     const r = await troubleshootError(error_text, apiUrl);
     const parts: string[] = [];
@@ -699,6 +702,11 @@ if (simmer) {
       source: z.string().optional().describe("Source tag for grouping trades (e.g. 'sdk:my-strategy')"),
     },
     mutates: false,
+    // simmer_trade is mutates:false so paper trades work without SIMMER_MCP_ALLOW_LIVE, but
+    // it CAN place real orders (dry_run=false + live venue + SIMMER_MCP_ALLOW_LIVE). Advertising
+    // readOnlyHint:true would be misleading to MCP clients that gate on annotations — override
+    // to destructiveHint:true so plan-mode clients treat it as a write regardless of paper default.
+    annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async (args, ctx) => executeTrade(simmer!, args as Parameters<typeof executeTrade>[1], ctx),
   });
 

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -279,6 +279,7 @@ if (simmer) {
       direction: z.enum(["lower", "higher"]).optional().describe('Whether "lower" or "higher" is better. Default: "higher"'),
     },
     mutates: false,
+    annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async ({ name, metric_name, skill_slug, metric_unit, direction }: {
       name: string;
       metric_name: string;
@@ -379,6 +380,7 @@ if (simmer) {
       timeout_seconds: z.number().optional().describe("Kill after this many seconds (default: 600)"),
     },
     mutates: false,
+    annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async ({ command, timeout_seconds }: { command: string; timeout_seconds?: number }, _ctx) => {
       // Per-call Pro check — Codex CRITICAL #1
       try {
@@ -443,6 +445,7 @@ if (simmer) {
       force: z.boolean().optional().describe("Set true to allow adding a new secondary metric not previously tracked"),
     },
     mutates: false,
+    annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async ({ commit, metric, status, description, metrics: secondaryMetrics, asi, force }: {
       commit: string;
       metric: number;

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -279,6 +279,7 @@ if (simmer) {
       direction: z.enum(["lower", "higher"]).optional().describe('Whether "lower" or "higher" is better. Default: "higher"'),
     },
     mutates: false,
+    // Re-calling archives prior results, resets session state and POSTs to the API.
     annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async ({ name, metric_name, skill_slug, metric_unit, direction }: {
       name: string;
@@ -380,6 +381,8 @@ if (simmer) {
       timeout_seconds: z.number().optional().describe("Kill after this many seconds (default: 600)"),
     },
     mutates: false,
+    // Executes an arbitrary shell command in the user's workspace. `mutates:false` only governs
+    // the SIMMER_MCP_ALLOW_LIVE gate — never advertise this as read-only on the wire.
     annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async ({ command, timeout_seconds }: { command: string; timeout_seconds?: number }, _ctx) => {
       // Per-call Pro check — Codex CRITICAL #1
@@ -445,6 +448,7 @@ if (simmer) {
       force: z.boolean().optional().describe("Set true to allow adding a new secondary metric not previously tracked"),
     },
     mutates: false,
+    // Calls gitAutoCommit()/gitRevert() against the user's working tree and POSTs the result.
     annotations: { readOnlyHint: false, destructiveHint: true },
     handler: async ({ commit, metric, status, description, metrics: secondaryMetrics, asi, force }: {
       commit: string;
@@ -906,6 +910,11 @@ if (simmer) {
       description: buildToolDescription(capturedSkill),
       schema: buildToolSchema(capturedSkill),
       mutates: false,
+      // Blanket readOnlyHint:true (the mutates-derived default) is correct for the currently
+      // bundled set: Tier A skills return SKILL.md, and the one skill with an entrypoint
+      // (preflight) runs a read-only health check. NOT derivable from `entrypoint` — having an
+      // entrypoint means "executes", not "mutates". A bundled skill that executes AND writes
+      // needs an explicit read-only declaration in the skill manifest; see SIM-4439.
       handler: async (args, _ctx) => {
         return invokeSkillTool(capturedSkill, args as Record<string, unknown>);
       },

--- a/mcp/src/tool-registry.ts
+++ b/mcp/src/tool-registry.ts
@@ -18,6 +18,13 @@
  *
  * Handlers receive ctx and must NOT re-read process.env — ctx is the single source
  * of truth for the live-trading decision.
+ *
+ * Wire annotations (MCP spec §3.3.2):
+ *   mutates:false  → readOnlyHint:true  (default)
+ *   mutates:true   → readOnlyHint:false + destructiveHint:true  (default)
+ * Override per-tool via the optional `annotations` field when the mutates-derived
+ * default is misleading (e.g. simmer_trade: mutates:false for paper-safety but
+ * can execute live trades, so it overrides to readOnlyHint:false/destructiveHint:true).
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -34,6 +41,11 @@ export type ToolResult = {
   isError?: boolean;
 };
 
+export type WireAnnotations = {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+};
+
 export type ToolDef<A> = {
   name: string;
   description: string | string[];
@@ -45,12 +57,20 @@ export type ToolDef<A> = {
    * false = tool may be paper-safe (e.g. simmer_trade dry-run); use ctx.allowLive internally.
    */
   mutates: boolean;
+  /**
+   * Optional: override the MCP wire annotations derived from `mutates`.
+   * Default mapping: mutates:false → {readOnlyHint:true}, mutates:true → {readOnlyHint:false, destructiveHint:true}.
+   * Use when the default is misleading — e.g. simmer_trade is mutates:false (paper-safe gate)
+   * but CAN place live trades, so it overrides to {readOnlyHint:false, destructiveHint:true}.
+   */
+  annotations?: WireAnnotations;
   handler: (args: A, ctx: ToolContext) => Promise<ToolResult>;
 };
 
 export interface RegistryEntry {
   name: string;
   mutates: boolean;
+  annotations: WireAnnotations;
 }
 
 /** Populated at registration time. Useful for introspection and tests. */
@@ -66,13 +86,19 @@ export function registerTool<A>(
   tool: ToolDef<A>,
   processEnv: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): void {
-  _toolRegistry.push({ name: tool.name, mutates: tool.mutates });
+  const wireAnnotations: WireAnnotations = tool.annotations ?? (
+    tool.mutates
+      ? { readOnlyHint: false, destructiveHint: true }
+      : { readOnlyHint: true }
+  );
+
+  _toolRegistry.push({ name: tool.name, mutates: tool.mutates, annotations: wireAnnotations });
   const desc = Array.isArray(tool.description) ? tool.description.join("\n") : tool.description;
 
   // Cast needed because McpServer.tool() has complex generic overloads;
   // our schema type (Record<string, any>) is structurally compatible at runtime.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (server.tool as any)(tool.name, desc, tool.schema, async (args: A) => {
+  (server.tool as any)(tool.name, desc, tool.schema, wireAnnotations, async (args: A) => {
     const allowLive = processEnv.SIMMER_MCP_ALLOW_LIVE === "true";
     if (tool.mutates && !allowLive) {
       return {

--- a/mcp/tests/mcp-protocol.test.ts
+++ b/mcp/tests/mcp-protocol.test.ts
@@ -111,6 +111,53 @@ test("tools/list with SIMMER_API_KEY returns core bundle plus raw market tools",
   assert.equal(names.includes("simmer_polymarket_soccer_shock_ladder"), false);
 });
 
+// --- tool annotations ---
+
+test("tools/list: every tool carries non-null annotations with a boolean readOnlyHint", async () => {
+  const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "sk_test_key" });
+  assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
+  type ToolEntry = { name: string; annotations?: { readOnlyHint?: unknown; destructiveHint?: unknown } };
+  const tools = (resp.result?.tools ?? []) as ToolEntry[];
+  for (const tool of tools) {
+    assert.ok(
+      tool.annotations != null,
+      `Tool "${tool.name}" has null/missing annotations`,
+    );
+    assert.equal(
+      typeof tool.annotations?.readOnlyHint,
+      "boolean",
+      `Tool "${tool.name}" annotations.readOnlyHint is not a boolean`,
+    );
+  }
+});
+
+test("tools/list: read-only tools have readOnlyHint:true; simmer_trade and simmer_cancel_order have destructiveHint:true", async () => {
+  const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "sk_test_key" });
+  assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
+  type ToolEntry = { name: string; annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean } };
+  const tools = (resp.result?.tools ?? []) as ToolEntry[];
+  const byName = Object.fromEntries(tools.map(t => [t.name, t.annotations]));
+
+  // Read-only tools — Odysseus misclassified these without annotations
+  const readOnlyTools = [
+    "list_skills", "get_skill_docs", "troubleshoot_error",
+    "simmer_get_markets", "simmer_get_briefing", "simmer_get_market_context",
+    "simmer_preflight",
+  ];
+  for (const name of readOnlyTools) {
+    assert.equal(byName[name]?.readOnlyHint, true, `${name}: expected readOnlyHint:true`);
+    assert.ok(!byName[name]?.destructiveHint, `${name}: expected no destructiveHint`);
+  }
+
+  // simmer_trade: mutates:false for paper-safe gate but CAN place live orders
+  assert.equal(byName["simmer_trade"]?.readOnlyHint, false, "simmer_trade: expected readOnlyHint:false");
+  assert.equal(byName["simmer_trade"]?.destructiveHint, true, "simmer_trade: expected destructiveHint:true");
+
+  // simmer_cancel_order: always mutates
+  assert.equal(byName["simmer_cancel_order"]?.readOnlyHint, false, "simmer_cancel_order: expected readOnlyHint:false");
+  assert.equal(byName["simmer_cancel_order"]?.destructiveHint, true, "simmer_cancel_order: expected destructiveHint:true");
+});
+
 // --- resources/list ---
 
 test("server does not register a resources capability (removed in v3.1.0)", async () => {

--- a/mcp/tests/mcp-protocol.test.ts
+++ b/mcp/tests/mcp-protocol.test.ts
@@ -164,6 +164,10 @@ test("tools/list: read-only tools have readOnlyHint:true; simmer_trade and simme
     assert.equal(byName[name]?.readOnlyHint, false, `${name}: expected readOnlyHint:false`);
     assert.equal(byName[name]?.destructiveHint, true, `${name}: expected destructiveHint:true`);
   }
+
+  // backtest_experiment simulates only — no execution, no writes. Pins the boundary so a future
+  // blanket "all *_experiment tools are destructive" sweep doesn't silently swallow it.
+  assert.equal(byName["backtest_experiment"]?.readOnlyHint, true, "backtest_experiment: expected readOnlyHint:true");
 });
 
 // --- resources/list ---

--- a/mcp/tests/mcp-protocol.test.ts
+++ b/mcp/tests/mcp-protocol.test.ts
@@ -156,6 +156,14 @@ test("tools/list: read-only tools have readOnlyHint:true; simmer_trade and simme
   // simmer_cancel_order: always mutates
   assert.equal(byName["simmer_cancel_order"]?.readOnlyHint, false, "simmer_cancel_order: expected readOnlyHint:false");
   assert.equal(byName["simmer_cancel_order"]?.destructiveHint, true, "simmer_cancel_order: expected destructiveHint:true");
+
+  // experiment tools: mutates:false (so they work without SIMMER_MCP_ALLOW_LIVE) but modify
+  // the user's workspace — run_experiment executes shell commands, log_experiment commits/reverts
+  // the working tree, init_experiment archives results and POSTs to the API
+  for (const name of ["run_experiment", "log_experiment", "init_experiment"]) {
+    assert.equal(byName[name]?.readOnlyHint, false, `${name}: expected readOnlyHint:false`);
+    assert.equal(byName[name]?.destructiveHint, true, `${name}: expected destructiveHint:true`);
+  }
 });
 
 // --- resources/list ---

--- a/mcp/tests/register-tool.test.ts
+++ b/mcp/tests/register-tool.test.ts
@@ -7,24 +7,43 @@
  *   2. Gate: mutates=true + no env → errorBlocked, handler never called.
  *   3. Pass-through: mutates=false → handler always called, ctx.live=false.
  *   4. Live path: mutates=true + env → handler called, ctx.live=true.
+ *   5. Wire annotations: mutates flag maps to readOnlyHint/destructiveHint.
  */
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { registerTool, _toolRegistry } from "../dist/tool-registry.js";
-import type { ToolResult, ToolContext } from "../dist/tool-registry.js";
+import type { ToolResult, ToolContext, WireAnnotations } from "../dist/tool-registry.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // ---------------------------------------------------------------------------
-// Minimal mock server
+// Minimal mock server — accepts both (name, desc, schema, handler) and
+// (name, desc, schema, annotations, handler) call shapes.
 // ---------------------------------------------------------------------------
 
 type CapturedHandler = (args: unknown) => Promise<ToolResult>;
 
-function makeMockServer(): { server: McpServer; getLastHandler: () => CapturedHandler } {
+function makeMockServer(): {
+  server: McpServer;
+  getLastHandler: () => CapturedHandler;
+  getLastAnnotations: () => WireAnnotations | null;
+} {
   let lastHandler: CapturedHandler | null = null;
+  let lastAnnotations: WireAnnotations | null = null;
   const server = {
-    tool(_name: string, _desc: string, _schema: unknown, handler: CapturedHandler) {
-      lastHandler = handler;
+    tool(
+      _name: string,
+      _desc: string,
+      _schema: unknown,
+      annotationsOrHandler: WireAnnotations | CapturedHandler,
+      maybeHandler?: CapturedHandler,
+    ) {
+      if (maybeHandler) {
+        lastAnnotations = annotationsOrHandler as WireAnnotations;
+        lastHandler = maybeHandler;
+      } else {
+        lastAnnotations = null;
+        lastHandler = annotationsOrHandler as CapturedHandler;
+      }
     },
   } as unknown as McpServer;
   return {
@@ -33,6 +52,7 @@ function makeMockServer(): { server: McpServer; getLastHandler: () => CapturedHa
       if (!lastHandler) throw new Error("No handler captured — was registerTool called?");
       return lastHandler;
     },
+    getLastAnnotations: () => lastAnnotations,
   };
 }
 
@@ -230,5 +250,64 @@ describe("registerTool live path — mutates:true with env", () => {
     const testArgs = { order_id: "ord_abc123" };
     await getLastHandler()(testArgs);
     assert.deepEqual(calls[0].args, testArgs, "handler should receive the original args");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Wire annotations: mutates flag → readOnlyHint / destructiveHint
+// ---------------------------------------------------------------------------
+
+describe("registerTool wire annotations", () => {
+  it("mutates:false → readOnlyHint:true passed to server.tool()", () => {
+    const { server, getLastAnnotations } = makeMockServer();
+    registerTool(server, {
+      name: "_test_annot_read",
+      description: "test",
+      schema: {},
+      mutates: false,
+      handler: async (_args, _ctx) => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    }, {});
+    assert.deepEqual(getLastAnnotations(), { readOnlyHint: true });
+  });
+
+  it("mutates:true → readOnlyHint:false + destructiveHint:true passed to server.tool()", () => {
+    const { server, getLastAnnotations } = makeMockServer();
+    registerTool(server, {
+      name: "_test_annot_write",
+      description: "test",
+      schema: {},
+      mutates: true,
+      handler: async (_args, _ctx) => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    }, {});
+    assert.deepEqual(getLastAnnotations(), { readOnlyHint: false, destructiveHint: true });
+  });
+
+  it("explicit annotations override the mutates-derived default", () => {
+    const { server, getLastAnnotations } = makeMockServer();
+    registerTool(server, {
+      name: "_test_annot_override",
+      description: "test",
+      schema: {},
+      mutates: false,
+      annotations: { readOnlyHint: false, destructiveHint: true },
+      handler: async (_args, _ctx) => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    }, {});
+    assert.deepEqual(getLastAnnotations(), { readOnlyHint: false, destructiveHint: true });
+  });
+
+  it("registry entry records the resolved annotations", () => {
+    const before = _toolRegistry.length;
+    const { server } = makeMockServer();
+    registerTool(server, {
+      name: "_test_annot_registry",
+      description: "test",
+      schema: {},
+      mutates: false,
+      annotations: { readOnlyHint: false, destructiveHint: true },
+      handler: async (_args, _ctx) => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    }, {});
+    const entry = _toolRegistry.slice(before).find(e => e.name === "_test_annot_registry");
+    assert.ok(entry, "registry entry should exist");
+    assert.deepEqual(entry?.annotations, { readOnlyHint: false, destructiveHint: true });
   });
 });


### PR DESCRIPTION
All 21 `simmer-mcp` tools returned `annotations=null` over the wire. MCP clients that gate on annotations (plan mode / read-only mode) fell back to name-based heuristics, misclassifying five read-only tools as writes because they carry a `simmer_` prefix rather than `get`/`list`/`fetch`. Discovered during Odysseus/Ollama integration verification.

## Changes

- `mcp/src/tool-registry.ts`: added `WireAnnotations` type and optional `annotations` override field to `ToolDef`; `registerTool` now derives annotations from `mutates` (`false` → `readOnlyHint:true`, `true` → `readOnlyHint:false, destructiveHint:true`) and passes them to `server.tool()` as the 4th arg; `RegistryEntry` also records the resolved annotations
- `mcp/src/mcp-server.ts`: added `{ readOnlyHint: true }` to the three free tools (`list_skills`, `get_skill_docs`, `troubleshoot_error`) that bypass `registerTool`; added `annotations: { readOnlyHint: false, destructiveHint: true }` override to `simmer_trade` (which is `mutates:false` for paper-safe gate semantics but CAN execute live trades)
- `mcp/tests/register-tool.test.ts`: updated mock server to accept the new 5-arg `server.tool()` call shape; added 4 unit tests for the annotation logic including the override path
- `mcp/tests/mcp-protocol.test.ts`: added 2 end-to-end wire tests — every tool has `annotations` with a boolean `readOnlyHint`, and named tools (`simmer_get_markets`, `simmer_trade`, `simmer_cancel_order`, etc.) carry the expected values
- `CHANGELOG.md`: documented the change

## Per-skill tools audit (simmer_preflight, simmer_simmer*)

- `simmer_preflight` (`preflight` skill, `managed:true`): runs a read-only health check — `mutates:false` is correct
- `simmer_simmer`, `simmer_simmer_briefing`, `simmer_simmer_mcp_setup`, `simmer_simmer_wallet_setup`: all Tier A instruction-only (no entrypoint) — return SKILL.md, never execute trades — `mutates:false` is correct

## Tests

```
ℹ tests 141
ℹ pass 141
ℹ fail 0
```

Including new tests:
- `✔ tools/list: every tool carries non-null annotations with a boolean readOnlyHint`
- `✔ tools/list: read-only tools have readOnlyHint:true; simmer_trade and simmer_cancel_order have destructiveHint:true`
- `✔ mutates:false → readOnlyHint:true passed to server.tool()`
- `✔ mutates:true → readOnlyHint:false + destructiveHint:true passed to server.tool()`
- `✔ explicit annotations override the mutates-derived default`
- `✔ registry entry records the resolved annotations`

Closes SIM-4369