### PR TITLE
fix(ci): retry verify step after publish to avoid CDN propagation race (SIM-4441)

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -192,7 +192,7 @@ jobs:
     needs: [plan, publish-mcp, publish-sdk]
     if: always() && (needs.plan.outputs.npm_publish_needed == 'true' || needs.plan.outputs.pypi_publish_needed == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -203,4 +203,13 @@ jobs:
           python-version: "3.12"
 
       - name: Check publish lag
-        run: python3 scripts/check_publish_lag.py
+        # Pass --retry-npm/--retry-pypi when this run just published a package so
+        # the verify step waits for CDN propagation instead of reading stale data.
+        env:
+          NPM_RESULT: ${{ needs.publish-mcp.result }}
+          PYPI_RESULT: ${{ needs.publish-sdk.result }}
+        run: |
+          args=""
+          [ "$NPM_RESULT" = "success" ] && args="$args --retry-npm"
+          [ "$PYPI_RESULT" = "success" ] && args="$args --retry-pypi"
+          python3 scripts/check_publish_lag.py $args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- **CI: publish-packages verify step no longer false-fails on successful releases.** The verify step now polls the npm and PyPI registries with a bounded retry (up to 120s, 10s interval) when this run just published a package, rather than reading once immediately after the publish step. npm's CDN-cached read path lags writes by seconds, so the single-read approach reliably returned stale data on real releases and left a red workflow run on main for releases that had fully succeeded.
+
 ### Added
 
 - **Hyperliquid trading with pmxt-constructed orders (SIM-4222).**

--- a/scripts/check_publish_lag.py
+++ b/scripts/check_publish_lag.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import time
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
@@ -133,6 +134,10 @@ def fetch_pypi_latest(package_name: str) -> str:
     return str(payload["info"]["version"])
 
 
+RETRY_INTERVAL_SECS = 10
+RETRY_MAX_SECS = 120
+
+
 def check_package(label: str, repo_version: str, published_version: str) -> bool:
     comparison = compare_versions(repo_version, published_version)
     if comparison > 0:
@@ -152,11 +157,65 @@ def check_package(label: str, repo_version: str, published_version: str) -> bool
     return True
 
 
+def check_package_with_retry(
+    label: str,
+    repo_version: str,
+    fetch_fn: "Callable[[], str]",
+    retry: bool,
+) -> bool:
+    """Check registry version, retrying if the package was just published.
+
+    Without retry the CDN-cached registry read can return stale data for several
+    seconds after a publish succeeds, producing a false "version ahead" failure.
+    With retry=True, poll up to RETRY_MAX_SECS before giving up.
+    """
+    if not retry:
+        return check_package(label, repo_version, fetch_fn())
+
+    deadline = time.monotonic() + RETRY_MAX_SECS
+    attempt = 0
+    while True:
+        attempt += 1
+        published_version = fetch_fn()
+        comparison = compare_versions(repo_version, published_version)
+        if comparison <= 0:
+            # registry caught up (match) or is ahead (newer release elsewhere)
+            return check_package(label, repo_version, published_version)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # timed out — emit the real error
+            return check_package(label, repo_version, published_version)
+        wait = min(RETRY_INTERVAL_SECS, remaining)
+        print(
+            f"{label}: registry at {published_version}, waiting for {repo_version} to propagate"
+            f" (attempt {attempt}, retrying in {int(wait)}s)…"
+        )
+        time.sleep(wait)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=ROOT)
     parser.add_argument("--npm-published-version", help="Override npm latest version for tests.")
     parser.add_argument("--pypi-published-version", help="Override PyPI latest version for tests.")
