### PR TITLE
fix(polymarket-skills): fail closed when the order book can't be fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Book-liquidity gates now fail CLOSED when the order book can't be
+  fetched.** `polymarket-fast-loop` (1.7.2), `polymarket-mert-sniper` (1.3.5)
+  and `polymarket-fast-scaler` (1.2.2) all traded on through a failed book
+  fetch. fast-scaler was the starkest: `fetch_orderbook_spread(...) or 0.0`
+  turned a fetch failure into a *perfect zero spread*, so `MAX_SPREAD_PCT`
+  cleared every time — the gate was most permissive exactly when it knew
+  least. fast-loop fell through its `if book:` with no else; mert-sniper
+  printed "proceeding with caution" and proceeded without any. All three now
+  skip the trade and record a `book unavailable` skip reason. Skipping costs
+  one cycle; trading an unmeasured book crosses whatever spread is actually
+  there, and live sampling shows most books sit wider than `MAX_SPREAD_PCT`.
+
 - **Book-liquidity gates were inverted across three Polymarket skills: they
   skipped liquid books and traded thin ones.** `polymarket-fast-loop`
   (1.7.1), `polymarket-mert-sniper` (1.3.4) and `polymarket-fast-scaler`

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.7.1"
+  version: "1.7.2"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -1178,16 +1178,26 @@ def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=Fal
             return
     else:
         book = fetch_orderbook_summary(clob_tokens) if clob_tokens else None
-        if book:
-            log(f"  Spread: {book['spread_pct']:.1%} (bid ${book['best_bid']:.3f} / ask ${book['best_ask']:.3f})")
-            log(f"  Depth: ${book['bid_depth_usd']:.0f} bid / ${book['ask_depth_usd']:.0f} ask (top 5)")
-            if book["spread_pct"] > MAX_SPREAD_PCT:
-                log(f"  ⏸️  Spread {book['spread_pct']:.1%} > 10% — illiquid, skip")
-                if not quiet:
-                    print(f"📊 Summary: No trade (wide spread: {book['spread_pct']:.1%})")
-                skip_reasons.append("wide spread")
-                _emit_skip_report()
-                return
+        if book is None:
+            # Fail CLOSED. A missing book used to fall straight through the
+            # spread gate and trade unmeasured. Skipping costs one sprint
+            # cycle; trading blind crosses whatever spread is actually there,
+            # and on live sampling most books are wider than MAX_SPREAD_PCT.
+            log("  ⏸️  Order book unavailable — cannot verify spread, skip")
+            if not quiet:
+                print("📊 Summary: No trade (order book unavailable)")
+            skip_reasons.append("book unavailable")
+            _emit_skip_report()
+            return
+        log(f"  Spread: {book['spread_pct']:.1%} (bid ${book['best_bid']:.3f} / ask ${book['best_ask']:.3f})")
+        log(f"  Depth: ${book['bid_depth_usd']:.0f} bid / ${book['ask_depth_usd']:.0f} ask (top 5)")
+        if book["spread_pct"] > MAX_SPREAD_PCT:
+            log(f"  ⏸️  Spread {book['spread_pct']:.1%} > 10% — illiquid, skip")
+            if not quiet:
+                print(f"📊 Summary: No trade (wide spread: {book['spread_pct']:.1%})")
+            skip_reasons.append("wide spread")
+            _emit_skip_report()
+            return
 
     # Check minimum momentum (loose gate when fair-value mode is on — edge check filters there)
     _momentum_floor = 0.01 if USE_FAIR_VALUE else MIN_MOMENTUM_PCT

