### PR TITLE
ci: run every skill's test suite (314 tests were invisible to CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,30 @@ jobs:
         working-directory: mcp
         run: npm test
 
+  skill-tests:
+    # Run each skill's own test suite. Until this job existed, CI ran only the
+    # root `tests/` directory, so every skills/*/tests file — preflight gates,
+    # orderbook-ordering regressions, venue routing — was never executed by CI
+    # and could rot silently. Each suite runs in its own pytest process; see
+    # the header of scripts/run_skill_tests.sh for why a single `pytest skills/`
+    # cannot work here.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install SDK (editable) + pytest
+        run: pip install -e . pytest
+
+      - name: Run every skill's test suite
+        run: bash scripts/run_skill_tests.sh
+
   skill-example-bind:
     # Bind every documented SDK example (SKILL.md + README) against the shipped
     # source. Catches the class of bug where an example uses a kwarg/method the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,22 +51,36 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **Book-liquidity gates were inverted across three Polymarket skills: they
-  skipped liquid books and traded thin ones.** `polymarket-fast-loop`
+- **Book-liquidity gates read the book from the wrong end in three Polymarket
+  skills, so they rejected tradeable markets.** `polymarket-fast-loop`
   (1.7.1), `polymarket-mert-sniper` (1.3.4) and `polymarket-fast-scaler`
   (1.2.1) each read `bids[0]`/`asks[0]` as best bid/ask, but the CLOB returns
   bids LOW→HIGH and asks HIGH→LOW (the ordering simmer_v3's
   `polymarket_client.py` and `orderbook.py` both document and sort for), so
   they computed worst-ask minus worst-bid — the full book width — and a raw
-  `[:5]` depth slice summed the levels *furthest* from the touch. Fast-loop
-  and fast-scaler blew through `MAX_SPREAD_PCT` on any market with real depth
-  and skipped it as "illiquid", while near-empty one-level books computed a
-  true touch spread and passed; mert-sniper's `MIN_BOOK_DEPTH_USD` thin-book
-  gate was measuring the back of the book. Net effect in all three: adverse
-  selection toward exactly the books the gates exist to avoid. Thin 5-minute
-  sprint books (worst≈best) masked it. All three now sort both sides before
-  reading the touch. Verified against the live CLOB: on a real book the old
-  read gave a 0.998 spread where the true touch spread was 0.001.
+  `[:5]` depth slice summed the levels *furthest* from the touch. All three
+  now sort both sides before reading the touch. Verified against the live
+  CLOB: on a real book the old read gave a 0.998 spread where the true touch
+  spread was 0.001.
+
+  **Measured impact (96 live books sampled).** The `MAX_SPREAD_PCT` misread is
+  one-directional: worst-ask minus worst-bid is always ≥ the touch spread, so
+  the gate could only ever be *too strict*, never too loose. It flagged 96 of
+  96 sampled books as too wide; a correct read passes 24 of them. So the cost
+  was **~25% of tradeable books skipped**, and zero cases of a thin book being
+  wrongly traded. mert-sniper's `MIN_BOOK_DEPTH_USD` gate is the one that can
+  err the dangerous way — summing the back of the ask side *overstates* depth
+  (far asks are the priciest) in 99% of books — but it crossed the $50
+  threshold into "thin book wrongly passed" in only 1% of the sample. Thin
+  5-minute sprint books (worst≈best) mask the bug entirely; no live sprint
+  market had two-sided depth at sampling time, so the rate for the market
+  class these skills actually trade is **not** measured by the above.
+
+  This corrects the impact description first published with this entry, which
+  claimed the gates "traded thin ones" and caused "adverse selection toward
+  exactly the books the gates exist to avoid." The mechanism was real but the
+  direction was wrong for the two spread gates: the dominant harm was missed
+  opportunity, not bad fills.
 
   Hardened while fixing: levels whose price won't parse are dropped rather
   than defaulted to `0`, since a zero-priced ask sorts to the front and

