### PR TITLE
release: simmer-mcp 3.4.9 — ship the SIM-4369 tool annotations fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Restore the legacy NegRiskAdapter to V2 trading spenders (SIM-4377).** Polymarket's 2026-07-18 adapter retirement covers relayer calls targeting the adapter, not the pUSD/CTF allowances where it is the spender — the CLOB still gates every neg-risk fill on that allowance. `set_approvals()` now grants the full 12-tx V2 set again (was 10 after #281); wallets approved without it were silently locked out of neg-risk markets.
 
-## [Unreleased]
-
-### Added
+## simmer-mcp v3.4.9 — 2026-08-09
 
 - **MCP tool annotations: all 21 `simmer-mcp` tools now emit `readOnlyHint`/`destructiveHint`.**
   Previously `annotations` was `null` on every tool, causing MCP clients that gate on annotations
@@ -28,6 +26,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   commit/revert on the working tree) and `init_experiment` (archives prior results, POSTs to
   the API). `backtest_experiment` is simulated only and stays read-only. `mutates` continues to
   govern the execution gate; `annotations` governs the wire protocol.
+
+## [Unreleased]
+
+### Added
 
 - **Hyperliquid trading with pmxt-constructed orders (SIM-4222).**
   `PmxtHyperliquidVenue` implements `VenueAdapter` against a self-hosted,

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Why

PR #296 (SIM-4369) merged the `readOnlyHint`/`destructiveHint` work but left `mcp/package.json` at **3.4.8** — the version npm already serves. `plan_package_publish.py` compares repo version against the registry, computed `npm_publish_needed=false`, and nothing shipped.

So the published package still returns `annotations=null`: the exact condition SIM-4369 was filed to fix, and the condition its own verification step (raw stdio `tools/list` probe against the published npm package) probes against. The ticket reads `done`; the user-visible bug is untouched.

## What

- `mcp/package.json` → **3.4.9**, so `publish-packages` fires on merge.
- CHANGELOG: move the annotations entry out of `[Unreleased]` into a `## simmer-mcp v3.4.9` section, matching the existing mcp-only release heading convention (cf. `simmer-mcp v3.3.0`). Remaining SDK entries stay under `[Unreleased]`.

The only `mcp/` commit since the 3.4.8 bump is #296, so this release carries exactly that change and nothing else.

## Expected red check

**`Publish Lag Check` will fail on this PR.** It fails whenever the repo version leads the registry, which is definitionally true for a release commit until the publish lands. It is not a required check — the last release PR (#287) went red on it the same way.

## Verification after merge

`publish-packages` → `publish-mcp` should ship 3.4.9. Confirm with `npm view simmer-mcp version`, then re-run the SIM-4369 stdio probe against the published package to close the loop empirically.

Refs SIM-4369