### PR TITLE
fix(polymarket-skills): book-liquidity gates were inverted in all three CLOB readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Fast-loop spread gate was inverted: it skipped liquid books and traded
+  thin ones.** `fetch_orderbook_summary` read `bids[0]`/`asks[0]` as best,
+  but the CLOB returns bids LOW→HIGH and asks HIGH→LOW (the ordering
+  simmer_v3's `polymarket_client.py` and `orderbook.py` both document and
+  sort for), so it computed worst-ask minus worst-bid — the full book width.
+  Any market with real depth blew through `MAX_SPREAD_PCT` and was skipped
+  as "illiquid", while near-empty one-level books computed a true touch
+  spread and passed: adverse selection toward exactly the books the gate
+  exists to avoid. Thin 5-minute sprint books (worst≈best) masked it. Now
+  sorts both sides before reading best, and sums top-5 depth from the touch
+  instead of the back of the book. Found during a Sentinel odds-tooling
+  survey of the SDK; `best_bid`/`best_ask`/depth were log-only, so the gate
+  was the only affected consumer.
+
 - **Hyperliquid action nonces could collide (SIM-4223).** Both HL adapters
   stamped the nonce with a bare wall-clock millisecond. Hyperliquid tracks
   nonces per signing key and accepts each value once, so two actions signed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,19 +51,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **Fast-loop spread gate was inverted: it skipped liquid books and traded
-  thin ones.** `fetch_orderbook_summary` read `bids[0]`/`asks[0]` as best,
-  but the CLOB returns bids LOW→HIGH and asks HIGH→LOW (the ordering
-  simmer_v3's `polymarket_client.py` and `orderbook.py` both document and
-  sort for), so it computed worst-ask minus worst-bid — the full book width.
-  Any market with real depth blew through `MAX_SPREAD_PCT` and was skipped
-  as "illiquid", while near-empty one-level books computed a true touch
-  spread and passed: adverse selection toward exactly the books the gate
-  exists to avoid. Thin 5-minute sprint books (worst≈best) masked it. Now
-  sorts both sides before reading best, and sums top-5 depth from the touch
-  instead of the back of the book. Found during a Sentinel odds-tooling
-  survey of the SDK; `best_bid`/`best_ask`/depth were log-only, so the gate
-  was the only affected consumer.
+- **Book-liquidity gates were inverted across three Polymarket skills: they
+  skipped liquid books and traded thin ones.** `polymarket-fast-loop`
+  (1.7.1), `polymarket-mert-sniper` (1.3.4) and `polymarket-fast-scaler`
+  (1.2.1) each read `bids[0]`/`asks[0]` as best bid/ask, but the CLOB returns
+  bids LOW→HIGH and asks HIGH→LOW (the ordering simmer_v3's
+  `polymarket_client.py` and `orderbook.py` both document and sort for), so
+  they computed worst-ask minus worst-bid — the full book width — and a raw
+  `[:5]` depth slice summed the levels *furthest* from the touch. Fast-loop
+  and fast-scaler blew through `MAX_SPREAD_PCT` on any market with real depth
+  and skipped it as "illiquid", while near-empty one-level books computed a
+  true touch spread and passed; mert-sniper's `MIN_BOOK_DEPTH_USD` thin-book
+  gate was measuring the back of the book. Net effect in all three: adverse
+  selection toward exactly the books the gates exist to avoid. Thin 5-minute
+  sprint books (worst≈best) masked it. All three now sort both sides before
+  reading the touch. Verified against the live CLOB: on a real book the old
+  read gave a 0.998 spread where the true touch spread was 0.001.
+
+  Hardened while fixing: levels whose price won't parse are dropped rather
+  than defaulted to `0`, since a zero-priced ask sorts to the front and
+  fabricates a negative spread that passes the gate; and sizes are parsed
+  only for the five levels nearest the touch, so one malformed level deep in
+  the book can't return `None` and make the caller skip the gate entirely.
+  Both are fail-open paths on a money gate.
+
+  Found during a Sentinel odds-tooling survey of the SDK (cross-repo review,
+  not a user report).
 
 - **Hyperliquid action nonces could collide (SIM-4223).** Both HL adapters
   stamped the nonce with a bare wall-clock millisecond. Hyperliquid tracks

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.7.0"
+  version: "1.7.1"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -316,15 +316,26 @@ def fetch_orderbook_summary(clob_token_ids):
         return None
 
     try:
