### PR TITLE
fix: restore legacy NegRiskAdapter to V2 trading spenders (SIM-4377)

### DIFF
--- a/simmer_sdk/approvals.py
+++ b/simmer_sdk/approvals.py
@@ -93,6 +93,17 @@ _V2_SPENDERS = {
         "name": "Neg Risk Exchange B",
         "description": "Secondary V2 neg-risk exchange (additional multi-outcome capacity)",
     },
+    # SIM-4377: the legacy NegRiskAdapter is still a V2 trading spender.
+    # Polymarket's 2026-07-18 retirement covers relayer calls TARGETING the
+    # adapter (redeem/convert) — not the pUSD allowance where the adapter is
+    # the spender. The CLOB's get_balance_allowance enumerates it and gates
+    # every neg-risk fill on it; without this entry, set_approvals() builds
+    # a set that can never satisfy the server's strict on-chain check.
+    "neg_risk_adapter": {
+        "address": NEG_RISK_ADAPTER,
+        "name": "Neg Risk Adapter",
+        "description": "Legacy neg-risk adapter — still required as a pUSD/CTF spender for neg-risk fills",
+    },
 }
 
 

--- a/simmer_sdk/polymarket_contracts.py
+++ b/simmer_sdk/polymarket_contracts.py
@@ -153,9 +153,16 @@ def active_spenders() -> list[str]:
     """Contract addresses that need token allowances for active trading.
 
     V1: 3 spenders (CTF Exchange, Neg Risk CTF Exchange, legacy Neg Risk Adapter).
-    V2: 3 spenders (CTF Exchange V2, Neg Risk Exchange A/B). The retired
-    legacy NegRiskAdapter is not a V2 active spender; the new collateral
-    adapter is covered by redemption_spenders().
+    V2: 4 spenders (CTF Exchange V2, Neg Risk Exchange A/B, legacy Neg Risk
+    Adapter).
+
+    SIM-4377: the legacy NegRiskAdapter belongs in the V2 set. Polymarket's
+    2026-07-18 retirement covers relayer calls TARGETING the adapter
+    (redeem/convert) — not the pUSD allowance where the adapter is the
+    spender. The CLOB still gates neg-risk fills on that allowance
+    (get_balance_allowance enumerates it), so dropping it silently locks a
+    wallet out of every neg-risk market. Mirrors the server-side
+    simmer_v3/polymarket_contracts.py fix.
     """
     addrs = get_active_addresses()
     spenders = [
@@ -164,6 +171,10 @@ def active_spenders() -> list[str]:
     ]
     if addrs.version == "v1":
         spenders.append(addrs.neg_risk_adapter)
+    else:
+        # addrs.neg_risk_adapter is remapped to the NEW collateral adapter
+        # in V2 — name the legacy constant explicitly.
+        spenders.append(NEG_RISK_ADAPTER)
     if addrs.neg_risk_exchange_secondary:
         spenders.append(addrs.neg_risk_exchange_secondary)
     return spenders

--- a/tests/test_polymarket_v2.py
+++ b/tests/test_polymarket_v2.py
@@ -43,15 +43,18 @@ def test_v1_flag_returns_three_spenders_usdce():
     assert collateral_token().lower() == "0x2791bca1f2de4661ed88a30c99a7a9449aa84174"
 
 
-def test_v2_explicit_returns_three_spenders_pusd():
+def test_v2_explicit_returns_four_spenders_pusd():
     _set_version("v2")
     from simmer_sdk.polymarket_contracts import (
         is_v2_enabled, active_spenders, collateral_token, exchange_version_str,
+        NEG_RISK_ADAPTER,
     )
     assert is_v2_enabled() is True
     assert exchange_version_str() == "v2"
-    # V2 keeps both NegRisk exchanges and drops the retired legacy adapter.
-    assert len(active_spenders()) == 3
+    # V2 keeps both NegRisk exchanges AND the legacy NegRiskAdapter — the
+    # CLOB gates neg-risk fills on its pUSD allowance (SIM-4377).
+    assert len(active_spenders()) == 4
+    assert NEG_RISK_ADAPTER in active_spenders()
     # pUSD is the V2 collateral
     assert collateral_token().lower() == "0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"
 