+    parser.add_argument(
+        "--retry-npm",
+        action="store_true",
+        default=False,
+        help=(
+            "Retry npm registry check until repo version appears (up to "
+            f"{RETRY_MAX_SECS}s). Use when this CI run just published the npm package."
+        ),
+    )
+    parser.add_argument(
+        "--retry-pypi",
+        action="store_true",
+        default=False,
+        help=(
+            "Retry PyPI registry check until repo version appears (up to "
+            f"{RETRY_MAX_SECS}s). Use when this CI run just published the PyPI package."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -166,13 +225,28 @@ def main() -> int:
 
     npm_repo_version = read_npm_repo_version(root)
     pypi_repo_version = read_pypi_repo_version(root)
-    npm_published_version = args.npm_published_version or fetch_npm_latest(NPM_PACKAGE)
-    pypi_published_version = args.pypi_published_version or fetch_pypi_latest(PYPI_PACKAGE)
 
-    ok = True
-    ok &= check_package(NPM_PACKAGE, npm_repo_version, npm_published_version)
-    ok &= check_package(PYPI_PACKAGE, pypi_repo_version, pypi_published_version)
-    return 0 if ok else 1
+    retry_npm = getattr(args, "retry_npm", False)
+    retry_pypi = getattr(args, "retry_pypi", False)
+
+    if args.npm_published_version:
+        npm_ok = check_package(NPM_PACKAGE, npm_repo_version, args.npm_published_version)
+    else:
+        npm_ok = check_package_with_retry(
+            NPM_PACKAGE, npm_repo_version, lambda: fetch_npm_latest(NPM_PACKAGE), retry=retry_npm
+        )
+
+    if args.pypi_published_version:
+        pypi_ok = check_package(PYPI_PACKAGE, pypi_repo_version, args.pypi_published_version)
+    else:
+        pypi_ok = check_package_with_retry(
+            PYPI_PACKAGE,
+            pypi_repo_version,
+            lambda: fetch_pypi_latest(PYPI_PACKAGE),
+            retry=retry_pypi,
+        )
+
+    return 0 if (npm_ok and pypi_ok) else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_check_publish_lag.py
+++ b/tests/test_check_publish_lag.py
@@ -1,5 +1,7 @@
 import importlib.util
 import sys
+import time
+import types
 from pathlib import Path
 
 import pytest
@@ -51,20 +53,24 @@ def test_check_package_outcomes(repo_version: str, published_version: str, expec
     assert check_publish_lag.check_package("simmer-mcp", repo_version, published_version) is expected
 
 
+def make_args(**kwargs):
+    defaults = {
+        "root": None,
+        "npm_published_version": None,
+        "pypi_published_version": None,
+        "retry_npm": False,
+        "retry_pypi": False,
+    }
+    defaults.update(kwargs)
+    return type("Args", (), defaults)()
+
+
 def test_main_fails_when_either_registry_lags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.0")
     monkeypatch.setattr(
         check_publish_lag,
         "parse_args",
-        lambda: type(
-            "Args",
-            (),
-            {
-                "root": tmp_path,
-                "npm_published_version": "3.4.9",
-                "pypi_published_version": "0.20.0",
-            },
-        )(),
+        lambda: make_args(root=tmp_path, npm_published_version="3.4.9", pypi_published_version="0.20.0"),
     )
 
     assert check_publish_lag.main() == 1
@@ -77,15 +83,89 @@ def test_main_passes_when_repo_matches_or_is_behind(
     monkeypatch.setattr(
         check_publish_lag,
         "parse_args",
-        lambda: type(
-            "Args",
-            (),
-            {
-                "root": tmp_path,
-                "npm_published_version": "3.4.4",
-                "pypi_published_version": "0.20.1",
-            },
-        )(),
+        lambda: make_args(root=tmp_path, npm_published_version="3.4.4", pypi_published_version="0.20.1"),
     )
 
     assert check_publish_lag.main() == 0
+
+
+def test_retry_succeeds_once_registry_propagates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry loop should pass once the registry returns the expected version."""
+    write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.0")
+
+    call_count = 0
+
+    def fake_fetch_npm(pkg):
+        nonlocal call_count
+        call_count += 1
+        return "3.4.10" if call_count >= 2 else "3.4.9"
+
+    monkeypatch.setattr(check_publish_lag, "fetch_npm_latest", fake_fetch_npm)
+    monkeypatch.setattr(check_publish_lag, "fetch_pypi_latest", lambda pkg: "0.20.0")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "time",
+        types.SimpleNamespace(monotonic=time.monotonic, sleep=lambda s: None),
+    )
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: make_args(root=tmp_path, retry_npm=True, retry_pypi=False),
+    )
+
+    assert check_publish_lag.main() == 0
+    assert call_count == 2
+
+
+def test_retry_fails_after_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry loop should give up and fail if registry never propagates within deadline."""
+    write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.0")
+
+    # Make time.monotonic() advance past the deadline on the second call.
+    start = time.monotonic()
+    tick = 0
+
+    def fake_monotonic():
+        nonlocal tick
+        tick += 1
+        # First call: sets deadline. Subsequent calls: already past deadline.
+        return start if tick == 1 else start + check_publish_lag.RETRY_MAX_SECS + 1
+
+    monkeypatch.setattr(check_publish_lag, "fetch_npm_latest", lambda pkg: "3.4.9")
+    monkeypatch.setattr(check_publish_lag, "fetch_pypi_latest", lambda pkg: "0.20.0")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "time",
+        types.SimpleNamespace(monotonic=fake_monotonic, sleep=lambda s: None),
+    )
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: make_args(root=tmp_path, retry_npm=True, retry_pypi=False),
+    )
+
+    assert check_publish_lag.main() == 1
+
+
+def test_no_retry_reads_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without retry flag, registry is read exactly once regardless of result."""
+    write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.0")
+
+    fetch_count = 0
+
+    def fake_fetch_npm(pkg):
+        nonlocal fetch_count
+        fetch_count += 1
+        return "3.4.9"  # stale — would need retry to pass
+
+    monkeypatch.setattr(check_publish_lag, "fetch_npm_latest", fake_fetch_npm)
+    monkeypatch.setattr(check_publish_lag, "fetch_pypi_latest", lambda pkg: "0.20.0")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: make_args(root=tmp_path, retry_npm=False, retry_pypi=False),
+    )
+
+    result = check_publish_lag.main()
+    assert fetch_count == 1
+    assert result == 1


### PR DESCRIPTION
The `publish-packages` verify step read the npm/PyPI registry exactly once, immediately after the publish step completed. npm's CDN-cached read path lags writes by seconds, so on real release runs the verify step consistently returned stale data and left a false red workflow run on `main` even though the publish had fully succeeded.

## Changes
- `scripts/check_publish_lag.py`: add `--retry-npm` / `--retry-pypi` flags — when set, poll the registry every 10s for up to 120s instead of reading once
- `.github/workflows/publish-packages.yml`: pass `--retry-npm` when `publish-mcp` succeeded, `--retry-pypi` when `publish-sdk` succeeded; bump verify job timeout 5m → 10m
- `tests/test_check_publish_lag.py`: four new tests covering retry-succeeds-on-propagation, timeout, no-retry single-read, plus helper `make_args()` factory so existing monkeypatch tests don't need per-test attribute bookkeeping

## Tests
```
python3 -m pytest tests/test_check_publish_lag.py -v
# 10 passed in 0.07s
```

## Risk
Low — no change to publish logic; only the verification step. Worst case: the 2-min retry window exhausts and the step still fails (same behavior as today, just delayed). For no-op runs (nothing published) the retry flags are never set and behavior is unchanged.

Closes SIM-4441