-        best_bid = float(bids[0]["price"])
-        best_ask = float(asks[0]["price"])
+        # CLOB returns bids LOW→HIGH and asks HIGH→LOW, so index [0] is the
+        # WORST price on each side. Sort so best is first before reading.
+        bids = sorted(
+            ({"price": float(b.get("price", 0)), "size": float(b.get("size", 0))} for b in bids),
+            key=lambda x: x["price"],
+            reverse=True,
+        )
+        asks = sorted(
+            ({"price": float(a.get("price", 0)), "size": float(a.get("size", 0))} for a in asks),
+            key=lambda x: x["price"],
+        )
+        best_bid = bids[0]["price"]
+        best_ask = asks[0]["price"]
         spread = best_ask - best_bid
         mid = (best_ask + best_bid) / 2
         spread_pct = spread / mid if mid > 0 else 0
 
-        # Sum depth (top 5 levels)
-        bid_depth = sum(float(b.get("size", 0)) * float(b.get("price", 0)) for b in bids[:5])
-        ask_depth = sum(float(a.get("size", 0)) * float(a.get("price", 0)) for a in asks[:5])
+        # Sum depth (top 5 levels nearest the touch)
+        bid_depth = sum(b["size"] * b["price"] for b in bids[:5])
+        ask_depth = sum(a["size"] * a["price"] for a in asks[:5])
 
         return {
             "best_bid": best_bid,

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -293,6 +293,41 @@ def fetch_live_prices(clob_token_ids):
     return fetch_live_midpoint(yes_token)
 
 
+def _book_levels_best_first(raw_levels, descending):
+    """Parse raw CLOB book levels and sort them best-price-first.
+
+    The CLOB returns bids LOW→HIGH and asks HIGH→LOW, so index [0] of the raw
+    response is the WORST price on each side — reading it as the touch inverts
+    the spread. Levels whose price won't parse are dropped rather than
+    defaulted to 0: a zero-priced ask would sort to the front and fabricate a
+    negative spread, which sails through the MAX_SPREAD_PCT gate.
+    """
+    levels = []
+    for lvl in raw_levels:
+        try:
+            levels.append((float(lvl["price"]), lvl))
+        except (KeyError, TypeError, ValueError):
+            continue
+    levels.sort(key=lambda pair: pair[0], reverse=descending)
+    return levels
+
+
+def _book_depth_usd(levels, count=5):
+    """Sum price x size over the `count` levels nearest the touch.
+
+    Sizes are parsed here rather than during the sort so one malformed level
+    deep in the book can't discard the whole summary (a None return makes the
+    caller skip the spread gate entirely).
+    """
+    total = 0.0
+    for price, lvl in levels[:count]:
+        try:
+            total += price * float(lvl.get("size", 0))
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
 def fetch_orderbook_summary(clob_token_ids):
     """Fetch order book for YES token and return spread + depth summary.
 
@@ -315,37 +350,24 @@ def fetch_orderbook_summary(clob_token_ids):
     if not bids or not asks:
         return None
 
-    try:
-        # CLOB returns bids LOW→HIGH and asks HIGH→LOW, so index [0] is the
-        # WORST price on each side. Sort so best is first before reading.
-        bids = sorted(
-            ({"price": float(b.get("price", 0)), "size": float(b.get("size", 0))} for b in bids),
-            key=lambda x: x["price"],
-            reverse=True,
-        )
-        asks = sorted(
-            ({"price": float(a.get("price", 0)), "size": float(a.get("size", 0))} for a in asks),
-            key=lambda x: x["price"],
-        )
-        best_bid = bids[0]["price"]
-        best_ask = asks[0]["price"]
-        spread = best_ask - best_bid
-        mid = (best_ask + best_bid) / 2
-        spread_pct = spread / mid if mid > 0 else 0
-
-        # Sum depth (top 5 levels nearest the touch)
-        bid_depth = sum(b["size"] * b["price"] for b in bids[:5])
-        ask_depth = sum(a["size"] * a["price"] for a in asks[:5])
-
-        return {
-            "best_bid": best_bid,
-            "best_ask": best_ask,
-            "spread_pct": spread_pct,
-            "bid_depth_usd": bid_depth,
-            "ask_depth_usd": ask_depth,
-        }
-    except (KeyError, ValueError, IndexError, TypeError):
+    bid_levels = _book_levels_best_first(bids, descending=True)
+    ask_levels = _book_levels_best_first(asks, descending=False)
+    if not bid_levels or not ask_levels:
         return None
+
+    best_bid = bid_levels[0][0]
+    best_ask = ask_levels[0][0]
+    spread = best_ask - best_bid
+    mid = (best_ask + best_bid) / 2
+    spread_pct = spread / mid if mid > 0 else 0
+
+    return {
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "spread_pct": spread_pct,
+        "bid_depth_usd": _book_depth_usd(bid_levels),
+        "ask_depth_usd": _book_depth_usd(ask_levels),
+    }
 
 
 # =============================================================================

--- a/skills/polymarket-fast-loop/tests/test_fastloop_orderbook_summary.py
+++ b/skills/polymarket-fast-loop/tests/test_fastloop_orderbook_summary.py
@@ -97,6 +97,33 @@ class TestFetchOrderbookSummary(unittest.TestCase):
         s = self._summary({"bids": _CLOB_BOOK["bids"], "asks": []})
         self.assertIsNone(s)
 
+    def test_unparseable_ask_price_does_not_fabricate_a_zero_touch(self):
+        # A level whose price is missing/garbage must be DROPPED, not defaulted
+        # to 0.0 — a zero-priced ask sorts to the front, yields a negative
+        # spread, and sails straight through the `> MAX_SPREAD_PCT` gate.
+        book = {
+            "bids": _CLOB_BOOK["bids"],
+            "asks": [{"size": "10"}, {"price": "junk", "size": "10"}] + _CLOB_BOOK["asks"],
+        }
+        s = self._summary(book)
+        self.assertAlmostEqual(s["best_ask"], 0.52)
+        self.assertGreater(s["spread_pct"], 0)
+        self.assertLess(s["spread_pct"], ft.MAX_SPREAD_PCT)
+
+    def test_malformed_size_deep_in_the_book_does_not_discard_the_summary(self):
+        # Sizes are parsed only for the five levels nearest the touch, so a bad
+        # size far from the touch can't return None — and a None return makes
+        # the caller skip the spread gate entirely (fail-open on a money gate).
+        deep_junk = [{"price": "0.05", "size": "not-a-number"}]
+        s = self._summary({"bids": deep_junk + _CLOB_BOOK["bids"], "asks": _CLOB_BOOK["asks"]})
+        self.assertIsNotNone(s)
+        self.assertAlmostEqual(s["best_bid"], 0.48)
+        self.assertAlmostEqual(s["bid_depth_usd"], 18.3)
+
+    def test_every_level_unparseable_returns_none(self):
+        s = self._summary({"bids": [{"price": "x"}], "asks": _CLOB_BOOK["asks"]})
+        self.assertIsNone(s)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/polymarket-fast-loop/tests/test_fastloop_orderbook_summary.py
+++ b/skills/polymarket-fast-loop/tests/test_fastloop_orderbook_summary.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for fetch_orderbook_summary in polymarket-fast-loop.
+
+Pins the CLOB book ordering contract: the API returns bids LOW→HIGH and asks
+HIGH→LOW (documented in simmer_v3/polymarket_client.py and orderbook.py), so
+best bid/ask must be read from the sorted front, never from index [0] of the
+raw response. The old code read [0] on both sides, which computed the spread
+as worst-ask minus worst-bid — inverting the 10% illiquidity gate: deep books
+looked wide (skipped) while near-empty books looked tight (traded).
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+# Stub simmer_sdk and simmer_sdk.skill before importing the skill module
+# (fastloop_trader imports from simmer_sdk.skill at module level)
+_mock_cfg = {
+    "entry_threshold": 0.05, "min_momentum_pct": 0.5, "max_position": 5.0,
+    "signal_source": "binance", "lookback_minutes": 5, "min_time_remaining": 0,
+    "asset": "BTC", "window": "5m", "volume_confidence": True, "daily_budget": 10.0,
+    "use_fair_value": False, "fair_value_min_edge": 0.05, "btc_annual_vol": 0.55,
+    "order_type": "GTC", "enable_news_veto": True,
+}
+
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+_guards_stub = types.ModuleType("simmer_sdk.guards.news_recency_veto")
+_guards_stub.load_macro_news_schedule = lambda path=None: {"events": []}
+_guards_stub.news_window_match = lambda market_id, schedule, lookback_s=30, now=None: (False, None)
+
+with patch.dict(sys.modules, {
+    "simmer_sdk": MagicMock(),
+    "simmer_sdk.skill": _skill_stub,
+    "simmer_sdk.guards.news_recency_veto": _guards_stub,
+}):
+    import fastloop_trader as ft  # noqa: E402
+
+
+# A liquid two-sided book in CLOB native ordering: bids LOW→HIGH (best = 0.48
+# is LAST), asks HIGH→LOW (best = 0.52 is LAST). Six levels per side so the
+# top-5 depth slice is distinguishable from a naive [:5] on the raw arrays.
+_CLOB_BOOK = {
+    "bids": [
+        {"price": "0.10", "size": "10"},
+        {"price": "0.20", "size": "10"},
+        {"price": "0.30", "size": "10"},
+        {"price": "0.40", "size": "10"},
+        {"price": "0.45", "size": "10"},
+        {"price": "0.48", "size": "10"},
+    ],
+    "asks": [
+        {"price": "0.90", "size": "10"},
+        {"price": "0.80", "size": "10"},
+        {"price": "0.70", "size": "10"},
+        {"price": "0.60", "size": "10"},
+        {"price": "0.55", "size": "10"},
+        {"price": "0.52", "size": "10"},
+    ],
+}
+
+
+class TestFetchOrderbookSummary(unittest.TestCase):
+    def _summary(self, book=_CLOB_BOOK):
+        with patch.object(ft, "_api_request", return_value=book):
+            return ft.fetch_orderbook_summary(["yes-token", "no-token"])
+
+    def test_best_prices_come_from_the_touch_not_index_zero(self):
+        s = self._summary()
+        self.assertAlmostEqual(s["best_bid"], 0.48)
+        self.assertAlmostEqual(s["best_ask"], 0.52)
+
+    def test_liquid_book_passes_the_spread_gate(self):
+        # Touch spread 0.04 on a 0.50 mid = 8%: under MAX_SPREAD_PCT. The old
+        # [0]-indexed read computed 0.90 - 0.10 = 0.80 spread (160% of mid)
+        # and skipped exactly the liquid books the gate exists to keep.
+        s = self._summary()
+        self.assertAlmostEqual(s["spread_pct"], 0.04 / 0.50)
+        self.assertLess(s["spread_pct"], ft.MAX_SPREAD_PCT)
+
+    def test_depth_sums_the_five_levels_nearest_the_touch(self):
+        s = self._summary()
+        # bids: 0.48+0.45+0.40+0.30+0.20 (drops the 0.10 tail), size 10 each
+        self.assertAlmostEqual(s["bid_depth_usd"], 18.3)
+        # asks: 0.52+0.55+0.60+0.70+0.80 (drops the 0.90 tail)
+        self.assertAlmostEqual(s["ask_depth_usd"], 31.7)
+
+    def test_one_sided_book_returns_none(self):
+        s = self._summary({"bids": _CLOB_BOOK["bids"], "asks": []})
+        self.assertIsNone(s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-fast-scaler/SKILL.md
+++ b/skills/polymarket-fast-scaler/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-scaler
 description: Trade Polymarket BTC 5-minute fast markets using a magnitude-gated conviction-ladder strategy. Only fires when |1m BTC momentum| >= 0.10%, the magnitude threshold the strategy is built around. Position size scales with signal strength (3 conviction tiers). Reference template for gate-filtered BTC fast-market trading; the original performance claim was retracted (see below).
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.2.0"
+  version: "1.2.1"
   displayName: Polymarket FastScaler
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-scaler/fast_scaler.py
+++ b/skills/polymarket-fast-scaler/fast_scaler.py
@@ -316,6 +316,26 @@ def fetch_live_midpoint(token_id):
         return None
 
 
+def _book_prices_best_first(raw_levels, descending):
+    """Parse raw CLOB book level prices and sort them best-first.
+
+    The CLOB returns bids LOW→HIGH and asks HIGH→LOW, so index [0] of the raw
+    response is the WORST price on each side — reading it as the touch computes
+    worst-ask minus worst-bid (the full book width) and inverts the
+    MAX_SPREAD_PCT gate. Levels whose price won't parse are dropped rather than
+    defaulted to 0, so a malformed level can't fabricate a zero-priced touch
+    (which would produce a negative spread that passes the gate).
+    """
+    prices = []
+    for lvl in raw_levels:
+        try:
+            prices.append(float(lvl["price"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+    prices.sort(reverse=descending)
+    return prices
+
+
 def fetch_orderbook_spread(clob_token_ids):
     """Return spread_pct for the YES token, or None on failure."""
     if not clob_token_ids:
@@ -328,13 +348,14 @@ def fetch_orderbook_spread(clob_token_ids):
     asks = result.get("asks", [])
     if not bids or not asks:
         return None
-    try:
-        best_bid = float(bids[0]["price"])
-        best_ask = float(asks[0]["price"])
-        mid = (best_bid + best_ask) / 2
-        return (best_ask - best_bid) / mid if mid > 0 else None
-    except (KeyError, ValueError, IndexError, TypeError):
+    bid_prices = _book_prices_best_first(bids, descending=True)
+    ask_prices = _book_prices_best_first(asks, descending=False)
+    if not bid_prices or not ask_prices:
         return None
+    best_bid = bid_prices[0]
+    best_ask = ask_prices[0]
+    mid = (best_bid + best_ask) / 2
+    return (best_ask - best_bid) / mid if mid > 0 else None
 
 
 # =============================================================================

--- a/skills/polymarket-fast-scaler/tests/test_fastscaler_orderbook_spread.py
+++ b/skills/polymarket-fast-scaler/tests/test_fastscaler_orderbook_spread.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for fetch_orderbook_spread in polymarket-fast-scaler.
+
+Pins the CLOB book ordering contract: the API returns bids LOW→HIGH and asks
+HIGH→LOW (documented in simmer_v3/polymarket_client.py and orderbook.py), so
+best bid/ask must be read from the sorted front, never from index [0] of the
+raw response.
+
+fast-scaler has no pre-fetched `spread_cents` fallback — every live run that
+reaches the spread check calls this function, and its result gates directly on
+MAX_SPREAD_PCT. Reading [0] computed worst-ask minus worst-bid (the full book
+width), so deep books were skipped as "illiquid" while near-empty one-level
+books computed a true touch spread and traded.
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import json
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+# Source the mock config from the skill's own config.json so this test doesn't
+# drift as CONFIG_SCHEMA gains keys.
+with open(os.path.join(_SKILL_DIR, "config.json")) as fh:
+    _mock_cfg = json.load(fh)
+
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: dict(_mock_cfg)
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+
+with patch.dict(sys.modules, {
+    "simmer_sdk": MagicMock(),
+    "simmer_sdk.skill": _skill_stub,
+}):
+    import fast_scaler as fs  # noqa: E402
+
+
+# CLOB native ordering: bids LOW→HIGH (best 0.48 LAST), asks HIGH→LOW (best
+# 0.52 LAST). Touch spread is 0.04 on a 0.50 mid = 8%, under MAX_SPREAD_PCT;
+# the old [0] read gave 0.90 - 0.10 = 0.80 (160% of mid) and skipped the book.
+_CLOB_BOOK = {
+    "bids": [
+        {"price": "0.10", "size": "10"},
+        {"price": "0.30", "size": "10"},
+        {"price": "0.45", "size": "10"},
+        {"price": "0.48", "size": "10"},
+    ],
+    "asks": [
+        {"price": "0.90", "size": "10"},
+        {"price": "0.70", "size": "10"},
+        {"price": "0.55", "size": "10"},
+        {"price": "0.52", "size": "10"},
+    ],
+}
+
+
+class TestFetchOrderbookSpread(unittest.TestCase):
+    def _spread(self, book=_CLOB_BOOK):
+        with patch.object(fs, "_api_request", return_value=book):
+            return fs.fetch_orderbook_spread(["yes-token", "no-token"])
+
+    def test_spread_is_the_touch_spread_not_the_book_width(self):
+        self.assertAlmostEqual(self._spread(), 0.04 / 0.50)
+
+    def test_liquid_book_passes_the_spread_gate(self):
+        self.assertLess(self._spread(), fs.MAX_SPREAD_PCT)
+
+    def test_one_sided_book_returns_none(self):
+        self.assertIsNone(self._spread({"bids": _CLOB_BOOK["bids"], "asks": []}))
+
+    def test_unparseable_ask_price_does_not_fabricate_a_zero_touch(self):
+        # A zero-defaulted ask sorts to the front and yields a NEGATIVE spread,
+        # which passes `> MAX_SPREAD_PCT` — fail-open on the illiquidity gate.
+        book = {
+            "bids": _CLOB_BOOK["bids"],
+            "asks": [{"size": "10"}, {"price": "junk", "size": "10"}] + _CLOB_BOOK["asks"],
+        }
+        s = self._spread(book)
+        self.assertAlmostEqual(s, 0.04 / 0.50)
+        self.assertGreater(s, 0)
+
+    def test_every_level_unparseable_returns_none(self):
+        self.assertIsNone(self._spread({"bids": [{"price": "x"}], "asks": _CLOB_BOOK["asks"]}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes, filters for strongly-skewed splits (60/40+), and places bounded trades against the under-priced side. Defaults — $10 max per trade, 5 trades/run, 8-minute expiry window, dry-run unless `--live`.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.3"
+  version: "1.3.4"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -271,6 +271,41 @@ def fetch_live_midpoint(token_id):
         return None
 
 
+def _book_levels_best_first(raw_levels, descending):
+    """Parse raw CLOB book levels and sort them best-price-first.
+
+    The CLOB returns bids LOW→HIGH and asks HIGH→LOW, so index [0] of the raw
+    response is the WORST price on each side — reading it as the touch inverts
+    the spread and makes a raw [:5] slice sum the levels FURTHEST from the
+    touch, which is what the MIN_BOOK_DEPTH_USD gate reads. Levels whose price
+    won't parse are dropped rather than defaulted to 0, so a malformed level
+    can't fabricate a zero-priced touch.
+    """
+    levels = []
+    for lvl in raw_levels:
+        try:
+            levels.append((float(lvl["price"]), lvl))
+        except (KeyError, TypeError, ValueError):
+            continue
+    levels.sort(key=lambda pair: pair[0], reverse=descending)
+    return levels
+
+
+def _book_depth_usd(levels, count=5):
+    """Sum price x size over the `count` levels nearest the touch.
+
+    Sizes are parsed here rather than during the sort so one malformed level
+    deep in the book can't discard the whole summary.
+    """
+    total = 0.0
+    for price, lvl in levels[:count]:
+        try:
+            total += price * float(lvl.get("size", 0))
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
 def fetch_orderbook_summary(token_id):
     """Fetch order book and return spread + depth summary.
 
@@ -286,26 +321,24 @@ def fetch_orderbook_summary(token_id):
     if not bids or not asks:
         return None
 
-    try:
-        best_bid = float(bids[0]["price"])
-        best_ask = float(asks[0]["price"])
-        spread = best_ask - best_bid
-        mid = (best_ask + best_bid) / 2
-        spread_pct = spread / mid if mid > 0 else 0
-
-        # Sum depth (top 5 levels)
-        bid_depth = sum(float(b.get("size", 0)) * float(b.get("price", 0)) for b in bids[:5])
-        ask_depth = sum(float(a.get("size", 0)) * float(a.get("price", 0)) for a in asks[:5])
-
-        return {
-            "best_bid": best_bid,
-            "best_ask": best_ask,
-            "spread_pct": spread_pct,
-            "bid_depth_usd": bid_depth,
-            "ask_depth_usd": ask_depth,
-        }
-    except (KeyError, ValueError, IndexError, TypeError):
+    bid_levels = _book_levels_best_first(bids, descending=True)
+    ask_levels = _book_levels_best_first(asks, descending=False)
+    if not bid_levels or not ask_levels:
         return None
+
+    best_bid = bid_levels[0][0]
+    best_ask = ask_levels[0][0]
+    spread = best_ask - best_bid
+    mid = (best_ask + best_bid) / 2
+    spread_pct = spread / mid if mid > 0 else 0
+
+    return {
+        "best_bid": best_bid,
+        "best_ask": best_ask,
+        "spread_pct": spread_pct,
+        "bid_depth_usd": _book_depth_usd(bid_levels),
+        "ask_depth_usd": _book_depth_usd(ask_levels),
+    }
 
 
 # =============================================================================

--- a/skills/polymarket-mert-sniper/tests/test_mertsniper_orderbook_summary.py
+++ b/skills/polymarket-mert-sniper/tests/test_mertsniper_orderbook_summary.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for fetch_orderbook_summary in polymarket-mert-sniper.
+
+Pins the CLOB book ordering contract: the API returns bids LOW→HIGH and asks
+HIGH→LOW (documented in simmer_v3/polymarket_client.py and orderbook.py), so
+best bid/ask must be read from the sorted front, never from index [0] of the
+raw response.
+
+mert-sniper's exposure is the DEPTH gate, not the spread: it reads
+bid_depth_usd / ask_depth_usd against MIN_BOOK_DEPTH_USD to decide whether a
+book is too thin to trade. A raw `[:5]` slice on CLOB-ordered arrays sums the
+five levels FURTHEST from the touch, so that gate was measuring the back of
+the book.
+
+All tests are pure-unit: no network calls, no SIMMER_API_KEY required.
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "market_filter": "", "max_bet_usd": 10.00, "expiry_window_mins": 8,
+    "min_split": 0.60, "max_trades_per_run": 5, "sizing_pct": 0.05,
+    "order_type": "GTC", "fee_buffer": 0.02, "min_edge": 0.0,
+    "enable_news_veto": True,
+}
+
+_skill_stub = types.ModuleType("simmer_sdk.skill")
+_skill_stub.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_stub.update_config = lambda updates, file, slug=None: None
+_skill_stub.get_config_path = lambda file: "/tmp/config.json"
+_guards_stub = types.ModuleType("simmer_sdk.guards.news_recency_veto")
+_guards_stub.load_macro_news_schedule = lambda path=None: {"events": []}
+_guards_stub.news_window_match = lambda market_id, schedule, lookback_s=30, now=None: (False, None)
+
+with patch.dict(sys.modules, {
+    "simmer_sdk": MagicMock(),
+    "simmer_sdk.skill": _skill_stub,
+    "simmer_sdk.guards.news_recency_veto": _guards_stub,
+}):
+    import mert_sniper as ms  # noqa: E402
+
+
+# Liquid two-sided book in CLOB native ordering: bids LOW→HIGH (best 0.48 is
+# LAST), asks HIGH→LOW (best 0.52 is LAST). The near-touch levels carry real
+# size and the far levels are near-worthless, so a back-of-book depth sum is
+# numerically distinguishable from a touch-side one.
+_CLOB_BOOK = {
+    "bids": [
+        {"price": "0.10", "size": "5"},
+        {"price": "0.20", "size": "5"},
+        {"price": "0.30", "size": "5"},
+        {"price": "0.40", "size": "100"},
+        {"price": "0.45", "size": "100"},
+        {"price": "0.48", "size": "100"},
+    ],
+    "asks": [
+        {"price": "0.90", "size": "5"},
+        {"price": "0.80", "size": "5"},
+        {"price": "0.70", "size": "5"},
+        {"price": "0.60", "size": "100"},
+        {"price": "0.55", "size": "100"},
+        {"price": "0.52", "size": "100"},
+    ],
+}
+
+
+class TestFetchOrderbookSummary(unittest.TestCase):
+    def _summary(self, book=_CLOB_BOOK):
+        with patch.object(ms, "_clob_request", return_value=book):
+            return ms.fetch_orderbook_summary("yes-token")
+
+    def test_best_prices_come_from_the_touch_not_index_zero(self):
+        s = self._summary()
+        self.assertAlmostEqual(s["best_bid"], 0.48)
+        self.assertAlmostEqual(s["best_ask"], 0.52)
+
+    def test_depth_sums_the_five_levels_nearest_the_touch(self):
+        s = self._summary()
+        # bids: 0.48*100 + 0.45*100 + 0.40*100 + 0.30*5 + 0.20*5 = 135.5
+        self.assertAlmostEqual(s["bid_depth_usd"], 135.5)
+        # asks: 0.52*100 + 0.55*100 + 0.60*100 + 0.70*5 + 0.80*5 = 174.5
+        self.assertAlmostEqual(s["ask_depth_usd"], 174.5)
+
+    def test_liquid_book_clears_the_min_depth_gate(self):
+        # The old [0]-indexed read summed the FAR side: bids 0.10*5 + 0.20*5 +
+        # 0.30*5 + 0.40*100 + 0.45*100 = 88.0 on the bid side and, on the asks,
+        # the most expensive levels — so a genuinely deep book could be skipped
+        # as "thin" (or a junk-laden one waved through) on back-of-book size.
+        s = self._summary()
+        self.assertGreater(s["bid_depth_usd"], ms.MIN_BOOK_DEPTH_USD)
+        self.assertGreater(s["ask_depth_usd"], ms.MIN_BOOK_DEPTH_USD)
+
+    def test_spread_is_the_touch_spread(self):
+        s = self._summary()
+        self.assertAlmostEqual(s["spread_pct"], 0.04 / 0.50)
+
+    def test_one_sided_book_returns_none(self):
+        self.assertIsNone(self._summary({"bids": _CLOB_BOOK["bids"], "asks": []}))
+
+    def test_unparseable_ask_price_does_not_fabricate_a_zero_touch(self):
+        book = {
+            "bids": _CLOB_BOOK["bids"],
+            "asks": [{"size": "10"}, {"price": "junk", "size": "10"}] + _CLOB_BOOK["asks"],
+        }
+        s = self._summary(book)
+        self.assertAlmostEqual(s["best_ask"], 0.52)
+        self.assertGreater(s["spread_pct"], 0)
+
+    def test_malformed_size_deep_in_the_book_does_not_discard_the_summary(self):
+        deep_junk = [{"price": "0.05", "size": "not-a-number"}]
+        s = self._summary({"bids": deep_junk + _CLOB_BOOK["bids"], "asks": _CLOB_BOOK["asks"]})
+        self.assertIsNotNone(s)
+        self.assertAlmostEqual(s["bid_depth_usd"], 135.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found during a Sentinel odds-tooling survey of the SDK (cross-repo review, not a user report).

## The bug

`fetch_orderbook_summary` read `bids[0]` / `asks[0]` as best bid/ask. The CLOB `/book` endpoint returns **bids LOW→HIGH and asks HIGH→LOW** — index `[0]` is the *worst* price on each side. This is the documented ordering in simmer's own other book readers, which all sort before reading best:

- `simmer_v3/polymarket_client.py:688` — comment: "Polymarket CLOB returns bids LOW→HIGH and asks HIGH→LOW"
- `simmer_v3/orderbook.py` — `_normalize_book` docstring (normalizes PolyNode *to* that CLOB ordering)
- `website/src/lib/polymarket/trading.js:74-79` — sorts both sides, then takes `[0]`

**Verified against the live CLOB, not just the citation.** On a real book: old read → bid `0.001` / ask `0.999`, spread `0.998`. True touch → bid `0.019` / ask `0.020`, spread `0.001`.

## Scope: all three CLOB readers, not one

The same function is copied verbatim into three published skills, all hitting the same raw `clob.polymarket.com/book`. **Every one of the three gates is behavior-bearing:**

| Skill | Installs | Confirmed trades | Last trade | Gate on corrupted data |
|---|---|---|---|---|
| `polymarket-fast-loop` | 8,445 | 14,509 / 346 wallets | Aug 7 | `MAX_SPREAD_PCT` — fallback branch only (runs when the Simmer API supplied no pre-fetched `spread_cents`) |
| `polymarket-mert-sniper` | 3,048 | 7,751 / 125 wallets | **Aug 9** | `MIN_BOOK_DEPTH_USD` — reads `bid_depth_usd`/`ask_depth_usd`, the fields the raw `[:5]` slice corrupts most |
| `polymarket-fast-scaler` | 680 | 235 / 4 wallets | Jun 20 | `MAX_SPREAD_PCT` — **no pre-fetch path**, so every live run hits it |

Effect in all three: deep books read as wide and were skipped as "illiquid"; near-empty one-level books computed a true touch spread and passed. Adverse selection toward exactly the books the gates exist to avoid. Depth summed the five levels *furthest* from the touch. Thin 5-minute sprint books (worst≈best) masked it.

## The fix

Sort both sides before reading the touch; sum top-5 depth from the sorted front.

Two fail-open paths hardened while in there (both surfaced in review, independently confirmed by a Codex pass):

1. **Unparseable price no longer defaults to `0`.** A zero-priced ask sorts to the front and fabricates a *negative* spread, which sails through `> MAX_SPREAD_PCT`. Such levels are now dropped.
2. **Sizes are parsed only for the five levels nearest the touch.** Parsing every level meant one malformed level deep in the book returned `None` — and a `None` makes the caller skip the spread gate entirely.

## Versions bumped (required — this is what makes the fix deliverable)

`1.7.0→1.7.1`, `1.3.3→1.3.4`, `1.2.0→1.2.1`. Skills ship via **ClawHub, not the PyPI wheel**, so without the bump the fix reaches zero of the ~12K installs. The `skill-governance` CI job enforces this and was red on the first revision of this PR.

**Post-merge step: republish all three to ClawHub, or nothing ships.**

## Tests

`test_fastloop_orderbook_summary.py` (extended) plus new `test_mertsniper_orderbook_summary.py` and `test_fastscaler_orderbook_spread.py`. Each uses a fixture in CLOB-native ordering whose best prices sit at the **end** of the raw arrays, so it fails on the old `[0]` read by construction, plus cases for both fail-open hardenings.

**Discriminance checked, not assumed:** 13 tests fail against the pre-fix sources; 31 pass after.

## Known gap (pre-existing, not fixed here)

**CI does not run skill tests at all** — `.github/workflows/ci.yml:62` runs only the root `tests/` directory, so every `skills/*/tests/` file is dead weight in CI, including these. A blanket `pytest skills/` currently fails at collection: basename collisions need `--import-mode=importlib`, and even then `skills/preflight/tests/test_preflight.py` breaks on collection-time `sys.modules` poisoning from other skills' `patch.dict(sys.modules, {"simmer_sdk": MagicMock()})` (it passes in isolation — same class as simmer PR #1335). Wiring that up touches every skill and belongs in its own PR, but until it lands these fixtures pin the contract for humans only.

No SIM ticket attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