@@ -172,10 +175,13 @@ def test_v2_approvals_count_and_tokens():
         NEG_RISK_CTF_COLLATERAL_ADAPTER,
     )
     txs = get_approval_transactions()
-    # 3 trading spenders × (pUSD + CTF) = 6, plus 4 V2 extras:
+    # 4 trading spenders × (pUSD + CTF) = 8, plus 4 V2 extras:
     #   pUSD → V2_FEE_ESCROW, CTF → CTF_COLLATERAL_ADAPTER,
     #   CTF → NEG_RISK_CTF_COLLATERAL_ADAPTER, pUSD → CTF_COLLATERAL_ADAPTER
-    assert len(txs) == 10
+    # SIM-4377: the legacy NegRiskAdapter is back in the trading spenders —
+    # the CLOB gates neg-risk fills on its pUSD allowance (supersedes the
+    # SIM-4001/#281 exclusion pin).
+    assert len(txs) == 12
     tokens = {tx["token"] for tx in txs}
     assert tokens == {"pUSD", "CTF"}
     spender_addrs = {tx["spender_address"] for tx in txs}
@@ -183,7 +189,7 @@ def test_v2_approvals_count_and_tokens():
     assert V2_FEE_ESCROW in spender_addrs
     assert CTF_COLLATERAL_ADAPTER in spender_addrs
     assert NEG_RISK_CTF_COLLATERAL_ADAPTER in spender_addrs
-    assert NEG_RISK_ADAPTER not in spender_addrs
+    assert NEG_RISK_ADAPTER in spender_addrs
 
 
 def test_v2_get_required_approvals_tokens():
@@ -201,15 +207,16 @@ def test_v2_get_required_approvals_tokens():
     assert "USDC" not in tokens
     assert "USDC.e" not in tokens
     assert tokens == {"pUSD", "CTF"}
-    # 3 trading spenders × (pUSD + CTF) = 6, plus 4 V2 extras = 10
+    # 4 trading spenders × (pUSD + CTF) = 8, plus 4 V2 extras = 12
     # (regression guard for SIM-1881 codex P2 — keeps metadata API in lockstep
     #  with get_approval_transactions() + get_missing_approval_transactions().)
-    assert len(approvals) == 10
+    # SIM-4377: legacy NegRiskAdapter restored to trading spenders.
+    assert len(approvals) == 12
     spender_addrs = {a["spender_address"] for a in approvals}
     assert V2_FEE_ESCROW in spender_addrs
     assert CTF_COLLATERAL_ADAPTER in spender_addrs
     assert NEG_RISK_CTF_COLLATERAL_ADAPTER in spender_addrs
-    assert NEG_RISK_ADAPTER not in spender_addrs
+    assert NEG_RISK_ADAPTER in spender_addrs
 
 
 # ==================== SignedOrder ====================


### PR DESCRIPTION
Companion to SupaFund/simmer#1770.

Reverts the `_V2_SPENDERS` / `active_spenders()` half of #281 (SIM-4001). Polymarket's 2026-07-18 adapter retirement covers relayer calls **targeting** the adapter (redeem/convert) — not the pUSD/CTF allowances where the adapter is the **spender**. The CLOB's `get_balance_allowance` still enumerates the adapter and gates every neg-risk fill on it, so a wallet approved via `set_approvals()` without it can never satisfy the server's strict on-chain check and is silently locked out of neg-risk markets.

On-chain evidence: ~129K pUSD approvals to the adapter in the last ~11 days ecosystem-wide — it is still part of Polymarket's standard activation set.

- V2 approval set: 10 → 12 txs (adapter pUSD approve + CTF operator)
- Test pins from #281 flipped to assert inclusion
- Full SDK suite: 710 passed

Must ship together with (or after) SupaFund/simmer#1770 — the server's v5 spender version makes the strict check require these approvals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jSaSoYToduVX6FLdKSqct