--- a/skills/polymarket-fast-scaler/SKILL.md
+++ b/skills/polymarket-fast-scaler/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-scaler
 description: Trade Polymarket BTC 5-minute fast markets using a magnitude-gated conviction-ladder strategy. Only fires when |1m BTC momentum| >= 0.10%, the magnitude threshold the strategy is built around. Position size scales with signal strength (3 conviction tiers). Reference template for gate-filtered BTC fast-market trading; the original performance claim was retracted (see below).
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.2.1"
+  version: "1.2.2"
   displayName: Polymarket FastScaler
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-scaler/fast_scaler.py
+++ b/skills/polymarket-fast-scaler/fast_scaler.py
@@ -837,7 +837,16 @@ def run_fast_scaler(dry_run=True, positions_only=False, show_config=False, quiet
         spread_pct = (pre_spread_cents / 100.0) / mid_est
         log(f"  Spread: {pre_spread_cents:.1f}¢ ({best.get('liquidity_tier', 'unknown')})")
     else:
-        spread_pct = fetch_orderbook_spread(clob_tokens) or 0.0
+        spread_pct = fetch_orderbook_spread(clob_tokens)
+        if spread_pct is None:
+            # Fail CLOSED. `or 0.0` used to turn a failed book fetch into a
+            # PERFECT zero spread, which cleared MAX_SPREAD_PCT every time —
+            # the gate was loudest exactly when it knew least. Skipping costs
+            # one sprint cycle; trading an unmeasured book crosses whatever
+            # spread happens to be there.
+            log("  ⏸️  Order book unavailable — cannot verify spread, skip")
+            _emit_automaton(signals=0, attempted=0, executed=0, skip_reason="book_unavailable")
+            return
         log(f"  Spread: {spread_pct:.1%} (live CLOB)")
 
     if spread_pct > MAX_SPREAD_PCT:

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes, filters for strongly-skewed splits (60/40+), and places bounded trades against the under-priced side. Defaults — $10 max per trade, 5 trades/run, 8-minute expiry window, dry-run unless `--live`.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.4"
+  version: "1.3.5"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -627,7 +627,13 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
                     skip_reasons.append("thin book")
                     continue
             else:
-                print(f"     Book:  unavailable (proceeding with caution)")
+                # Fail CLOSED. This previously proceeded "with caution", which
+                # in practice meant no caution at all: the depth gate is the
+                # only thing standing between this skill and a thin book, so
+                # an unavailable book is the moment it matters most.
+                print(f"     Skip: order book unavailable — cannot verify depth")
+                skip_reasons.append("book unavailable")
+                continue
 
         # Fee-aware EV check (entry fee only — Polymarket binary redemption is free).
         # mert-sniper has no external price signal, so "divergence from neutral" is not a


### PR DESCRIPTION
Follow-up to #299. **This one changes runtime trading behavior, so it wants an explicit decision rather than a rubber stamp.**

## What's wrong

All three CLOB-reading skills trade on through a failed book fetch — the liquidity gate is most permissive exactly when it knows least.

| Skill | Current behavior on fetch failure |
|---|---|
| `polymarket-fast-scaler` | `fetch_orderbook_spread(...) or 0.0` — a failure becomes a **perfect zero spread** and clears `MAX_SPREAD_PCT` every time. Not just skipping the gate: asserting an ideal book. |
| `polymarket-fast-loop` | `if book:` with no `else` — falls through to the momentum check and trades unmeasured. |
| `polymarket-mert-sniper` | prints `"Book: unavailable (proceeding with caution)"` and proceeds with none. |

mert-sniper's is a *deliberate* documented choice by whoever wrote it — worth knowing before overriding it. The other two look like oversights, and fast-scaler's `or 0.0` almost certainly is: nobody intends "fetch failed" to mean "zero spread."

## The change

All three skip the trade and record a `book unavailable` skip reason.

**The tradeoff, stated plainly:** a false skip costs one cycle of opportunity. A false trade crosses whatever spread is actually there. Live sampling of 96 books (see #300) found **72 of 96 sit wider than `MAX_SPREAD_PCT`** — so "a book we couldn't measure is probably fine" is a bad prior. That's the argument for failing closed; if you weigh missed cycles higher, the honest answer is to close this PR rather than half-apply it.

## Known coverage gap — stated, not papered over

The gates live inside long procedural `run()`/decision functions with no test seam, so **these caller paths are not unit-tested**. What IS covered is the helper returning `None` rather than `0.0`. Adding a seam so the decision function is drivable is real follow-up work; I didn't want to smuggle a refactor of the main trade loop into a behavior-change PR.

All 314 skill tests still pass (via #300's runner).

## If merged

Needs a ClawHub republish for 1.7.2 / 1.3.5 / 1.2.2, same as #299 — merging alone ships nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)