### PR TITLE
chore: release 0.24.1 (SIM-4377 adapter restore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.1 (2026-08-06)
+
+- **Restore the legacy NegRiskAdapter to V2 trading spenders (SIM-4377).** Polymarket's 2026-07-18 adapter retirement covers relayer calls targeting the adapter, not the pUSD/CTF allowances where it is the spender — the CLOB still gates every neg-risk fill on that allowance. `set_approvals()` now grants the full 12-tx V2 set again (was 10 after #281); wallets approved without it were silently locked out of neg-risk markets.
+
 ## [Unreleased]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.0"
+version = "0.24.1"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Version bump + changelog for the SIM-4377 fix merged in #297. Unbumped merges don't publish; this ships 0.24.1 to PyPI via the OIDC workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jSaSoYToduVX6FLdKSqct