--- a/scripts/run_skill_tests.sh
+++ b/scripts/run_skill_tests.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Run every skill's test suite, each in its own pytest process.
+#
+# Why per-skill processes instead of one `pytest skills/`:
+#
+#   Skills are standalone bundles that get published to ClawHub and run on an
+#   agent host, not an importable package tree. Their tests reflect that — they
+#   stub the SDK by assigning into sys.modules so the skill module can be
+#   imported without a live SIMMER_API_KEY. Several do it permanently at import
+#   time rather than through a `patch.dict` context manager, e.g.
+#
+#       sys.modules["simmer_sdk"] = MagicMock()
+#
+#   In a single shared pytest process that stub leaks into every test collected
+#   afterwards, so a suite needing the REAL simmer_sdk (skills/preflight) dies
+#   at collection with "'simmer_sdk' is not a package". A one-process run also
+#   hits basename collisions between same-named test files in different skills.
+#
+#   Isolating per skill fixes both without editing 17 test files across skills
+#   owned by different workstreams, and it matches how skills actually execute.
+#
+# Usage: scripts/run_skill_tests.sh [skills_dir]
+set -uo pipefail
+
+SKILLS_DIR="${1:-skills}"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "No '$SKILLS_DIR' directory — nothing to do."
+  exit 0
+fi
+
+failed_suites=()
+passed=0
+total_tests=0
+
+while IFS= read -r tests_dir; do
+  skill="$(basename "$(dirname "$tests_dir")")"
+  output="$(python -m pytest "$tests_dir" -q 2>&1)"
+  status=$?
+  summary="$(printf '%s\n' "$output" | tail -1)"
+
+  if [ $status -eq 0 ]; then
+    printf '  ok   %-40s %s\n' "$skill" "$summary"
+    passed=$((passed + 1))
+    n="$(printf '%s' "$summary" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || true)"
+    total_tests=$((total_tests + ${n:-0}))
+  else
+    printf '  FAIL %-40s %s\n' "$skill" "$summary"
+    printf '%s\n' "$output" | tail -40 | sed 's/^/       /'
+    failed_suites+=("$skill")
+  fi
+done < <(find "$SKILLS_DIR" -type d -name tests | sort)
+
+echo
+if [ ${#failed_suites[@]} -gt 0 ]; then
+  echo "Skill tests FAILED in ${#failed_suites[@]} suite(s): ${failed_suites[*]}"
+  exit 1
+fi
+
+echo "Skill tests passed: $passed suite(s), $total_tests test(s)."


### PR DESCRIPTION
## The gap

`.github/workflows/ci.yml` ran only the root `tests/` directory. Every `skills/*/tests` file was therefore **never executed by CI** — 314 tests across 14 suites, including preflight gates, venue routing, and the orderbook-ordering regressions added in #299. A regression fixture CI doesn't run is documentation, not a gate.

## Why not just `pytest skills/`

It fails at collection, for two independent reasons:

1. **sys.modules poisoning.** Skills are standalone bundles, so their tests stub the SDK to import the skill without a live `SIMMER_API_KEY`. Several do it *permanently at import time* rather than through a `patch.dict` context manager — `sys.modules["simmer_sdk"] = MagicMock()` in `kalshi-weather-trader`, `polymarket-nothing-ever-happens`, `polymarket-weather-trader`. That leaks into everything collected afterwards, so `skills/preflight` (which needs the real package) dies with `'simmer_sdk' is not a package`. It passes fine alone.
2. **Basename collisions** between same-named test files in different skills (`test_sources_none.py` exists twice).

## The fix

`scripts/run_skill_tests.sh` runs each skill's suite in its own pytest process. This sidesteps both problems without editing 17 test files owned by other workstreams, and it matches how skills actually execute on an agent host. Per-suite runtime is ~0.05s, so the whole job is a few seconds.

**Starts green:** all 14 suites pass today (314 tests), so this gates without a cleanup backlog.

**Verified it can fail:** injected a deliberately failing test → job exits 1 and names the suite; removed it → exits 0. A gate that can't go red isn't a gate.

## Also: corrects the #299 impact record

I measured the bug from #299 against 96 live books. The result contradicts what that PR (and its CHANGELOG entry, which I wrote) claimed:

- The `MAX_SPREAD_PCT` misread is **one-directional**. Worst-ask minus worst-bid is always ≥ the touch spread, so the gate could only ever be *too strict*. It flagged **96/96** sampled books as too wide; a correct read passes **24**. Net cost: **~25% of tradeable books skipped, zero thin books wrongly traded.**
- The published entry said the gates "traded thin ones" and caused "adverse selection toward exactly the books the gates exist to avoid." Mechanism right, **direction wrong**. The dominant harm was missed opportunity, not bad fills.
- The one gate that *can* err dangerously is mert-sniper's `MIN_BOOK_DEPTH_USD`: summing the back of the ask side overstates depth (far asks are priciest) in **99%** of books, but it crossed the $50 threshold into "thin book wrongly passed" in only **1%**.
- **Stated limit:** no live sprint market had two-sided depth at sampling time, so the rate for the market class these skills actually trade is unmeasured. The sample is general top-volume markets.

## Not in this PR

All three skills **fail open** when the book fetch fails — `None` skips the gate and the trade proceeds (`fast_scaler.py` is the starkest: `fetch_orderbook_spread(...) or 0.0` turns a fetch failure into a perfect zero spread). That's a runtime behavior change with its own tradeoff, so it gets its own PR and its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)