### PR TITLE
docs(polymarket-skills): retract the wrong impact claim from the 1.7.1/1.2.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Retracts the wrong impact claim in the `polymarket-fast-loop@1.7.1` and
+  `polymarket-fast-scaler@1.2.1` ClawHub release notes** (republished as
+  1.7.3 / 1.2.3; no code change in either). Both claimed the inverted book
+  read made the skill "trade near-empty books". That is wrong in direction:
+  worst-ask minus worst-bid is always ≥ the touch spread, so the spread gate
+  could only ever be too *strict*, never too loose. Measured across 96 live
+  books, the old read rejected 96/96 where a correct read passes 24 — ~25% of
+  tradeable books skipped, and **zero** thin books wrongly traded.
+  `polymarket-mert-sniper@1.3.4`'s note needs no correction: it describes the
+  `MIN_BOOK_DEPTH_USD` gate, which genuinely can err toward over-trading
+  (ask-side depth overstated in 99% of books, crossing the $50 threshold in
+  1%). ClawHub has no affordance to amend a published changelog, so a patch
+  release is the only way to put the correction where readers look.
+
 - **Book-liquidity gates now fail CLOSED when the order book can't be
   fetched.** `polymarket-fast-loop` (1.7.2), `polymarket-mert-sniper` (1.3.5)
   and `polymarket-fast-scaler` (1.2.2) all traded on through a failed book

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.7.2"
+  version: "1.7.3"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-scaler/SKILL.md
+++ b/skills/polymarket-fast-scaler/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-scaler
 description: Trade Polymarket BTC 5-minute fast markets using a magnitude-gated conviction-ladder strategy. Only fires when |1m BTC momentum| >= 0.10%, the magnitude threshold the strategy is built around. Position size scales with signal strength (3 conviction tiers). Reference template for gate-filtered BTC fast-market trading; the original performance claim was retracted (see below).
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.2.2"
+  version: "1.2.3"
   displayName: Polymarket FastScaler
   difficulty: advanced
 ---


### PR DESCRIPTION
**No code change.** Version bumps + CHANGELOG only.

## Why a release is needed for a docs fix

ClawHub has no way to amend a published version's changelog — the CLI exposes `publish`, `tag`, `rename`, `merge`, `delete` and nothing else, and an authenticated API edit isn't available to us. Version history *is* publicly readable (`/api/v1/skills/<slug>/versions/<v>`), so the wrong text stays reachable until a newer version carries the correction.

## What was wrong

`polymarket-fast-loop@1.7.1` and `polymarket-fast-scaler@1.2.1` both shipped a note saying the inverted book read skipped liquid markets **"while trading near-empty ones."** The second half is false.

Worst-ask minus worst-bid is always ≥ the touch spread, so the spread gate could only ever be **too strict**. Over-trading was not a reachable outcome. Measured across 96 live books:

| | old `[0]` read | correct touch read |
|---|---|---|
| books flagged too wide | **96 / 96** | 72 / 96 |
| books passing the gate | 0 | **24** |

So the cost was **~25% of tradeable books skipped, zero thin books wrongly traded** — missed opportunity, not adverse selection.

## What is NOT corrected

`polymarket-mert-sniper@1.3.4` stays as published. Its note describes the `MIN_BOOK_DEPTH_USD` gate, which genuinely *can* err toward over-trading — summing the back of the ask side overstates depth (far asks are priciest) in 99% of books, crossing the $50 threshold in 1% of the sample. That note was accurate.

## Version hygiene

Repo `SKILL.md` versions bump in lockstep with the republish so repo == registry. Drift in the other direction makes future publishes silently fail to become the installed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)