### PR TITLE
feat(skills): port Nansen copytrader overlay into simmer-sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,26 @@ jobs:
       - name: Check repo versions are published
         run: python3 scripts/check_publish_lag.py
 
+  nansen-no-cli-guard:
+    name: Nansen Overlay (no-CLI guard)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The adapter shelled out to the `nansen` CLI through two rounds of
+      # review before being ported to direct HTTPS. This guard is the lock on
+      # that regression. The skill's 109 tests run in the `skill-tests` job.
+      - name: Assert no subprocess/CLI path
+        run: |
+          if grep -rnE '\b(subprocess|Popen|check_output|os\.system|shutil\.which)\b' \
+               skills/nansen-copytrader-overlay --include='*.py'; then
+            echo "::error::subprocess/CLI path reintroduced - this skill must use direct HTTPS only"
+            exit 1
+          fi
+          echo "OK: no subprocess path"
+
   skill-governance:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/skills/nansen-copytrader-overlay/DISCLAIMER.md
+++ b/skills/nansen-copytrader-overlay/DISCLAIMER.md
@@ -1,0 +1,54 @@
+# Disclaimer
+
+## Research tooling, not financial advice
+
+Nothing this skill produces is financial, investment, or trading advice. It
+re-ranks a list of wallets using Nansen's Polymarket PnL data and attaches
+reason codes. Deciding whether to act on that ranking, and with how much
+capital, is your responsibility.
+
+## It does not place trades
+
+Every function and CLI command here is signal-only. The skill returns a
+ranked list and stops. The live insider scan refuses to run outside dry-run
+by design and raises rather than warning. Nothing in this package can move
+funds, and adding execution on top of it is a deliberate change you make at
+your own risk.
+
+## The scoring is unvalidated
+
+The scoring weights, the 50/50 blend between the Nansen score and your
+existing score, the `MIN_RESOLVED_MARKETS` floor and the tag penalties are
+reasoned starting points. They have not been fitted to data, backtested, or
+forward-tested. No result shows that this re-ranking improves realised
+copytrading returns. Treat the output as research until that changes.
+
+## Past performance is not predictive
+
+The primary signal is realised PnL in a specific market. A wallet that
+earned in a market may have been lucky, may have had information you do not
+have, and may not repeat. Copying a wallet also means copying its entry
+price, its timing and its risk tolerance, none of which this skill can see.
+Edges depend on spreads, fees, latency and liquidity.
+
+## Wallet coverage is partial
+
+Owner-address harvesting covers roughly 40% of a typical leaderboard, so
+some wallets are scored on less data than others. Wallets absent from the
+target market's leaderboard are kept at their original score rather than
+scored against a signal that does not exist. Read the reason codes; they
+tell you which case each wallet fell into.
+
+## It spends your money
+
+This skill is bring-your-own-key. Every call consumes credits on your own
+Nansen account. The credit guards are hard caps, not estimates, but you
+should still confirm your balance before a large run. Nansen's published
+price list did not match what we were billed for one endpoint, so treat any
+credit figure as approximate.
+
+## Third-party data
+
+Nansen is an independent data provider. Simmer does not control the accuracy,
+availability or pricing of their API, and their schemas can change without
+notice. If their data is wrong, this skill's output is wrong.

--- a/skills/nansen-copytrader-overlay/SKILL.md
+++ b/skills/nansen-copytrader-overlay/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: nansen-copytrader-overlay
+description: Rank Polymarket copytrading leaders using Nansen as a data layer — pnl-by-market for the target market is the primary signal, address-summary/pnl-by-address is a secondary, credit-guarded refinement. Includes an experimental (dry-run only) live insider scan. Use when Simmer needs to re-rank or filter a leader list before executing copytrading rebalances on a specific Polymarket market.
+tags:
+  - copytrading
+  - polymarket
+  - nansen
+metadata:
+  author: Simmer (@simmer_markets)
+  version: "0.1.0"
+  displayName: Nansen Copytrader Overlay
+  difficulty: intermediate
+  simmer:
+    credit:
+      name: "Alyna Takahashi"
+      url: "https://github.com/alyna123t"
+      label: by
+---
+
+# Nansen Copytrader Overlay
+
+Nansen is a **data layer only** in this skill: PM PnL quality overlay +
+address-summary/wallet quality. It is **not** smart-money-labeled
+copytrading — Nansen's smart-money labels are not Polymarket-specific, and
+no code path here calls the labels endpoint at all.
+
+## When to use this skill
+
+Simmer is about to execute a copytrading rebalance into a specific
+Polymarket market and has a candidate leader list (wallets + an existing
+`wallet_score`). Use this skill to re-rank that list using Nansen's
+Polymarket-specific PnL data before Simmer acts on it.
+
+Do **not** use this skill to:
+- Generate smart-money labels or entity classifications (out of scope — see framing above).
+- Place trades. Every function and CLI command here is signal-only; the
+  caller (Simmer's execution wrapper) owns the actual `--live` gate.
+
+## Core signal: pnl-by-market first
+
+The primary ranking signal is `pnl_by_market(market_id)` — who is actually
+profitable **in the target market**, not a wallet's broad trading history.
+`pnl_by_address` / `trades_by_address` (broad history) and
+`address_summary` (cheap wallet-quality pre-filter) are secondary —
+they refine the market-specific score, they never replace it. A wallet
+absent from the target market's leaderboard gets tagged
+`NOT_IN_MARKET_LEADERBOARD` and keeps its original score with a small
+discount, rather than a fabricated 50/50 blend against a signal that
+doesn't exist.
+
+## Running it
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install pytest   # for tests only; the skill itself is stdlib-only
+export NANSEN_API_KEY=...   # your own Nansen key — sent as the `apiKey` header
+```
+
+No `nansen` CLI required: calls go straight to `https://api.nansen.ai/api/v1`
+over HTTPS. Bring-your-own-key — every call spends **your** Nansen credits,
+so `--max-wallets` (default 30) and `--max-calls` (default 40) are
+deliberately conservative.
+
+### Getting a Nansen key
+
+Sign up at **[nsn.ai/simmer](https://nsn.ai/simmer)**, then copy your key from
+the Nansen dashboard. Signing up through that link gets you the Simmer partner
+discount on your subscription and API credits.
+
+**What a run costs.** Credit prices measured directly against the live API on
+2026-08-11:
+
+| Endpoint | Credits |
+|---|---|
+| `pnl-by-market` (primary signal, once per run) | 5 |
+| `top-holders` | 5 |
+| `address-summary`, `pnl-by-address`, `trades-by-address`, `market-screener` | 1 |
+| `account` (balance check) | 0 |
+
+At the default caps a full run costs **about 45 credits**. Note that Nansen's
+published price list currently shows `pnl-by-market` at 1 credit; we are billed
+5, so budget from the table above rather than from their docs.
+
+**Which plan you need.** Nansen's free tier gives 100 starter credits plus 10
+per day, which covers roughly two full runs and is enough to try the skill. For
+regular use, Pro (2,000 credits per month) covers about 45 runs. Check your
+balance any time with `GET /api/v1/account`, which is free.
+
+Rank leaders for a market:
+
+```bash
+python3 nansen_skill_cli.py copytrader-overlay \
+    --market-id 12345 \
+    --leaders leaders.json \
+    --top-n 5
+```
+
+`leaders.json`:
+
+```json
+[
+  {"proxy_address": "0xabc...", "owner_address": "0xowner...", "wallet_score": 0.8}
+]
+```
+
+World Cup market variant (adds WC-specialist bonus to the secondary signal):
+
+```bash
+python3 nansen_skill_cli.py copytrader-overlay \
+    --market-id 12345 --leaders leaders.json --worldcup
+```
+
+Experimental live insider scan (always dry-run — see below):
+
+```bash
+python3 nansen_skill_cli.py insider-scan --market-id 12345 67890
+```
+
+Programmatic use (what `copytrading_strategy.py` would actually call):
+
+```python
+from nansen_copytrader_overlay_general import enrich_leaders
+
+enriched = enrich_leaders(
+    leaders=raw_leaders,           # [{proxy_address, owner_address, wallet_score}, ...]
+    market_id=target_market_id,    # the market Simmer is about to copytrade into
+    dry_run=not is_live,
+)
+target_wallets = [l["proxy_address"] for l in enriched[:top_n]]
+```
+
+## Proxy vs. owner wallets — must be explicit
+
+Nansen indexes Polymarket activity (`prediction-market/...`) by the
+**proxy** wallet (the contract Polymarket trades through), and profiler
+data (`profiler/...`) by the **owner** (signing/EOA) wallet.
+`address-summary` is a prediction-market endpoint, so it takes the
+**proxy** — passing the owner returns an all-zero row.
+
+`owner_address` is optional on input: it rides along on every
+`pnl-by-market` row and is read from there when omitted. That harvest
+covers only about **40% of the leaderboard** — 30 of 50 rows on the market
+used to verify this carried the placeholder `"0x"` rather than a real
+owner, which is treated as absent.
+
+| Field | Used for | Endpoints |
+|---|---|---|
+| `proxy_address` (or legacy `address`) | Polymarket-specific data | `pnl-by-market`, `pnl-by-address`, `trades-by-address`, `top-holders`, `address-summary` |
+| `owner_address` (optional) | General on-chain wallet quality | `historical-balances` |
+
+A leader missing `proxy_address` is tagged `MISSING_PROXY_ADDRESS` and
+skipped (kept at its original score, discounted). Missing `owner_address`
+is tagged `MISSING_OWNER_ADDRESS` for the record but does **not** gate the
+secondary signal — every call in that path is proxy-keyed.
+
+## Credit guards (hard, not advisory)
+
+Nansen bills per call against **your** key, so every enrichment run is
+protected by:
+
+- **`max_wallets`** (default 30): leaders beyond the cap are never
+  enriched — they keep their original score, tagged
+  `CREDIT_GUARD_MAX_WALLETS`.
+- **`CreditGuard(max_calls=...)`** (default 40): a hard ceiling on live
+  Nansen calls for the whole run, with a 5-minute TTL cache so re-fetching
+  the same market/wallet doesn't double-spend. If the budget runs out
+  mid-run, remaining leaders are tagged `CREDIT_GUARD_EXHAUSTED` and kept
+  at their original score — the run does not crash, and it does not keep
+  spending.
+- **No `profiler labels` wrapper exists**, so nothing here can call it
+  (100 credits for common labels, 500 for premium). The live insider scan's
+  known-entity discount uses a free local allowlist instead.
+- **`address_summary` as a pre-filter**: a wallet only gets the more
+  expensive `pnl_by_address` + `trades_by_address` pull if its cheap
+  `address_summary` win-rate/resolved-count check clears
+  `MIN_RESOLVED_MARKETS` first.
+
+Tune both via the CLI (`--max-wallets`, `--max-calls`) or by passing
+`max_wallets=` / `guard=CreditGuard(max_calls=...)` directly.
+
+## Live insider scan — experimental, dry-run only
+
+`nansen_live_insider_scan.py` / `insider-scan` is **not launchable for live
+trading**. `scan_live_markets(dry_run=False)` and `--live` both hard-refuse
+(`LiveTradingNotSupportedError`), because two things are unconfirmed
+against the live API:
+
+1. **Owner/proxy handling**: scanned wallets come from PM trade data (proxy
+   addresses), but `historical_balances` is a profiler/owner-indexed
+   endpoint — `wallet_age_days` may be silently wrong until there's an
+   owner mapping for scanned wallets.
+2. **`HIGH_NO_ENTRY` price semantics**: whether Nansen quotes NO-side
+   trades in YES terms or the NO token's own price changes whether this
+   flag means conviction or the opposite. Unconfirmed — see the module
+   docstring.
+
+Removing the guard requires a deliberate code change after both are
+verified — not a flag flip.
+
+## Tests
+
+```bash
+source .venv/bin/activate
+pytest tests/ -v
+```
+
+## Status
+
+This skill ships as **research tooling, not an allocation signal.** The
+scoring weights (the 50/50 blend, `MIN_RESOLVED_MARKETS`, the tag penalties)
+are reasoned defaults. They have not been fitted or backtested, and no
+forward test has shown that the re-ranking improves realised copytrading
+returns. Read `DISCLAIMER.md` before acting on the output.
+
+## Credits
+
+Built by **Alyna Takahashi** ([@alyna123t](https://github.com/alyna123t)),
+who wrote the adapter, both overlays and the insider scan. Code review by
+**Nick** ([@BridgeAISocial](https://github.com/BridgeAISocial)). Published and
+maintained by Simmer. Nansen provides the underlying Polymarket data.

--- a/skills/nansen-copytrader-overlay/clawhub.json
+++ b/skills/nansen-copytrader-overlay/clawhub.json
@@ -1,0 +1,36 @@
+{
+  "emoji": "🔍",
+  "sensitivity": "standard",
+  "published": false,
+  "publish_reason": "Research tooling. Scoring weights are unfitted and no forward-lift backtest has been run (SKILL.md 'Status'). Do not publish until lift is proven and the co-branding copy is signed off with Nansen.",
+  "primaryEnv": "NANSEN_API_KEY",
+  "requires": {
+    "env": [
+      "NANSEN_API_KEY"
+    ],
+    "pip": []
+  },
+  "envVars": [
+    {
+      "name": "NANSEN_API_KEY",
+      "required": true,
+      "description": "Your own Nansen API key, sent as the `apiKey` header. Sign up at https://nsn.ai/simmer for the Simmer partner discount. A full run costs about 45 credits; Nansen's free tier (100 starter credits + 10/day) covers roughly two runs."
+    },
+    {
+      "name": "NANSEN_USER_AGENT",
+      "required": false,
+      "description": "Override the browser User-Agent sent to Nansen. Cloudflare rejects the default python-urllib UA, so the skill sends a browser UA already. Only set this if that stops working."
+    },
+    {
+      "name": "NANSEN_API_BASE",
+      "required": false,
+      "description": "Override the Nansen API base URL. Defaults to https://api.nansen.ai/api/v1."
+    }
+  ],
+  "cron": null,
+  "autostart": false,
+  "automaton": {
+    "managed": false
+  },
+  "tunables": []
+}

--- a/skills/nansen-copytrader-overlay/nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/nansen_adapter.py
@@ -1,0 +1,772 @@
+"""
+Nansen API adapter for Simmer.
+
+Direct HTTPS client for the Nansen REST API.  All calls are read-only
+(research/prediction-market endpoints); no trading happens here.
+
+Responsibilities:
+- POST to https://api.nansen.ai/api/v1/... and normalise JSON responses
+- Retry transient failures (up to MAX_RETRIES) with exponential backoff
+- Rate-limit between calls (INTER_CALL_DELAY_S)
+- Surface a *specific* NansenError subclass per failure mode
+
+Design constraints:
+- No dependency on the local `nansen` CLI — this skill ships to users who
+  won't have that binary installed.  Auth is the NANSEN_API_KEY env var,
+  sent as the `apiKey` header (not `X-Api-Key`, not `Authorization: Bearer`).
+- Standard library only (urllib) so the skill installs with zero deps.
+- All endpoints are POST.  GET returns 405.
+- A browser-like User-Agent is required; Cloudflare blocks the default
+  python-urllib/curl UA.
+- All public functions return plain dicts/lists (no dataclasses) so callers
+  can serialise freely.
+
+Failure modes are distinct and must not be conflated (each maps to its own
+exception below) — observed against the live API:
+    401  NansenAuthError            missing/invalid apiKey
+    402  NansenPaymentRequiredError  x402 paywall — request had NO apiKey
+    403  NansenAccessDeniedError     request refused: plan/entitlement OR balance
+    404  NansenRouteError            wrong path
+    422  NansenRequestError          malformed body (e.g. missing `date`)
+    429/5xx                          transient — retried
+
+On 403 specifically: an access problem and a cost problem look identical
+from here, and this integration has been bitten in both directions. The
+API does not say which one it is, so neither does this module — check
+`GET /api/v1/account` (free) to tell them apart before concluding anything.
+"""
+
+import json
+import os
+import time
+import datetime
+import logging
+import urllib.request
+import urllib.error
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+INTER_CALL_DELAY_S = 1.5     # pause between wallet calls to avoid rate-limits
+HTTP_TIMEOUT_S = 60          # address-summary can take >30s on busy wallets
+
+NANSEN_API_BASE = os.environ.get(
+    "NANSEN_API_BASE", "https://api.nansen.ai/api/v1"
+).rstrip("/")
+
+# Cloudflare in front of api.nansen.ai rejects the default urllib UA.
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
+
+class NansenError(Exception):
+    """Base class for all Nansen API failures."""
+    pass
+
+
+class NansenAuthError(NansenError):
+    """401 — the apiKey header was missing, malformed, or rejected."""
+    pass
+
+
+class NansenPaymentRequiredError(NansenError):
+    """
+    402 — the x402 paywall answered instead of the API.
+
+    This means the request carried NO apiKey at all.  It is NOT a quota
+    problem: an authenticated request never sees a 402.  Treat it as an
+    auth/config bug, not as "the data is gated".
+    """
+    pass
+
+
+class NansenAccessDeniedError(NansenError):
+    """
+    403 — the API refused the call. Cause is ambiguous by design of the API.
+
+    Two very different things produce this and the response does not
+    distinguish them:
+      - entitlement: the account's plan doesn't include this endpoint
+      - balance:     the call costs more credits than the account has left
+
+    Do NOT read this as "credits exhausted" on its own. Observed while
+    porting this module: `profiler/address/labels` returned 403 on a
+    `plan: free` key with 27 credits remaining, while cheaper
+    prediction-market endpoints on the same key still returned 200. Since
+    label lookups run 100-500 credits, balance alone explains that — but a
+    plan exclusion would look exactly the same, and on a well-funded
+    account it could only be entitlement.
+
+    `GET /api/v1/account` returns {"plan", "credits_remaining"} and is free
+    and uncounted; call it before concluding which one you have.
+    """
+    pass
+
+
+# Back-compat alias. The old name asserted a cause the API never reports.
+NansenCreditsExhaustedError = NansenAccessDeniedError
+
+
+class NansenRouteError(NansenError):
+    """
+    404 — the path is wrong (not a data or permission issue).
+
+    Note this is only reliable *with* a valid key. Unauthenticated, the API
+    answers 401 for every path including nonexistent ones, so a bare request
+    cannot be used to test whether a route exists.
+    """
+    pass
+
+
+class NansenRequestError(NansenError):
+    """422 — the request body was malformed or missing a required field."""
+    pass
+
+
+class CreditGuardExceeded(NansenError):
+    """Raised when a CreditGuard's max_calls budget is exhausted mid-run."""
+    pass
+
+
+def _api_key() -> str:
+    """
+    Return the Nansen API key.
+
+    Reads NANSEN_API_KEY from the environment; falls back to a local .env
+    file so a bring-your-own-key checkout works without extra setup.
+    """
+    key = os.environ.get("NANSEN_API_KEY", "").strip()
+    if key:
+        return key
+
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    try:
+        with open(env_path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line.startswith("NANSEN_API_KEY="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Credit guard — hard cap on live Nansen calls per run, with a TTL cache so
+# repeated lookups (e.g. the same market_id across several leaders) don't
+# both count against the budget and re-spend credits.
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_CALLS_PER_RUN = 40
+DEFAULT_CACHE_TTL_S = 300.0  # 5 minutes
+
+
+class CreditGuard:
+    """
+    Tracks a hard call budget and a short-lived cache for one enrichment run.
+
+    Every module in this repo that calls into `nansen_adapter` should be
+    given a CreditGuard instance (or construct a default one) rather than
+    calling `_post` unbounded — credits, not rate limits, are the binding
+    constraint on this account (see README "Credits" section).
+    """
+
+    def __init__(self, max_calls: int = DEFAULT_MAX_CALLS_PER_RUN,
+                 cache_ttl_s: float = DEFAULT_CACHE_TTL_S):
+        self.max_calls = max_calls
+        self.cache_ttl_s = cache_ttl_s
+        self.calls_made = 0
+        self._cache: dict[tuple, tuple[float, Any]] = {}
+
+    def get_cached(self, key: tuple) -> Optional[Any]:
+        hit = self._cache.get(key)
+        if hit is None:
+            return None
+        ts, value = hit
+        if (time.time() - ts) >= self.cache_ttl_s:
+            return None
+        return value
+
+    def consume(self, key: tuple) -> None:
+        """Charge one call against the budget. Raises if the budget is spent."""
+        if self.calls_made >= self.max_calls:
+            raise CreditGuardExceeded(
+                f"credit guard tripped: max_calls={self.max_calls} exhausted "
+                f"(next call was: {key[:3]})"
+            )
+        self.calls_made += 1
+
+    def put_cache(self, key: tuple, value: Any) -> None:
+        self._cache[key] = (time.time(), value)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Status codes that are worth retrying — everything else is a hard failure
+# that retrying would only burn time (and, for 403, credits) on.
+_TRANSIENT_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+_STATUS_EXCEPTIONS = {
+    401: NansenAuthError,
+    402: NansenPaymentRequiredError,
+    403: NansenAccessDeniedError,
+    404: NansenRouteError,
+    422: NansenRequestError,
+}
+
+
+def _post(path: str, body: Optional[dict], retries: int = MAX_RETRIES,
+          guard: Optional[CreditGuard] = None, method: str = "POST") -> Any:
+    """
+    POST `body` to `NANSEN_API_BASE/path` and return parsed JSON.
+
+    If `guard` is given: a cache hit within `guard.cache_ttl_s` short-circuits
+    the call entirely (no credits spent, no budget consumed); otherwise the
+    call is charged against `guard.max_calls` before it runs, raising
+    CreditGuardExceeded if the budget is already spent.
+
+    Raises the NansenError subclass matching the HTTP status (see module
+    docstring). Transient statuses are retried with exponential backoff.
+    """
+    cache_key = (path, json.dumps(body, sort_keys=True))
+    if guard is not None:
+        cached = guard.get_cached(cache_key)
+        if cached is not None:
+            return cached
+        guard.consume(cache_key)
+
+    key = _api_key()
+    if not key:
+        # Fail loudly here rather than letting the request go out bare and
+        # come back as a confusing 402 x402 paywall response.
+        raise NansenAuthError(
+            "NANSEN_API_KEY is not set — set the env var (or add it to .env). "
+            "An unauthenticated request returns a 402 x402 paywall error, "
+            "which is an auth bug, not a quota problem."
+        )
+
+    url = f"{NANSEN_API_BASE}/{path.lstrip('/')}"
+    payload = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {
+        "apiKey": key,
+        "Content-Type": "application/json",
+        "User-Agent": os.environ.get("NANSEN_USER_AGENT", DEFAULT_USER_AGENT),
+        "Accept": "application/json",
+    }
+
+    last_err: Optional[Exception] = None
+
+    for attempt in range(retries):
+        if attempt > 0:
+            time.sleep(2 ** attempt)  # exponential backoff
+
+        req = urllib.request.Request(url, data=payload, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+                raw = resp.read().decode("utf-8")
+            parsed = json.loads(raw)
+            if guard is not None:
+                guard.put_cache(cache_key, parsed)
+            return parsed
+
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                detail = e.read().decode("utf-8", "replace")[:300]
+            except Exception:
+                pass
+
+            exc_cls = _STATUS_EXCEPTIONS.get(e.code)
+            if exc_cls is not None:
+                # Hard failure — retrying cannot change the outcome.
+                raise exc_cls(f"{e.code} on {path}: {detail}") from None
+
+            last_err = NansenError(f"HTTP {e.code} on {path}: {detail}")
+            if e.code not in _TRANSIENT_STATUSES:
+                raise last_err from None
+            logger.warning("nansen %s transient %d (attempt %d/%d)",
+                           path, e.code, attempt + 1, retries)
+
+        except urllib.error.URLError as e:
+            last_err = NansenError(f"network error calling {path}: {e.reason}")
+            logger.warning("nansen %s network error (attempt %d/%d): %s",
+                           path, attempt + 1, retries, e.reason)
+        except TimeoutError:
+            last_err = NansenError(f"nansen timed out after {HTTP_TIMEOUT_S}s: {path}")
+            logger.warning("nansen %s timeout (attempt %d/%d)", path, attempt + 1, retries)
+        except json.JSONDecodeError as e:
+            # Not transient — a 200 with non-JSON means something structural.
+            raise NansenError(f"nansen returned non-JSON from {path}: {e}") from None
+
+    raise last_err or NansenError(f"nansen call failed: {path}")
+
+
+def _rows(raw: Any) -> list[dict]:
+    """Unwrap the standard {"pagination": {...}, "data": [...]} envelope."""
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        data = raw.get("data")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return [data]
+    return []
+
+
+def _paginate(limit: int) -> dict:
+    return {"page": 1, "per_page": limit}
+
+
+def _order_by(field: str, direction: str = "DESC") -> list[dict]:
+    return [{"direction": direction, "field": field}]
+
+
+def _safe_float(v, default=0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Public API
+#
+# Endpoint paths and request bodies below are verified against the live API.
+# ---------------------------------------------------------------------------
+
+def account() -> dict:
+    """
+    Return {"plan": str, "credits_remaining": int} for the current key.
+
+    GET /account, and it is free — it does not spend credits and takes no
+    CreditGuard. Use it to tell an entitlement 403 from a balance 403
+    before assuming either (see NansenAccessDeniedError).
+    """
+    raw = _post("account", None, method="GET")
+    return raw if isinstance(raw, dict) else {}
+
+
+def pnl_by_market(market_id: str, limit: int = 50,
+                   guard: Optional[CreditGuard] = None) -> list[dict]:
+    """
+    Return PnL leaderboard for a single Polymarket market — who is actually
+    profitable IN THIS MARKET, ranked by realised + unrealised PnL.
+
+    This is the core copytrader signal: it is Polymarket-market-specific,
+    unlike pnl_by_address/trades_by_address which reflect a wallet's whole
+    trading history and may not say anything about this market.
+
+    Rows are keyed by the wallet's PROXY address, and each row also carries
+    `owner_address` for free — though that field is frequently the literal
+    placeholder "0x" (see `owner_address_from_row`).
+
+    Fields per entry:
+        address, owner_address, side_held, net_buy_cost_usd,
+        net_sell_proceeds_usd, redemption_value_usd, unrealized_value_usd,
+        total_pnl_usd, question, market_id, market_resolved
+    """
+    raw = _post("prediction-market/pnl-by-market", {
+        "market_id": str(market_id),
+        "order_by": _order_by("total_pnl_usd"),
+        "pagination": _paginate(limit),
+    }, guard=guard)
+    return [_normalise_pnl_row(r) for r in _rows(raw)]
+
+
+def pnl_by_address(address: str, limit: int = 30,
+                    guard: Optional[CreditGuard] = None) -> list[dict]:
+    """
+    Return per-market PnL breakdown for a wallet's PROXY address.
+
+    Secondary/general signal — broad wallet history, not market-specific.
+    Prefer pnl_by_market() as the primary copytrader ranking signal.
+
+    Fields per entry:
+        market_id, question, side_held, net_buy_cost_usd,
+        unrealized_value_usd, total_pnl_usd, market_resolved
+    """
+    raw = _post("prediction-market/pnl-by-address", {
+        "address": address,
+        "order_by": _order_by("total_pnl_usd"),
+        "pagination": _paginate(limit),
+    }, guard=guard)
+    return [_normalise_pnl_address_row(r) for r in _rows(raw)]
+
+
+def trades_by_address(address: str, limit: int = 100,
+                       guard: Optional[CreditGuard] = None) -> list[dict]:
+    """
+    Return trade history for a wallet's PROXY address.
+
+    Fields per entry:
+        timestamp, market_id, market_question, side, price,
+        size, usdc_value, taker_action, buyer, seller
+    """
+    raw = _post("prediction-market/trades-by-address", {
+        "address": address,
+        "order_by": _order_by("timestamp"),
+        "pagination": _paginate(limit),
+    }, guard=guard)
+    return [_normalise_trade_row(r) for r in _rows(raw)]
+
+
+def trades_by_market(market_id: str, limit: int = 50,
+                      guard: Optional[CreditGuard] = None) -> list[dict]:
+    """Return recent trades for a market."""
+    raw = _post("prediction-market/trades-by-market", {
+        "market_id": str(market_id),
+        "order_by": _order_by("timestamp"),
+        "pagination": _paginate(limit),
+    }, guard=guard)
+    return [_normalise_trade_row(r) for r in _rows(raw)]
+
+
+def historical_balances(address: str, chain: str = "polygon",
+                         days: int = 365, limit: int = 100,
+                         guard: Optional[CreditGuard] = None) -> list[dict]:
+    """
+    Return historical token balances for a wallet's OWNER (signing) address.
+
+    Profiler endpoints track general on-chain wallet activity, indexed by
+    the EOA that signs — not the Polymarket proxy contract. Pass the owner
+    address, not the proxy address (see README proxy/owner note).
+
+    `date` is a REQUIRED field on this endpoint; omitting it returns 422.
+
+    Fields: block_timestamp, value_usd, token_symbol
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    raw = _post("profiler/address/historical-balances", {
+        "address": address,
+        "chain": chain,
+        "date": {
+            "from": (now - datetime.timedelta(days=days)).strftime("%Y-%m-%d"),
+            "to": now.strftime("%Y-%m-%d"),
+        },
+        "pagination": _paginate(limit),
+    }, guard=guard)
+    return _rows(raw)
+
+
+def address_summary(address: str, chain: str = "polygon",
+                    guard: Optional[CreditGuard] = None) -> dict:
+    """
+    Return a one-call wallet summary using the Polymarket-specific endpoint.
+
+    Takes the wallet's PROXY address. This endpoint is Polymarket-indexed:
+    passing the OWNER (EOA) address returns a valid-looking row with every
+    metric zeroed, which silently fails any downstream history gate. Verified
+    on a live wallet: proxy -> 6375 markets_traded, owner -> 0.
+
+    Kept `chain` arg for backward compatibility; endpoint is address-only.
+
+    Fields: address, first_seen, wallet_age_days, realized_pnl_usd,
+        unrealized_pnl_usd, total_pnl_usd, markets_won, markets_traded,
+        win_rate, p2p_tokens_sent, p2p_tokens_received
+    """
+    raw = _post("prediction-market/address-summary", {
+        "address": address,
+    }, guard=guard)
+
+    rows = _rows(raw)
+    row = rows[0] if rows else {}
+    return _normalise_address_summary(row, address)
+
+
+# NOTE: there is deliberately no `profiler_labels` wrapper here.
+# This skill's framing is realised PnL only — it does not market on entity
+# or smart-money labels, and Nansen's labels aren't Polymarket-specific.
+# Shipping an unverified stub for an endpoint we've decided not to use is
+# worse than not shipping it. Cheap to add back if Nansen ever exposes
+# prediction-market labels.
+
+
+def top_holders(market_id: str, limit: int = 30,
+                 guard: Optional[CreditGuard] = None) -> list[dict]:
+    """
+    Return top position holders for a live market.
+
+    Fields: market_id, outcome_index, address, owner_address, side,
+        position_size, avg_entry_price, current_price, unrealized_pnl_usd
+    """
+    raw = _post("prediction-market/top-holders", {
+        "market_id": str(market_id),
+        "order_by": _order_by("position_size"),
+        "pagination": _paginate(limit),
+    }, guard=guard)
+    return _rows(raw)
+
+
+def market_screener(sort_by: str = "volume_24hr", limit: int = 20,
+                    status: str = "active", query: Optional[str] = None,
+                    guard: Optional[CreditGuard] = None) -> list[dict]:
+    """
+    Return markets from the Polymarket screener.
+
+    Fields include: market_id, question, slug, event_id, event_title,
+        active, closed, end_date, tags, volume, volume_24hr, liquidity,
+        open_interest, best_bid, best_ask
+    """
+    body: dict[str, Any] = {
+        "order_by": _order_by(sort_by),
+        "status": status,
+        "pagination": _paginate(limit),
+    }
+    if query:
+        body["query"] = query
+    raw = _post("prediction-market/market-screener", body, guard=guard)
+    return _rows(raw)
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+def _normalise_pnl_row(r: dict) -> dict:
+    return {
+        "address": r.get("address") or r.get("proxy_wallet") or "",
+        "owner_address": _clean_owner(r.get("owner_address") or r.get("ownerAddress")),
+        "side_held": (r.get("side_held") or r.get("sideHeld") or "").lower(),
+        "net_buy_cost_usd": _safe_float(r.get("net_buy_cost_usd") or r.get("netBuyCostUsd")),
+        "unrealized_value_usd": _safe_float(r.get("unrealized_value_usd") or r.get("unrealizedValueUsd")),
+        "total_pnl_usd": _safe_float(r.get("total_pnl_usd") or r.get("totalPnlUsd")),
+        "market_resolved": bool(r.get("market_resolved") or r.get("marketResolved")),
+        "question": r.get("question") or "",
+        "market_id": str(r.get("market_id") or r.get("marketId") or ""),
+    }
+
+
+def _normalise_pnl_address_row(r: dict) -> dict:
+    return {
+        "market_id": str(r.get("market_id") or r.get("marketId") or ""),
+        "question": r.get("question") or r.get("market_question") or "",
+        "side_held": (r.get("side_held") or r.get("sideHeld") or "").lower(),
+        "net_buy_cost_usd": _safe_float(r.get("net_buy_cost_usd") or r.get("netBuyCostUsd")),
+        "unrealized_value_usd": _safe_float(r.get("unrealized_value_usd") or r.get("unrealizedValueUsd")),
+        "total_pnl_usd": _safe_float(r.get("total_pnl_usd") or r.get("totalPnlUsd")),
+        "market_resolved": bool(r.get("market_resolved") or r.get("marketResolved")),
+    }
+
+
+def _normalise_address_summary(r: dict, fallback_address: str) -> dict:
+    """
+    Normalise a prediction-market/address-summary row.
+
+    Written against the verified live shape (see
+    artifacts/nansen/address_summary_raw.json). This endpoint reports
+    `markets_traded` / `markets_won`, NOT `resolved_count` / `avg_roi` —
+    `resolved_count` is kept as an alias of markets_traded for callers that
+    gate on history depth, and `avg_roi` is not offered by this endpoint at
+    all (compute it from pnl_by_address instead).
+    """
+    r = r or {}
+    win_rate = r.get("win_rate")
+    markets_traded = int(_safe_float(r.get("markets_traded"), 0))
+    return {
+        "address": r.get("address") or fallback_address,
+        "win_rate": _safe_float(win_rate, None) if win_rate is not None else None,
+        "avg_roi": None,  # not exposed by this endpoint
+        "markets_traded": markets_traded,
+        "markets_won": int(_safe_float(r.get("markets_won"), 0)),
+        "resolved_count": markets_traded,  # back-compat alias for history gates
+        "wallet_age_days": _safe_float(r.get("wallet_age_days"), None)
+                           if r.get("wallet_age_days") is not None else None,
+        "first_seen": r.get("first_seen") or "",
+        "realized_pnl_usd": _safe_float(r.get("realized_pnl_usd")),
+        "unrealized_pnl_usd": _safe_float(r.get("unrealized_pnl_usd")),
+        "total_pnl_usd": _safe_float(r.get("total_pnl_usd") or r.get("totalPnlUsd")),
+        "p2p_tokens_sent": _safe_float(r.get("p2p_tokens_sent")),
+        "p2p_tokens_received": _safe_float(r.get("p2p_tokens_received")),
+    }
+
+
+def _normalise_trade_row(r: dict) -> dict:
+    return {
+        "timestamp": r.get("timestamp") or r.get("block_timestamp") or "",
+        "market_id": str(r.get("market_id") or r.get("marketId") or ""),
+        "market_question": r.get("market_question") or r.get("question") or "",
+        "side": (r.get("side") or "").lower(),
+        "price": _safe_float(r.get("price")),
+        "size": _safe_float(r.get("size")),
+        "usdc_value": _safe_float(r.get("usdc_value") or r.get("usdcValue")),
+        "taker_action": (r.get("taker_action") or r.get("takerAction") or "").lower(),
+        "buyer": r.get("buyer") or "",
+        "seller": r.get("seller") or "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Proxy vs owner wallet routing
+# ---------------------------------------------------------------------------
+# Nansen indexes Polymarket (`prediction-market/...`) activity by the PROXY
+# wallet — the contract wallet Polymarket trades through. Profiler endpoints
+# (`profiler/...`) track general on-chain activity and are indexed by the
+# OWNER (signing/EOA) wallet instead.
+#
+# address_summary is a prediction-market endpoint and therefore takes the
+# PROXY address, despite summarising "the wallet".
+
+# Placeholder values the API returns when it has no owner mapping. "0x" is
+# by far the most common (30 of 50 rows on a live market) — passing it to a
+# profiler endpoint would query a nonexistent wallet and silently return
+# empty history, so it must be treated as absent.
+_NULL_ADDRESSES = frozenset({
+    "",
+    "0x",
+    "0x0",
+    "0x0000000000000000000000000000000000000000",
+})
+
+
+def _clean_owner(value: Optional[str]) -> str:
+    """Return a usable owner address, or "" for API placeholders like "0x"."""
+    v = (value or "").strip()
+    return "" if v.lower() in _NULL_ADDRESSES else v
+
+
+def get_proxy_address(leader: dict) -> str:
+    """Address to use for `prediction-market/...` calls (pnl-by-market,
+    pnl-by-address, trades-by-address, trades-by-market, top-holders,
+    address-summary)."""
+    return leader.get("proxy_address") or leader.get("address") or ""
+
+
+def get_owner_address(leader: dict, row: Optional[dict] = None) -> str:
+    """
+    Address to use for `profiler/...` calls (historical-balances).
+
+    Prefers an explicit `owner_address` on the leader dict, then falls back to
+    the `owner_address` carried on an already-fetched pnl_by_market /
+    top_holders `row` — that field comes back for free on every leaderboard
+    row, so callers needn't supply it separately.
+
+    Never falls back to `address`/`proxy_address`: profiler data keyed by the
+    wrong wallet type silently returns someone else's (or nobody's) history.
+    Placeholder values such as "0x" are treated as absent for the same reason.
+    """
+    owner = _clean_owner(leader.get("owner_address"))
+    if owner:
+        return owner
+    if row:
+        return _clean_owner(row.get("owner_address"))
+    return ""
+
+
+def owner_address_from_row(row: Optional[dict]) -> str:
+    """
+    Extract a usable owner address from a leaderboard row, or "".
+
+    Note: roughly 60% of live pnl_by_market rows carry the placeholder "0x"
+    rather than a real owner, so callers must handle "" as a normal outcome
+    and skip profiler enrichment for those wallets rather than erroring.
+    """
+    return _clean_owner((row or {}).get("owner_address"))
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers (shared across overlay modules)
+# ---------------------------------------------------------------------------
+
+def compute_roi(net_buy_cost_usd: float, total_pnl_usd: float) -> Optional[float]:
+    """ROI as a fraction (1.0 = 100%). None if cost <= 0."""
+    if net_buy_cost_usd <= 0:
+        return None
+    return total_pnl_usd / net_buy_cost_usd
+
+
+def wallet_age_days(balances: list[dict]) -> Optional[float]:
+    """
+    Days since first non-zero balance record, or None if unknown.
+    Expects records sorted by block_timestamp ascending.
+    """
+    for row in balances:
+        v = _safe_float(row.get("value_usd"), -1)
+        if v > 0:
+            ts = row.get("block_timestamp")
+            if not ts:
+                continue
+            try:
+                dt = datetime.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+                now = datetime.datetime.now(datetime.timezone.utc)
+                return (now - dt).total_seconds() / 86400
+            except (ValueError, TypeError):
+                continue
+    return None
+
+
+def pnl_quality_score(
+    pnl_rows: list[dict],
+    min_resolved: int = 3,
+) -> dict:
+    """
+    Compute PnL quality features from per-market PnL history.
+
+    Returns:
+        win_rate:       fraction of resolved profitable markets
+        avg_roi:        mean ROI across resolved markets (None if < min_resolved)
+        consistency:    1 - (std(roi) / (mean(roi) + 1e-9)) clamped [0, 1]
+        concentration:  largest single-market PnL / total_pnl (1.0 = one-market wonder)
+        recency_days:   days since most recent resolved market
+        resolved_count: number of resolved markets in history
+    """
+    import math
+
+    resolved = [r for r in pnl_rows if r.get("market_resolved")]
+    if not resolved:
+        return {
+            "win_rate": None,
+            "avg_roi": None,
+            "consistency": None,
+            "concentration": None,
+            "recency_days": None,
+            "resolved_count": 0,
+        }
+
+    rois = []
+    for r in resolved:
+        roi = compute_roi(r["net_buy_cost_usd"], r["total_pnl_usd"])
+        if roi is not None:
+            rois.append(roi)
+
+    wins = sum(1 for r in resolved if r["total_pnl_usd"] > 0)
+    win_rate = wins / len(resolved)
+
+    avg_roi = None
+    consistency = None
+    if len(rois) >= min_resolved:
+        avg_roi = sum(rois) / len(rois)
+        if len(rois) >= 2:
+            variance = sum((x - avg_roi) ** 2 for x in rois) / len(rois)
+            std_roi = math.sqrt(variance)
+            consistency = max(0.0, 1.0 - std_roi / (abs(avg_roi) + 1e-9))
+            consistency = min(1.0, consistency)
+        else:
+            consistency = 1.0
+
+    total_pnl = sum(r["total_pnl_usd"] for r in resolved)
+    if total_pnl != 0:
+        max_market_pnl = max(abs(r["total_pnl_usd"]) for r in resolved)
+        concentration = max_market_pnl / (abs(total_pnl) + 1e-9)
+        concentration = min(1.0, concentration)
+    else:
+        concentration = None
+
+    # Recency: find most recent resolved market (we don't have resolution timestamps
+    # in pnl_by_address, so we use position in the list as a proxy — Nansen returns
+    # most recent first by default)
+    recency_days = None  # Would need timestamp field; left as None here
+
+    return {
+        "win_rate": win_rate,
+        "avg_roi": avg_roi,
+        "consistency": consistency,
+        "concentration": concentration,
+        "recency_days": recency_days,
+        "resolved_count": len(resolved),
+    }

--- a/skills/nansen-copytrader-overlay/nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/nansen_adapter.py
@@ -176,6 +176,15 @@ class CreditGuard:
 
     def __init__(self, max_calls: int = DEFAULT_MAX_CALLS_PER_RUN,
                  cache_ttl_s: float = DEFAULT_CACHE_TTL_S):
+        # A nonpositive budget is never what a caller means. It makes the very
+        # first request raise CreditGuardExceeded, which surfaces as a traceback
+        # rather than the tagged CREDIT_GUARD_EXHAUSTED recovery path the
+        # overlays implement. Fail here, where the number came from.
+        if max_calls < 1:
+            raise ValueError(
+                f"max_calls must be >= 1, got {max_calls}. A budget below 1 "
+                "trips the guard on the first call."
+            )
         self.max_calls = max_calls
         self.cache_ttl_s = cache_ttl_s
         self.calls_made = 0

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
@@ -480,12 +480,23 @@ def enrich_leaders(
     if not leaders:
         return []
 
+    # max_wallets is a credit cap, so a nonpositive value must be rejected
+    # rather than quietly widened: 0 is falsy and would skip the cap branch
+    # entirely (enriching every leader), and a negative value becomes a
+    # slice bound (-1 enriches all but the last). Both spend MORE of the
+    # caller's credits than the number they passed.
+    if max_wallets < 1:
+        raise ValueError(
+            f"max_wallets must be >= 1, got {max_wallets}. It is a hard credit "
+            "cap; 0 and negative values would enrich more wallets, not fewer."
+        )
+
     if guard is None:
         guard = CreditGuard()
 
     to_enrich = leaders
     skipped: list[dict] = []
-    if max_wallets and len(leaders) > max_wallets:
+    if len(leaders) > max_wallets:
         ranked = sorted(leaders, key=lambda l: float(l.get(base_score_key) or 0.0), reverse=True)
         to_enrich, skipped = ranked[:max_wallets], ranked[max_wallets:]
         logger.warning(

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
@@ -1,0 +1,614 @@
+"""
+Module 1: nansen-copytrader-overlay-general
+============================================
+Enriches a leader ranking (from Simmer's copytrading system) with Nansen
+PnL quality features and returns an adjusted ranking with reason codes.
+
+Core signal — pnl-by-market first:
+    The primary signal is `pnl_by_market(market_id)`: who is actually
+    profitable IN THE TARGET MARKET, fetched once per call and matched
+    against each leader's proxy wallet. This is the Polymarket-specific
+    edge Nansen has. Broad wallet history (`pnl_by_address` /
+    `trades_by_address`) is a SECONDARY signal, pulled only for wallets
+    that already clear a cheap `address_summary` pre-filter, and only to
+    refine — never to replace — the market-specific score.
+
+    Nansen is a data layer here: PM PnL quality + address-summary wallet
+    quality. It is not a smart-money label — Nansen's smart-money labels
+    are not Polymarket-specific and this module never calls them.
+
+Integration point:
+    Called BEFORE Simmer executes copytrading rebalances.  The caller
+    (e.g. copytrading_strategy.py) passes the market being copytraded and
+    a list of leader dicts and gets back the same list re-ranked by
+    `adjusted_score`.
+
+Usage:
+    from nansen_copytrader_overlay_general import enrich_leaders
+
+    enriched = enrich_leaders(
+        market_id="12345",           # the market you're about to copytrade into
+        leaders=[
+            {"proxy_address": "0xabc...", "owner_address": "0xowner...",
+             "wallet_score": 0.8},
+        ],
+        dry_run=True,         # always True unless --live was passed
+        top_n=5,
+    )
+    # enriched[i] has all original keys plus:
+    #   nansen_features, reason_tags, adjusted_score, adjusted_rank
+
+Proxy vs owner wallets:
+    Nansen indexes Polymarket activity (pnl-by-market, pnl-by-address,
+    trades-by-address) by the PROXY wallet, and profiler data
+    (address-summary) by the OWNER (signing) wallet. Leader dicts must
+    carry both `proxy_address` and `owner_address` explicitly — there is
+    no resolution step here. `address` is accepted as a legacy alias for
+    `proxy_address` only.
+
+Credit guards:
+    Every call goes through a CreditGuard (see nansen_adapter.py): a hard
+    max_calls budget plus a short TTL cache so re-enriching the same
+    market/wallet within a run doesn't re-spend credits. `max_wallets`
+    caps how many leaders get enriched at all — the rest keep their
+    original score, tagged CREDIT_GUARD_MAX_WALLETS. If the call budget
+    is exhausted mid-run, remaining leaders keep their original score too
+    (tagged CREDIT_GUARD_EXHAUSTED) instead of the run crashing.
+
+Dry-run default:
+    When dry_run=True (the default) no trades are emitted — just the
+    enriched ranking is returned.  The --live gate in the caller controls
+    whether Simmer acts on the output.
+"""
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from nansen_adapter import (
+    pnl_by_market,
+    pnl_by_address,
+    trades_by_address,
+    address_summary,
+    pnl_quality_score,
+    compute_roi,
+    get_proxy_address,
+    get_owner_address,
+    NansenError,
+    CreditGuard,
+    CreditGuardExceeded,
+    INTER_CALL_DELAY_S,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Scoring weights
+# ---------------------------------------------------------------------------
+
+# Overall quality blend: market-specific PnL (primary) vs. general wallet
+# history (secondary refinement only). Weights sum to 1.0.
+MARKET_SIGNAL_WEIGHT = 0.65
+GENERAL_SIGNAL_WEIGHT = 0.35
+
+# General (secondary) quality sub-weights — unchanged from the pre-market-first
+# design, just demoted to a refinement signal.
+WEIGHT_WIN_RATE = 0.30
+WEIGHT_AVG_ROI = 0.25
+WEIGHT_CONSISTENCY = 0.20
+WEIGHT_CONCENTRATION_PENALTY = 0.15   # high concentration = penalty
+WEIGHT_VOLUME = 0.10                   # total resolved markets = experience proxy
+
+MIN_RESOLVED_MARKETS = 3  # minimum resolved markets to score general quality
+MAX_CONCENTRATION = 0.70  # concentration above this gets max penalty
+
+# Applied instead of the 50/50 blend when there's no usable Nansen signal at
+# all (missing proxy address, wallet absent from this market's leaderboard,
+# or the market fetch itself failed) — in each case we don't have a real
+# signal to blend, so the leader's original score should barely move rather
+# than take a ~50% haircut.
+NO_ADJUSTMENT_DISCOUNT = 0.9
+
+DEFAULT_MAX_WALLETS = 30       # hard cap on leaders enriched per call
+DEFAULT_MARKET_LEADERBOARD_LIMIT = 100
+
+
+@dataclass
+class LeaderEnrichment:
+    """Nansen-derived features and reason tags for a single leader wallet."""
+    address: str
+
+    # Market-specific (primary) features
+    market_score: Optional[float] = None
+    market_total_pnl_usd: Optional[float] = None
+    market_roi: Optional[float] = None
+
+    # General/secondary quality features
+    win_rate: Optional[float] = None
+    avg_roi: Optional[float] = None
+    consistency: Optional[float] = None
+    concentration: Optional[float] = None
+    resolved_count: int = 0
+    distinct_markets_traded: int = 0
+
+    # Derived
+    quality_score: float = 0.0    # 0–1 composite (market + general blend)
+    has_signal: bool = False      # True once a real Nansen score (market or
+                                   # legacy general) was computed for this wallet
+    reason_tags: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def _compute_quality_score(features: dict, distinct_markets: int) -> tuple[float, list[str]]:
+    """
+    Compute a 0–1 GENERAL (secondary) quality score from broad wallet-history
+    Nansen features. This is the same scoring rubric used before market-first
+    became the primary signal — now only a refinement on top of market_score.
+
+    Returns (score, reason_tags).
+    """
+    tags: list[str] = []
+    score = 0.0
+    available_weight = 0.0
+
+    win_rate = features.get("win_rate")
+    avg_roi = features.get("avg_roi")
+    consistency = features.get("consistency")
+    concentration = features.get("concentration")
+    resolved_count = features.get("resolved_count", 0)
+
+    if resolved_count < MIN_RESOLVED_MARKETS:
+        tags.append(f"INSUFFICIENT_HISTORY:{resolved_count}_resolved")
+        return 0.0, tags
+
+    # Win rate component
+    if win_rate is not None:
+        score += WEIGHT_WIN_RATE * win_rate
+        available_weight += WEIGHT_WIN_RATE
+        if win_rate >= 0.70:
+            tags.append("HIGH_WIN_RATE")
+        elif win_rate < 0.40:
+            tags.append("LOW_WIN_RATE")
+
+    # ROI component (cap at 2x = 200%, normalise to 0-1; 150% avg ROI is already excellent)
+    if avg_roi is not None:
+        roi_norm = min(1.0, max(0.0, avg_roi / 2.0))
+        score += WEIGHT_AVG_ROI * roi_norm
+        available_weight += WEIGHT_AVG_ROI
+        if avg_roi >= 1.0:
+            tags.append("STRONG_ROI")
+        elif avg_roi < 0:
+            tags.append("NEGATIVE_AVG_ROI")
+
+    # Consistency component
+    if consistency is not None:
+        score += WEIGHT_CONSISTENCY * consistency
+        available_weight += WEIGHT_CONSISTENCY
+        if consistency >= 0.70:
+            tags.append("CONSISTENT_PNL")
+        elif consistency < 0.30:
+            tags.append("ERRATIC_PNL")
+
+    # Concentration penalty
+    if concentration is not None:
+        penalty = min(1.0, concentration / MAX_CONCENTRATION)
+        score -= WEIGHT_CONCENTRATION_PENALTY * penalty
+        available_weight += WEIGHT_CONCENTRATION_PENALTY
+        if concentration >= MAX_CONCENTRATION:
+            tags.append("HIGH_CONCENTRATION_RISK")
+
+    # Volume / experience component (normalise to 0-1, cap at 50 markets)
+    if resolved_count > 0:
+        vol_norm = min(1.0, resolved_count / 50.0)
+        score += WEIGHT_VOLUME * vol_norm
+        available_weight += WEIGHT_VOLUME
+        if resolved_count >= 20:
+            tags.append("EXPERIENCED_TRADER")
+        elif resolved_count < 5:
+            tags.append("LIMITED_HISTORY")
+
+    # Normalise by available weight to handle missing features
+    if available_weight > 0:
+        score = score / available_weight * (WEIGHT_WIN_RATE + WEIGHT_AVG_ROI +
+                                             WEIGHT_CONSISTENCY + WEIGHT_CONCENTRATION_PENALTY +
+                                             WEIGHT_VOLUME)
+
+    # Clamp
+    score = max(0.0, min(1.0, score))
+
+    if distinct_markets < 3:
+        tags.append("NARROW_FOCUS")
+
+    return round(score, 4), tags
+
+
+def _compute_market_score(row: dict, rank: Optional[int], leaderboard_size: int) -> tuple[float, list[str]]:
+    """
+    Compute a 0–1 score from this wallet's pnl_by_market row for the target
+    market — the PRIMARY copytrader signal.
+
+    Returns (score, reason_tags).
+    """
+    tags: list[str] = []
+    total_pnl = row.get("total_pnl_usd", 0.0)
+    roi = compute_roi(row.get("net_buy_cost_usd", 0.0), total_pnl)
+
+    tags.append("MARKET_PROFITABLE" if total_pnl > 0 else "MARKET_UNPROFITABLE")
+
+    if roi is not None:
+        score = min(1.0, max(0.0, roi / 2.0))
+    else:
+        # No cost basis to compute ROI (e.g. a fully airdropped/gifted
+        # position) — fall back to a coarse profit/loss signal.
+        score = 0.6 if total_pnl > 0 else 0.0
+
+    if rank is not None and leaderboard_size > 0:
+        if (rank + 1) / leaderboard_size <= 0.2:
+            tags.append("MARKET_TOP_PNL")
+            score = min(1.0, score + 0.15)
+
+    return round(score, 4), tags
+
+
+# ---------------------------------------------------------------------------
+# Market leaderboard fetch (shared with the World Cup overlay variant)
+# ---------------------------------------------------------------------------
+
+def fetch_market_leaderboard(
+    market_id: str,
+    guard: CreditGuard,
+    limit: int = DEFAULT_MARKET_LEADERBOARD_LIMIT,
+) -> tuple[Optional[dict], int]:
+    """
+    Fetch the pnl_by_market leaderboard for `market_id` and index it by
+    lowercased address AND owner_address for lookup.
+
+    Returns (leaderboard_or_None, size). leaderboard is None if the fetch
+    failed outright (market-specific ranking unavailable this run) —
+    CreditGuardExceeded is NOT swallowed here, it propagates so the caller
+    can stop the run rather than silently proceed with no signal at all.
+    """
+    try:
+        rows = pnl_by_market(market_id, limit=limit, guard=guard)
+    except CreditGuardExceeded:
+        raise
+    except NansenError as e:
+        logger.error(
+            "pnl_by_market fetch failed for market %s: %s — market-specific "
+            "ranking unavailable this run, leaders keep their original score",
+            market_id, e,
+        )
+        return None, 0
+
+    leaderboard: dict[str, tuple[int, dict]] = {}
+    for i, row in enumerate(rows):
+        for key in (row.get("address"), row.get("owner_address")):
+            if key:
+                leaderboard.setdefault(key.lower(), (i, row))
+    return leaderboard, len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Per-leader enrichment
+# ---------------------------------------------------------------------------
+
+def enrich_leader_for_market(
+    leader: dict,
+    leaderboard: Optional[dict],
+    leaderboard_size: int,
+    guard: CreditGuard,
+) -> LeaderEnrichment:
+    """
+    Enrich a single leader against an already-fetched market leaderboard.
+
+    market_score (primary) comes from the leaderboard lookup — no extra
+    API call. The general/secondary quality pull only happens for wallets
+    that are IN the leaderboard, gated by a cheap address_summary check
+    first (so a wallet with no meaningful history doesn't cost a full
+    pnl_by_address + trades_by_address pull).
+    """
+    proxy = get_proxy_address(leader)
+    enrichment = LeaderEnrichment(address=proxy or leader.get("wallet_address", ""))
+
+    if not proxy:
+        enrichment.error = "MISSING_PROXY_ADDRESS"
+        enrichment.reason_tags = ["MISSING_PROXY_ADDRESS"]
+        return enrichment
+
+    if leaderboard is None:
+        enrichment.reason_tags = ["MARKET_FETCH_ERROR"]
+        return enrichment
+
+    entry = leaderboard.get(proxy.lower())
+    if entry is None:
+        enrichment.reason_tags = ["NOT_IN_MARKET_LEADERBOARD"]
+        return enrichment
+
+    rank, row = entry
+    # owner_address rides along on every leaderboard row, so callers don't
+    # have to supply it; it is still often the "0x" placeholder, in which
+    # case this resolves to "" and profiler-keyed enrichment is skipped.
+    owner = get_owner_address(leader, row)
+    market_score, market_tags = _compute_market_score(row, rank, leaderboard_size)
+    enrichment.market_score = market_score
+    enrichment.market_total_pnl_usd = row.get("total_pnl_usd")
+    enrichment.market_roi = compute_roi(row.get("net_buy_cost_usd", 0.0), row.get("total_pnl_usd", 0.0))
+    enrichment.reason_tags = list(market_tags)
+    enrichment.has_signal = True
+
+    general_score: Optional[float] = None
+    # Every call in this block is a prediction-market endpoint, so all three
+    # take the PROXY address. `owner` is only needed by profiler endpoints,
+    # which this overlay doesn't call — so a missing owner is recorded but
+    # must not gate the secondary layer.
+    if not owner:
+        enrichment.reason_tags.append("MISSING_OWNER_ADDRESS")
+
+    try:
+        summary = address_summary(proxy, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+
+        if summary["resolved_count"] < MIN_RESOLVED_MARKETS:
+            enrichment.reason_tags.append(
+                f"INSUFFICIENT_HISTORY:{summary['resolved_count']}_resolved"
+            )
+        else:
+            pnl_rows = pnl_by_address(proxy, limit=50, guard=guard)
+            time.sleep(INTER_CALL_DELAY_S)
+            trade_rows = trades_by_address(proxy, limit=100, guard=guard)
+            time.sleep(INTER_CALL_DELAY_S)
+
+            features = pnl_quality_score(pnl_rows, min_resolved=MIN_RESOLVED_MARKETS)
+            distinct_markets = len({t["market_id"] for t in trade_rows if t["market_id"]})
+            general_score, general_tags = _compute_quality_score(features, distinct_markets)
+
+            enrichment.win_rate = features["win_rate"]
+            enrichment.avg_roi = features["avg_roi"]
+            enrichment.consistency = features["consistency"]
+            enrichment.concentration = features["concentration"]
+            enrichment.resolved_count = features["resolved_count"]
+            enrichment.distinct_markets_traded = distinct_markets
+            enrichment.reason_tags.extend(general_tags)
+    except CreditGuardExceeded:
+        raise
+    except NansenError as e:
+        logger.warning("General enrichment fetch failed for %s: %s", proxy[:10], e)
+        enrichment.reason_tags.append("NANSEN_FETCH_ERROR")
+
+    if general_score is None:
+        enrichment.quality_score = market_score
+    else:
+        enrichment.quality_score = round(
+            MARKET_SIGNAL_WEIGHT * market_score + GENERAL_SIGNAL_WEIGHT * general_score, 4
+        )
+
+    return enrichment
+
+
+def _has_usable_signal(enrichment: LeaderEnrichment) -> bool:
+    return enrichment.error is None and enrichment.has_signal
+
+
+def _blend_and_rank(
+    enriched_pairs: list[tuple[dict, LeaderEnrichment]],
+    dry_run: bool,
+    top_n: Optional[int],
+    base_score_key: str,
+    extra_features: Optional[dict] = None,
+) -> list[dict]:
+    output = []
+    for leader, enrichment in enriched_pairs:
+        base = float(leader.get(base_score_key) or 0.0)
+
+        if _has_usable_signal(enrichment):
+            adjusted = 0.5 * base + 0.5 * enrichment.quality_score
+        else:
+            adjusted = base * NO_ADJUSTMENT_DISCOUNT
+
+        output.append({
+            **leader,
+            "nansen_features": {
+                "market_score": enrichment.market_score,
+                "market_total_pnl_usd": enrichment.market_total_pnl_usd,
+                "market_roi": enrichment.market_roi,
+                "win_rate": enrichment.win_rate,
+                "avg_roi": enrichment.avg_roi,
+                "consistency": enrichment.consistency,
+                "concentration": enrichment.concentration,
+                "resolved_count": enrichment.resolved_count,
+                "distinct_markets_traded": enrichment.distinct_markets_traded,
+                "quality_score": enrichment.quality_score,
+                "error": enrichment.error,
+                **(extra_features.get(enrichment.address, {}) if extra_features else {}),
+            },
+            "reason_tags": enrichment.reason_tags,
+            "adjusted_score": round(adjusted, 4),
+            "dry_run": dry_run,
+        })
+
+    output.sort(key=lambda x: x["adjusted_score"], reverse=True)
+    for i, item in enumerate(output):
+        item["adjusted_rank"] = i + 1
+
+    if top_n:
+        output = output[:top_n]
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def enrich_leaders(
+    leaders: list[dict],
+    market_id: Optional[str] = None,
+    dry_run: bool = True,
+    top_n: Optional[int] = None,
+    base_score_key: str = "wallet_score",
+    max_wallets: int = DEFAULT_MAX_WALLETS,
+    guard: Optional[CreditGuard] = None,
+) -> list[dict]:
+    """
+    Enrich a list of leader dicts with Nansen PnL quality features.
+
+    Args:
+        leaders:         list of dicts with at least {"proxy_address": ...,
+                         "owner_address": ..., base_score_key: float}
+        market_id:       the Polymarket market being copytraded. When given,
+                         pnl_by_market(market_id) is the PRIMARY signal
+                         (recommended — this is the market-specific edge).
+                         When omitted, falls back to broad wallet-history
+                         ranking only, with a warning.
+        dry_run:         if True (default) no trades are emitted — just return ranking
+        top_n:           if set, return only top N after adjustment
+        base_score_key:  key in leader dict for the original score (default "wallet_score")
+        max_wallets:     hard cap on leaders enriched this call (credit guard).
+                         Leaders beyond the cap keep their original score.
+        guard:           shared CreditGuard; a fresh one (default budget) is
+                         created if not supplied.
+
+    Returns:
+        list of leader dicts, each extended with:
+            nansen_features: dict  — raw Nansen quality features
+            reason_tags:     list  — human-readable reason codes
+            adjusted_score:  float — blended score (original 0.5 + nansen 0.5)
+            adjusted_rank:   int   — 1-based rank after adjustment
+            dry_run:         bool  — echoes the dry_run flag
+    """
+    if not leaders:
+        return []
+
+    if guard is None:
+        guard = CreditGuard()
+
+    to_enrich = leaders
+    skipped: list[dict] = []
+    if max_wallets and len(leaders) > max_wallets:
+        ranked = sorted(leaders, key=lambda l: float(l.get(base_score_key) or 0.0), reverse=True)
+        to_enrich, skipped = ranked[:max_wallets], ranked[max_wallets:]
+        logger.warning(
+            "%d leaders exceed max_wallets=%d — enriching the top %d by %s, "
+            "keeping the remaining %d at their original score (CREDIT_GUARD_MAX_WALLETS)",
+            len(leaders), max_wallets, max_wallets, base_score_key, len(skipped),
+        )
+
+    if market_id is None:
+        logger.warning(
+            "enrich_leaders() called without market_id — falling back to broad "
+            "wallet-history ranking (pnl-by-address/trades-by-address), which "
+            "is NOT Polymarket-market-specific. Pass market_id to use "
+            "pnl-by-market, the primary copytrader signal (see README)."
+        )
+        enriched_pairs = _enrich_pairs_legacy(to_enrich, guard)
+    else:
+        enriched_pairs = _enrich_pairs_for_market(to_enrich, market_id, guard)
+
+    for leader in skipped:
+        enriched_pairs.append((leader, LeaderEnrichment(
+            address=get_proxy_address(leader) or leader.get("wallet_address", ""),
+            reason_tags=["CREDIT_GUARD_MAX_WALLETS"],
+        )))
+
+    return _blend_and_rank(enriched_pairs, dry_run, top_n, base_score_key)
+
+
+def _enrich_pairs_for_market(
+    leaders: list[dict], market_id: str, guard: CreditGuard,
+) -> list[tuple[dict, LeaderEnrichment]]:
+    leaderboard, leaderboard_size = fetch_market_leaderboard(market_id, guard)
+
+    enriched_pairs: list[tuple[dict, LeaderEnrichment]] = []
+    guard_exhausted = False
+    for leader in leaders:
+        if guard_exhausted:
+            enrichment = LeaderEnrichment(
+                address=get_proxy_address(leader) or leader.get("wallet_address", ""),
+                reason_tags=["CREDIT_GUARD_EXHAUSTED"],
+            )
+        else:
+            try:
+                enrichment = enrich_leader_for_market(leader, leaderboard, leaderboard_size, guard)
+            except CreditGuardExceeded:
+                guard_exhausted = True
+                logger.warning(
+                    "Credit guard exhausted (max_calls=%d) mid-run — remaining "
+                    "leaders keep their original score", guard.max_calls,
+                )
+                enrichment = LeaderEnrichment(
+                    address=get_proxy_address(leader) or leader.get("wallet_address", ""),
+                    reason_tags=["CREDIT_GUARD_EXHAUSTED"],
+                )
+        enriched_pairs.append((leader, enrichment))
+        logger.info(
+            "Leader %s: quality=%.3f tags=%s",
+            enrichment.address[:10], enrichment.quality_score, enrichment.reason_tags,
+        )
+    return enriched_pairs
+
+
+def _enrich_pairs_legacy(
+    leaders: list[dict], guard: CreditGuard,
+) -> list[tuple[dict, LeaderEnrichment]]:
+    """
+    Legacy path: broad wallet-history ranking with no target market. Kept
+    for callers that genuinely need a market-agnostic ranking (e.g. ranking
+    leaders across many markets at once); prefer passing market_id.
+    """
+    enriched_pairs: list[tuple[dict, LeaderEnrichment]] = []
+    guard_exhausted = False
+    for leader in leaders:
+        proxy = get_proxy_address(leader)
+        enrichment = LeaderEnrichment(address=proxy or leader.get("wallet_address", ""))
+
+        if not proxy:
+            enrichment.error = "MISSING_PROXY_ADDRESS"
+            enrichment.reason_tags = ["MISSING_PROXY_ADDRESS"]
+            enriched_pairs.append((leader, enrichment))
+            continue
+
+        if guard_exhausted:
+            enrichment.reason_tags = ["CREDIT_GUARD_EXHAUSTED"]
+            enriched_pairs.append((leader, enrichment))
+            continue
+
+        try:
+            pnl_rows = pnl_by_address(proxy, limit=50, guard=guard)
+            time.sleep(INTER_CALL_DELAY_S)
+            trade_rows = trades_by_address(proxy, limit=100, guard=guard)
+            time.sleep(INTER_CALL_DELAY_S)
+
+            features = pnl_quality_score(pnl_rows, min_resolved=MIN_RESOLVED_MARKETS)
+            distinct_markets = len({t["market_id"] for t in trade_rows if t["market_id"]})
+            quality_score, reason_tags = _compute_quality_score(features, distinct_markets)
+
+            enrichment.win_rate = features["win_rate"]
+            enrichment.avg_roi = features["avg_roi"]
+            enrichment.consistency = features["consistency"]
+            enrichment.concentration = features["concentration"]
+            enrichment.resolved_count = features["resolved_count"]
+            enrichment.distinct_markets_traded = distinct_markets
+            enrichment.quality_score = quality_score
+            enrichment.reason_tags = reason_tags
+            enrichment.has_signal = not any(
+                t.startswith("INSUFFICIENT_HISTORY") for t in reason_tags
+            )
+        except CreditGuardExceeded:
+            guard_exhausted = True
+            logger.warning(
+                "Credit guard exhausted (max_calls=%d) mid-run — remaining "
+                "leaders keep their original score", guard.max_calls,
+            )
+            enrichment.reason_tags = ["CREDIT_GUARD_EXHAUSTED"]
+        except NansenError as e:
+            logger.warning("Nansen fetch failed for %s: %s", proxy[:10], e)
+            enrichment.error = str(e)
+            enrichment.reason_tags = ["NANSEN_FETCH_ERROR"]
+
+        enriched_pairs.append((leader, enrichment))
+        logger.info(
+            "Leader %s: quality=%.3f tags=%s",
+            enrichment.address[:10], enrichment.quality_score, enrichment.reason_tags,
+        )
+    return enriched_pairs

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_worldcup.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_worldcup.py
@@ -317,12 +317,21 @@ def enrich_leaders(
     if not leaders:
         return []
 
+    # See the same guard in the general overlay: 0 is falsy and skips the cap
+    # branch entirely, a negative value becomes a slice bound. Both enrich MORE
+    # wallets than the caller asked for, on the caller's own credits.
+    if max_wallets < 1:
+        raise ValueError(
+            f"max_wallets must be >= 1, got {max_wallets}. It is a hard credit "
+            "cap; 0 and negative values would enrich more wallets, not fewer."
+        )
+
     if guard is None:
         guard = CreditGuard()
 
     to_enrich = leaders
     skipped: list[dict] = []
-    if max_wallets and len(leaders) > max_wallets:
+    if len(leaders) > max_wallets:
         ranked = sorted(leaders, key=lambda l: float(l.get(base_score_key) or 0.0), reverse=True)
         to_enrich, skipped = ranked[:max_wallets], ranked[max_wallets:]
         logger.warning(

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_worldcup.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_worldcup.py
@@ -1,0 +1,408 @@
+"""
+Module 2: nansen-copytrader-overlay-worldcup
+=============================================
+Same overlay pattern as nansen_copytrader_overlay_general — pnl-by-market
+for the target market is the PRIMARY signal — tuned for the World Cup
+market lifecycle:
+
+- Filters the secondary/general Nansen PnL history to World Cup markets
+  only, and blends a WC-specialist bonus into the secondary signal.
+- Adds WC-specific reason tags (WC_SPECIALIST, WC_NOVICE, etc.)
+
+World Cup market detection:
+    A market is classified as WC if its question or event_title contains
+    any of the WC_KEYWORDS below.  No external API call needed.
+
+Integration point:
+    Same interface as nansen_copytrader_overlay_general.enrich_leaders().
+    Swap it in for WC-specific agent runs.
+"""
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from nansen_adapter import (
+    pnl_by_address,
+    trades_by_address,
+    address_summary,
+    pnl_quality_score,
+    compute_roi,
+    get_proxy_address,
+    get_owner_address,
+    NansenError,
+    CreditGuard,
+    CreditGuardExceeded,
+    INTER_CALL_DELAY_S,
+)
+from nansen_copytrader_overlay_general import (
+    MIN_RESOLVED_MARKETS,
+    NO_ADJUSTMENT_DISCOUNT,
+    MARKET_SIGNAL_WEIGHT,
+    GENERAL_SIGNAL_WEIGHT,
+    DEFAULT_MAX_WALLETS,
+    LeaderEnrichment,
+    fetch_market_leaderboard,
+    _compute_market_score,
+    _blend_and_rank,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# WC configuration
+# ---------------------------------------------------------------------------
+
+# Bare "fifa", "knockout" and "final 2026" over-match (FIFA president
+# elections, boxing knockouts, unrelated 2026 finals). "fifa" is narrowed to
+# require a WC pairing; "knockout" is demoted to a weak keyword that only
+# counts alongside an explicit world-cup mention; "final 2026" is dropped
+# entirely — genuine WC finals still match via "quarter/semi-final" below.
+WC_KEYWORDS = re.compile(
+    r"world\s*cup|wc\s*202[456]|fifwc|fifa\s*(?:world\s*cup|202[456])|"
+    r"group\s+[a-h]\b|quarter.final|semi.final|"
+    r"\bwc\b.*\b(winner|champion|advance|goal|score)",
+    re.IGNORECASE,
+)
+
+_WC_WEAK_KEYWORDS = re.compile(r"\bknockout\b", re.IGNORECASE)
+_WC_CONTEXT = re.compile(r"world\s*cup|wc\s*202[456]|fifwc", re.IGNORECASE)
+
+# WC-specific secondary-signal sub-weights (used within GENERAL_SIGNAL_WEIGHT's
+# share of the overall blend — the market_score from pnl-by-market for the
+# target market remains the primary signal, same as overlay-general).
+WEIGHT_WIN_RATE = 0.25
+WEIGHT_AVG_ROI = 0.20
+WEIGHT_CONSISTENCY = 0.20
+WEIGHT_CONCENTRATION_PENALTY = 0.10
+WEIGHT_VOLUME = 0.10
+WEIGHT_WC_SPECIALIST = 0.15   # bonus for WC-focused history
+
+
+def _is_wc_market(question: str) -> bool:
+    q = question or ""
+    if WC_KEYWORDS.search(q):
+        return True
+    return bool(_WC_WEAK_KEYWORDS.search(q) and _WC_CONTEXT.search(q))
+
+
+@dataclass
+class WCLeaderEnrichment(LeaderEnrichment):
+    """Extended enrichment with WC-specific features."""
+    wc_resolved_count: int = 0
+    wc_win_rate: Optional[float] = None
+    wc_avg_roi: Optional[float] = None
+    wc_specialist_score: float = 0.0   # 0–1: fraction of resolved PnL that is WC
+
+
+def _compute_wc_quality_score(
+    general_features: dict,
+    wc_features: dict,
+    distinct_markets: int,
+) -> tuple[float, list[str]]:
+    """
+    Compute the SECONDARY (general + WC-specialist) quality score from broad
+    wallet history. This blends into the overall score at GENERAL_SIGNAL_WEIGHT
+    — the primary signal is still pnl-by-market for the target market.
+
+    Returns (score, reason_tags).
+    """
+    from nansen_copytrader_overlay_general import _compute_quality_score
+
+    tags: list[str] = []
+    resolved_count = general_features.get("resolved_count", 0)
+
+    if resolved_count < MIN_RESOLVED_MARKETS:
+        tags.append(f"INSUFFICIENT_HISTORY:{resolved_count}_resolved")
+        return 0.0, tags
+
+    # --- General components (same rubric as overlay-general's secondary signal) ---
+    score_general, general_tags = _compute_quality_score(general_features, distinct_markets)
+    tags.extend(general_tags)
+
+    # --- WC-specialist bonus ---
+    wc_resolved = wc_features.get("wc_resolved_count", 0)
+    wc_specialist_score = 0.0
+    if resolved_count > 0:
+        wc_specialist_score = min(1.0, wc_resolved / max(1, resolved_count))
+
+    if wc_specialist_score >= 0.5:
+        tags.append("WC_SPECIALIST")
+    elif wc_specialist_score > 0 and wc_specialist_score < 0.2:
+        tags.append("WC_NOVICE")
+
+    wc_win_rate = wc_features.get("wc_win_rate")
+    if wc_win_rate is not None:
+        if wc_win_rate >= 0.65:
+            tags.append("WC_HIGH_WIN_RATE")
+        elif wc_win_rate < 0.35:
+            tags.append("WC_LOW_WIN_RATE")
+
+    specialist_component = wc_specialist_score * WEIGHT_WC_SPECIALIST
+    general_weight = WEIGHT_WIN_RATE + WEIGHT_AVG_ROI + WEIGHT_CONSISTENCY + \
+                     WEIGHT_CONCENTRATION_PENALTY + WEIGHT_VOLUME
+
+    score = score_general * (general_weight / (general_weight + WEIGHT_WC_SPECIALIST)) + \
+            specialist_component
+
+    score = max(0.0, min(1.0, score))
+
+    wc_avg_roi = wc_features.get("wc_avg_roi")
+    if wc_avg_roi is not None and wc_avg_roi > 0:
+        roi_bonus = min(0.05, wc_avg_roi * 0.02)  # small boost for positive WC ROI
+        score = min(1.0, score + roi_bonus)
+        if wc_avg_roi >= 2.0:
+            tags.append("STRONG_WC_ROI")
+
+    return round(score, 4), tags
+
+
+def _fetch_wc_secondary_signal(proxy: str, owner: str, guard: CreditGuard, enrichment: WCLeaderEnrichment) -> Optional[float]:
+    """
+    Shared secondary-signal fetch: address_summary pre-filter, then full
+    pnl_by_address/trades_by_address + WC filtering. Mutates `enrichment`
+    in place with whatever features were computed; returns the WC quality
+    score, or None if no usable secondary signal was obtained.
+    """
+    # address_summary/pnl_by_address/trades_by_address are all
+    # prediction-market endpoints keyed by the PROXY address. A missing
+    # owner is worth recording but must not gate this block — only profiler
+    # endpoints need the owner wallet.
+    if not owner:
+        enrichment.reason_tags.append("MISSING_OWNER_ADDRESS")
+
+    try:
+        summary = address_summary(proxy, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+
+        if summary["resolved_count"] < MIN_RESOLVED_MARKETS:
+            enrichment.reason_tags.append(f"INSUFFICIENT_HISTORY:{summary['resolved_count']}_resolved")
+            return None
+
+        pnl_rows = pnl_by_address(proxy, limit=100, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+        trade_rows = trades_by_address(proxy, limit=200, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+
+        general_features = pnl_quality_score(pnl_rows, min_resolved=MIN_RESOLVED_MARKETS)
+
+        wc_pnl_rows = [r for r in pnl_rows if _is_wc_market(r.get("question", ""))]
+        wc_resolved = [r for r in wc_pnl_rows if r.get("market_resolved")]
+        wc_resolved_count = len(wc_resolved)
+
+        wc_win_rate = None
+        wc_avg_roi = None
+        if wc_resolved:
+            wins = sum(1 for r in wc_resolved if r["total_pnl_usd"] > 0)
+            wc_win_rate = wins / len(wc_resolved)
+            rois = [r["total_pnl_usd"] / r["net_buy_cost_usd"]
+                    for r in wc_resolved if r["net_buy_cost_usd"] > 0]
+            if rois:
+                wc_avg_roi = sum(rois) / len(rois)
+
+        wc_features = {
+            "wc_resolved_count": wc_resolved_count,
+            "wc_win_rate": wc_win_rate,
+            "wc_avg_roi": wc_avg_roi,
+        }
+
+        distinct_markets = len({t["market_id"] for t in trade_rows if t["market_id"]})
+        score, tags = _compute_wc_quality_score(general_features, wc_features, distinct_markets)
+
+        enrichment.win_rate = general_features["win_rate"]
+        enrichment.avg_roi = general_features["avg_roi"]
+        enrichment.consistency = general_features["consistency"]
+        enrichment.concentration = general_features["concentration"]
+        enrichment.resolved_count = general_features["resolved_count"]
+        enrichment.distinct_markets_traded = distinct_markets
+        enrichment.wc_resolved_count = wc_resolved_count
+        enrichment.wc_win_rate = wc_win_rate
+        enrichment.wc_avg_roi = wc_avg_roi
+        enrichment.wc_specialist_score = wc_resolved_count / max(1, general_features["resolved_count"])
+        enrichment.reason_tags.extend(tags)
+
+        if any(t.startswith("INSUFFICIENT_HISTORY") for t in tags):
+            return None
+        return score
+    except CreditGuardExceeded:
+        raise
+    except NansenError as e:
+        logger.warning("WC secondary fetch failed for %s: %s", proxy[:10], e)
+        enrichment.reason_tags.append("NANSEN_FETCH_ERROR")
+        return None
+
+
+def enrich_leader_worldcup_for_market(
+    leader: dict, leaderboard: Optional[dict], leaderboard_size: int, guard: CreditGuard,
+) -> WCLeaderEnrichment:
+    """Market-first WC enrichment — pnl-by-market for the target market is primary."""
+    proxy = get_proxy_address(leader)
+    enrichment = WCLeaderEnrichment(address=proxy or leader.get("wallet_address", ""))
+
+    if not proxy:
+        enrichment.error = "MISSING_PROXY_ADDRESS"
+        enrichment.reason_tags = ["MISSING_PROXY_ADDRESS"]
+        return enrichment
+
+    if leaderboard is None:
+        enrichment.reason_tags = ["MARKET_FETCH_ERROR"]
+        return enrichment
+
+    entry = leaderboard.get(proxy.lower())
+    if entry is None:
+        enrichment.reason_tags = ["NOT_IN_MARKET_LEADERBOARD"]
+        return enrichment
+
+    rank, row = entry
+    # owner_address comes back on the leaderboard row we already fetched.
+    owner = get_owner_address(leader, row)
+    market_score, market_tags = _compute_market_score(row, rank, leaderboard_size)
+    enrichment.market_score = market_score
+    enrichment.market_total_pnl_usd = row.get("total_pnl_usd")
+    enrichment.market_roi = compute_roi(row.get("net_buy_cost_usd", 0.0), row.get("total_pnl_usd", 0.0))
+    enrichment.reason_tags = list(market_tags)
+    enrichment.has_signal = True
+
+    wc_score = _fetch_wc_secondary_signal(proxy, owner, guard, enrichment)
+
+    if wc_score is None:
+        enrichment.quality_score = market_score
+    else:
+        enrichment.quality_score = round(
+            MARKET_SIGNAL_WEIGHT * market_score + GENERAL_SIGNAL_WEIGHT * wc_score, 4
+        )
+
+    return enrichment
+
+
+def enrich_leader_worldcup(leader: dict, guard: CreditGuard) -> WCLeaderEnrichment:
+    """
+    Legacy (no target market) WC enrichment: broad wallet history filtered to
+    WC markets only. Prefer enrich_leaders(..., market_id=...) — this path
+    exists for market-agnostic WC leaderboards only.
+    """
+    proxy = get_proxy_address(leader)
+    owner = get_owner_address(leader)
+    enrichment = WCLeaderEnrichment(address=proxy or leader.get("wallet_address", ""))
+
+    if not proxy:
+        enrichment.error = "MISSING_PROXY_ADDRESS"
+        enrichment.reason_tags = ["MISSING_PROXY_ADDRESS"]
+        return enrichment
+
+    score = _fetch_wc_secondary_signal(proxy, owner, guard, enrichment)
+    if score is not None:
+        enrichment.quality_score = score
+        enrichment.has_signal = True
+    return enrichment
+
+
+def enrich_leaders(
+    leaders: list[dict],
+    market_id: Optional[str] = None,
+    dry_run: bool = True,
+    top_n: Optional[int] = None,
+    base_score_key: str = "wallet_score",
+    max_wallets: int = DEFAULT_MAX_WALLETS,
+    guard: Optional[CreditGuard] = None,
+) -> list[dict]:
+    """
+    World Cup variant of enrich_leaders — same interface as
+    nansen_copytrader_overlay_general.enrich_leaders(). Pass `market_id` for
+    the primary pnl-by-market signal (recommended); omitted falls back to a
+    WC-filtered broad-history ranking only.
+    """
+    if not leaders:
+        return []
+
+    if guard is None:
+        guard = CreditGuard()
+
+    to_enrich = leaders
+    skipped: list[dict] = []
+    if max_wallets and len(leaders) > max_wallets:
+        ranked = sorted(leaders, key=lambda l: float(l.get(base_score_key) or 0.0), reverse=True)
+        to_enrich, skipped = ranked[:max_wallets], ranked[max_wallets:]
+        logger.warning(
+            "%d leaders exceed max_wallets=%d — enriching the top %d by %s, "
+            "keeping the remaining %d at their original score (CREDIT_GUARD_MAX_WALLETS)",
+            len(leaders), max_wallets, max_wallets, base_score_key, len(skipped),
+        )
+
+    enriched_pairs: list[tuple[dict, WCLeaderEnrichment]] = []
+    guard_exhausted = False
+
+    if market_id is None:
+        logger.warning(
+            "enrich_leaders() called without market_id — falling back to WC-filtered "
+            "broad wallet-history ranking, which is NOT specific to the target market. "
+            "Pass market_id to use pnl-by-market, the primary copytrader signal."
+        )
+        for leader in to_enrich:
+            proxy = get_proxy_address(leader)
+            if guard_exhausted and proxy:
+                enrichment = WCLeaderEnrichment(address=proxy, reason_tags=["CREDIT_GUARD_EXHAUSTED"])
+            else:
+                try:
+                    enrichment = enrich_leader_worldcup(leader, guard)
+                except CreditGuardExceeded:
+                    guard_exhausted = True
+                    logger.warning(
+                        "Credit guard exhausted (max_calls=%d) mid-run — remaining "
+                        "leaders keep their original score", guard.max_calls,
+                    )
+                    enrichment = WCLeaderEnrichment(
+                        address=proxy or leader.get("wallet_address", ""),
+                        reason_tags=["CREDIT_GUARD_EXHAUSTED"],
+                    )
+            enriched_pairs.append((leader, enrichment))
+    else:
+        leaderboard, leaderboard_size = fetch_market_leaderboard(market_id, guard)
+        for leader in to_enrich:
+            proxy = get_proxy_address(leader)
+            if guard_exhausted:
+                enrichment = WCLeaderEnrichment(
+                    address=proxy or leader.get("wallet_address", ""),
+                    reason_tags=["CREDIT_GUARD_EXHAUSTED"],
+                )
+            else:
+                try:
+                    enrichment = enrich_leader_worldcup_for_market(leader, leaderboard, leaderboard_size, guard)
+                except CreditGuardExceeded:
+                    guard_exhausted = True
+                    logger.warning(
+                        "Credit guard exhausted (max_calls=%d) mid-run — remaining "
+                        "leaders keep their original score", guard.max_calls,
+                    )
+                    enrichment = WCLeaderEnrichment(
+                        address=proxy or leader.get("wallet_address", ""),
+                        reason_tags=["CREDIT_GUARD_EXHAUSTED"],
+                    )
+            enriched_pairs.append((leader, enrichment))
+
+    for leader in skipped:
+        enriched_pairs.append((leader, WCLeaderEnrichment(
+            address=get_proxy_address(leader) or leader.get("wallet_address", ""),
+            reason_tags=["CREDIT_GUARD_MAX_WALLETS"],
+        )))
+
+    extra_features = {
+        e.address: {
+            "wc_resolved_count": e.wc_resolved_count,
+            "wc_win_rate": e.wc_win_rate,
+            "wc_avg_roi": e.wc_avg_roi,
+            "wc_specialist_score": e.wc_specialist_score,
+        }
+        for _, e in enriched_pairs
+    }
+
+    for leader, enrichment in enriched_pairs:
+        logger.info(
+            "WC leader %s: quality=%.3f wc_resolved=%d tags=%s",
+            enrichment.address[:10], enrichment.quality_score,
+            enrichment.wc_resolved_count, enrichment.reason_tags,
+        )
+
+    return _blend_and_rank(enriched_pairs, dry_run, top_n, base_score_key, extra_features=extra_features)

--- a/skills/nansen-copytrader-overlay/nansen_live_insider_scan.py
+++ b/skills/nansen-copytrader-overlay/nansen_live_insider_scan.py
@@ -1,0 +1,556 @@
+"""
+Module 3: nansen-live-insider-scan
+====================================
+Adapted from the resolved-market insider scan (nansen-polymarket-insider-scan
+skill) for LIVE (unresolved) markets.
+
+Key difference from the original:
+    - Original scans resolved markets to find who WON suspiciously.
+    - This module scans LIVE markets to find wallets making aggressive,
+      potentially informed entries RIGHT NOW — before resolution.
+
+Signal output: a structured object per suspicious wallet with
+    market_id, side, confidence, edge, reason_tags
+
+EXPERIMENTAL — dry-run only:
+    This module is not launchable for live trading yet. `scan_live_markets()`
+    hard-raises `LiveTradingNotSupportedError` if called with dry_run=False,
+    because two things are unconfirmed against the live Nansen API:
+      1. Owner/proxy wallet handling: wallets discovered here come from
+         `trades_by_market` (a PM/proxy-indexed endpoint), so they are
+         proxy addresses — correct for the `trades_by_address` follow-up
+         call. But `historical_balances` is a PROFILER endpoint indexed by
+         OWNER (signing) wallet, and this module has no owner mapping for
+         scanned wallets — `wallet_age_days` may be silently wrong.
+      2. `HIGH_NO_ENTRY` price semantics (see FLAG_HIGH_ENTRY_PRICE below).
+    Removing the guard is a deliberate code change, not a flag flip — do it
+    only after both are verified against the live API.
+
+--live gate:
+    This module NEVER places trades itself.  It emits signal objects.
+    The Simmer execution wrapper (caller) checks dry_run before acting.
+
+Usage:
+    from nansen_live_insider_scan import scan_live_markets
+
+    signals = scan_live_markets(
+        market_ids=["12345", "67890"],  # or None to auto-discover top markets
+        dry_run=True,                    # required — dry_run=False raises
+        min_suspicion_score=3,
+    )
+    # signals is list[InsiderSignal]; each signal.dry_run == True.
+"""
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from nansen_adapter import (
+    market_screener,
+    trades_by_market,
+    top_holders,
+    trades_by_address,
+    historical_balances,
+    wallet_age_days,
+    NansenError,
+    CreditGuard,
+    CreditGuardExceeded,
+    INTER_CALL_DELAY_S,
+    _safe_float,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LiveTradingNotSupportedError(NansenError):
+    """
+    Raised by scan_live_markets() when called with dry_run=False.
+
+    This module is experimental — owner/proxy wallet handling and the
+    HIGH_NO_ENTRY price-semantics assumption are unconfirmed against the
+    live Nansen API (see module docstring). Do not remove this guard
+    without verifying both.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Known-entity check
+# ---------------------------------------------------------------------------
+# Nansen's profiler `labels` endpoint costs 100-500 credits per lookup, and it
+# was previously called for every scanned wallet just to apply a -2 score
+# discount. A default scan (10 markets x 15 wallets) would burn 15K-75K
+# credits — more than the account's entire grant. Known entities are checked
+# against this local, free allowlist instead. Extend it with addresses from
+# Nansen's public entity labels (or Polymarket's own docs) as they're found;
+# it ships small on purpose.
+KNOWN_ENTITY_ADDRESSES: set[str] = {
+    # "0x...": populate with known CEX / market-maker / fund addresses
+}
+
+
+def _is_known_entity(address: str) -> bool:
+    return address.lower() in KNOWN_ENTITY_ADDRESSES
+
+
+# ---------------------------------------------------------------------------
+# Signal dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class InsiderSignal:
+    """
+    A live insider-scan signal for a single wallet on a single market.
+
+    Deterministic: given the same Nansen data, same signal is always emitted.
+    """
+    market_id: str
+    market_question: str
+    wallet_address: str
+    side: str                    # "yes" or "no"
+    confidence: float            # 0.0–1.0
+    edge: float                  # estimated informational edge (0.0–1.0)
+    suspicion_score: int         # sum of flag points (see FLAG_* constants)
+    reason_tags: list[str] = field(default_factory=list)
+
+    # Context fields
+    entry_price: float = 0.0     # most recent trade price on this market
+    position_usd: float = 0.0   # estimated position size in USD
+    wallet_age_days: Optional[float] = None
+    distinct_markets_traded: int = 0
+    has_known_label: bool = False
+
+    dry_run: bool = True         # echoes caller's dry_run flag
+
+    def as_dict(self) -> dict:
+        return {
+            "market_id": self.market_id,
+            "market_question": self.market_question,
+            "wallet_address": self.wallet_address,
+            "side": self.side,
+            "confidence": self.confidence,
+            "edge": self.edge,
+            "suspicion_score": self.suspicion_score,
+            "reason_tags": self.reason_tags,
+            "entry_price": self.entry_price,
+            "position_usd": self.position_usd,
+            "wallet_age_days": self.wallet_age_days,
+            "distinct_markets_traded": self.distinct_markets_traded,
+            "has_known_label": self.has_known_label,
+            "dry_run": self.dry_run,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Suspicion flags — same scoring rubric as the resolved-market skill,
+# adapted for live (unresolved) markets
+# ---------------------------------------------------------------------------
+
+FLAG_NEW_WALLET = 3          # wallet funded within 7 days
+FLAG_YOUNG_WALLET = 1        # wallet funded 8–28 days ago
+FLAG_SINGLE_MARKET = 3       # only ever traded this one market
+FLAG_FEW_MARKETS = 1         # traded 2–3 distinct markets
+# UNVERIFIED ASSUMPTION: HIGH_NO_ENTRY assumes `price` is quoted in YES terms
+# for both sides (a NO trade at 0.25 means the market implies 75% YES odds).
+# If Nansen instead returns the NO token's own market price, buying NO at
+# 0.25 is a cheap longshot, not a conviction entry, and the flag's polarity
+# is inverted for NO trades. Confirm against the live API before trusting
+# HIGH_NO_ENTRY (and the mirrored `edge` calculation below for NO trades).
+FLAG_HIGH_ENTRY_PRICE = 2    # buying YES at >= 0.75 (high conviction entry)
+FLAG_LARGE_POSITION = 2      # position >= $5k USD
+FLAG_RAPID_ACCUMULATION = 2  # 3+ trades in this market in last 24h
+FLAG_KNOWN_ENTITY = -2       # Nansen-labeled wallet (CEX, fund, etc.)
+
+SUSPICION_THRESHOLD = 3      # flag wallets at this score or above
+HIGH_RISK_THRESHOLD = 7      # "high confidence suspicious" at this score
+
+# Hard credit-guard ceilings — callers can pass a lower max_wallets_per_market
+# / top_markets, but never a higher one than this regardless of what's asked.
+HARD_MAX_WALLETS_PER_MARKET = 30
+HARD_MAX_MARKETS_PER_SCAN = 25
+
+
+def _score_wallet(
+    address: str,
+    market_id: str,
+    market_trades: list[dict],   # all recent trades for this market
+    dry_run: bool = True,
+    guard: Optional[CreditGuard] = None,
+) -> Optional[InsiderSignal]:
+    """
+    Score a single wallet for suspicious behaviour on a live market.
+
+    Returns an InsiderSignal if suspicious (score >= SUSPICION_THRESHOLD),
+    or None if not suspicious / on error.
+
+    NOTE: `address` here is a proxy wallet (sourced from PM trade data), and
+    is passed as-is to historical_balances(), a profiler/owner-indexed
+    endpoint — see the module docstring's owner/proxy caveat. wallet_age_days
+    may be wrong until that's resolved; this is part of why scan_live_markets
+    hard-refuses dry_run=False.
+    """
+    # Filter trades for this wallet on this market
+    wallet_trades = [
+        t for t in market_trades
+        if t.get("buyer") == address or t.get("seller") == address
+    ]
+    if not wallet_trades:
+        return None
+
+    # Determine dominant side (yes/no) and last entry price
+    yes_vol = sum(t["usdc_value"] for t in wallet_trades
+                  if t.get("side") == "yes" and t.get("buyer") == address)
+    no_vol = sum(t["usdc_value"] for t in wallet_trades
+                 if t.get("side") == "no" and t.get("buyer") == address)
+    side = "yes" if yes_vol >= no_vol else "no"
+    position_usd = yes_vol if side == "yes" else no_vol
+
+    # No buy volume on either side (wallet only appears here as a seller in
+    # this market) — not a conviction entry, and not worth the 2 downstream
+    # API calls to profile further.
+    if position_usd <= 0:
+        return None
+
+    # Last entry price for this side
+    side_trades = [t for t in wallet_trades
+                   if t.get("side") == side and t.get("buyer") == address]
+    entry_price = side_trades[-1]["price"] if side_trades else 0.0
+
+    # Recent activity (last 24h trades on this market). Computed here, before
+    # the pre-gate, because the gate scores on it — and computed from data we
+    # already hold, so it costs nothing.
+    now = datetime.now(timezone.utc)
+    recent_market_trades = []
+    for t in wallet_trades:
+        ts = t.get("timestamp")
+        if ts:
+            try:
+                dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+                if (now - dt).total_seconds() < 86400:
+                    recent_market_trades.append(t)
+            except (ValueError, TypeError):
+                pass
+
+    # Free local pre-gate: if no local signal, skip paid API calls
+    local_signal = False
+
+    if side == "yes" and entry_price >= 0.75:
+        local_signal = True
+    elif side == "no" and entry_price <= 0.25:
+        local_signal = True
+
+    if position_usd >= 5000:
+        local_signal = True
+
+    if len(recent_market_trades) >= 3:
+        local_signal = True
+
+    if not local_signal:
+        return None
+
+    # Fetch wallet-level data with rate-limit pauses
+    try:
+        all_trades = trades_by_address(address, limit=100, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+    except CreditGuardExceeded:
+        raise
+    except NansenError as e:
+        logger.warning("trades_by_address failed for %s: %s", address[:10], e)
+        all_trades = []
+
+    try:
+        balances = historical_balances(address, chain="polygon", days=365, limit=100, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+    except CreditGuardExceeded:
+        raise
+    except NansenError as e:
+        logger.warning("historical_balances failed for %s: %s", address[:10], e)
+        balances = []
+
+    has_known_label = _is_known_entity(address)
+    age_days = wallet_age_days(balances)
+    distinct_markets = len({t["market_id"] for t in all_trades if t["market_id"]})
+
+
+    # ---------------------------------------------------------------------------
+    # Score
+    # ---------------------------------------------------------------------------
+    score = 0
+    tags: list[str] = []
+
+    # Wallet age
+    if age_days is not None:
+        if age_days <= 7:
+            score += FLAG_NEW_WALLET
+            tags.append("NEW_WALLET")
+        elif age_days <= 28:
+            score += FLAG_YOUNG_WALLET
+            tags.append("YOUNG_WALLET")
+    # else: age unknown — skip age flags
+
+    # Market focus
+    if distinct_markets <= 1:
+        score += FLAG_SINGLE_MARKET
+        tags.append("SINGLE_MARKET")
+    elif distinct_markets <= 3:
+        score += FLAG_FEW_MARKETS
+        tags.append("FEW_MARKETS")
+
+    # Entry price (buying conviction near certainty)
+    if side == "yes" and entry_price >= 0.75:
+        score += FLAG_HIGH_ENTRY_PRICE
+        tags.append("HIGH_YES_ENTRY")
+    elif side == "no" and entry_price <= 0.25:
+        score += FLAG_HIGH_ENTRY_PRICE
+        tags.append("HIGH_NO_ENTRY")
+
+    # Position size
+    if position_usd >= 5000:
+        score += FLAG_LARGE_POSITION
+        tags.append("LARGE_POSITION")
+
+    # Rapid accumulation
+    if len(recent_market_trades) >= 3:
+        score += FLAG_RAPID_ACCUMULATION
+        tags.append("RAPID_ACCUMULATION")
+
+    # Known entity discount
+    if has_known_label:
+        score += FLAG_KNOWN_ENTITY
+        tags.append("KNOWN_ENTITY")
+
+    if score < SUSPICION_THRESHOLD:
+        return None
+
+    # ---------------------------------------------------------------------------
+    # Confidence + edge
+    # ---------------------------------------------------------------------------
+    # Confidence: scale score to [0, 1] against max possible score
+    max_possible = (FLAG_NEW_WALLET + FLAG_SINGLE_MARKET + FLAG_HIGH_ENTRY_PRICE +
+                    FLAG_LARGE_POSITION + FLAG_RAPID_ACCUMULATION)
+    confidence = min(1.0, max(0.0, score / max_possible))
+
+    # Edge: heuristic — higher entry price on YES suggests strong conviction
+    # Edge = how far from 0.50 the entry was (normalised)
+    if side == "yes":
+        edge = min(1.0, abs(entry_price - 0.50) * 2)
+    else:
+        edge = min(1.0, abs((1.0 - entry_price) - 0.50) * 2)
+
+    if score >= HIGH_RISK_THRESHOLD:
+        tags.insert(0, "HIGH_RISK")
+
+    market_question = wallet_trades[0].get("market_question", "") if wallet_trades else ""
+
+    return InsiderSignal(
+        market_id=market_id,
+        market_question=market_question,
+        wallet_address=address,
+        side=side,
+        confidence=round(confidence, 4),
+        edge=round(edge, 4),
+        suspicion_score=score,
+        reason_tags=tags,
+        entry_price=round(entry_price, 4),
+        position_usd=round(position_usd, 2),
+        wallet_age_days=round(age_days, 1) if age_days is not None else None,
+        distinct_markets_traded=distinct_markets,
+        has_known_label=has_known_label,
+        dry_run=dry_run,
+    )
+
+
+def scan_market(
+    market_id: str,
+    dry_run: bool = True,
+    min_suspicion_score: int = SUSPICION_THRESHOLD,
+    max_wallets: int = 20,
+    guard: Optional[CreditGuard] = None,
+) -> list[InsiderSignal]:
+    """
+    Scan a single live market for suspicious wallets.
+
+    Returns a list of InsiderSignal objects, sorted by suspicion_score descending.
+    """
+    max_wallets = min(max_wallets, HARD_MAX_WALLETS_PER_MARKET)
+    signals: list[InsiderSignal] = []
+
+    try:
+        trades = trades_by_market(market_id, limit=100, guard=guard)
+        time.sleep(INTER_CALL_DELAY_S)
+    except CreditGuardExceeded:
+        raise
+    except NansenError as e:
+        logger.warning("trades_by_market failed for market %s: %s", market_id, e)
+        return []
+
+    # Collect unique buyer addresses
+    buyers = list(dict.fromkeys(
+        t["buyer"] for t in trades if t.get("buyer") and t["buyer"] != "0x"
+    ))[:max_wallets]
+
+    for address in buyers:
+        try:
+            signal = _score_wallet(address, market_id, trades, dry_run=dry_run, guard=guard)
+            if signal and signal.suspicion_score >= min_suspicion_score:
+                signals.append(signal)
+                logger.info(
+                    "Suspicious: %s on market %s score=%d tags=%s dry_run=%s",
+                    address[:10], market_id, signal.suspicion_score, signal.reason_tags, dry_run,
+                )
+        except CreditGuardExceeded:
+            raise
+        except Exception as e:
+            logger.warning("Error scoring wallet %s: %s", address[:10], e)
+            continue
+
+    signals.sort(key=lambda s: s.suspicion_score, reverse=True)
+    return signals
+
+
+def scan_live_markets(
+    market_ids: Optional[list[str]] = None,
+    dry_run: bool = True,
+    min_suspicion_score: int = SUSPICION_THRESHOLD,
+    top_markets: int = 10,
+    max_wallets_per_market: int = 15,
+    guard: Optional[CreditGuard] = None,
+) -> list[InsiderSignal]:
+    """
+    Main entry point: scan one or more live markets for insider patterns.
+
+    Args:
+        market_ids:           specific market IDs to scan, or None for auto-discovery
+        dry_run:              must be True — this module is experimental and
+                              dry-run only (see module docstring). Passing
+                              dry_run=False raises LiveTradingNotSupportedError.
+        min_suspicion_score:  minimum score to include in output (default 3)
+        top_markets:          if market_ids is None, scan top N markets by volume
+                              (hard-capped at HARD_MAX_MARKETS_PER_SCAN)
+        max_wallets_per_market: max wallets to profile per market
+                              (hard-capped at HARD_MAX_WALLETS_PER_MARKET)
+        guard:                shared CreditGuard; a fresh one (default budget)
+                              is created if not supplied, and shared across
+                              every market scanned in this call.
+
+    Returns:
+        list[InsiderSignal] sorted by suspicion_score descending.
+
+    --live gate:
+        EXPERIMENTAL: dry_run=False is not supported yet (raises). Once
+        owner/proxy handling and NO-side price semantics are confirmed
+        against the live API and this guard is removed, the CALLER remains
+        responsible for checking dry_run before submitting orders — this
+        function never places trades itself.
+    """
+    if not dry_run:
+        raise LiveTradingNotSupportedError(
+            "nansen_live_insider_scan is experimental and dry-run only: "
+            "owner/proxy wallet handling (historical_balances uses a proxy "
+            "address with no owner mapping) and HIGH_NO_ENTRY price semantics "
+            "are unconfirmed against the live Nansen API. See module docstring."
+        )
+
+    if guard is None:
+        guard = CreditGuard()
+
+    top_markets = min(top_markets, HARD_MAX_MARKETS_PER_SCAN)
+    max_wallets_per_market = min(max_wallets_per_market, HARD_MAX_WALLETS_PER_MARKET)
+
+    # Auto-discover markets if none specified
+    if not market_ids:
+        try:
+            markets = market_screener(sort_by="volume_24hr", limit=top_markets,
+                                       status="active", guard=guard)
+            market_ids = [str(m.get("market_id") or m.get("id") or "") for m in markets]
+            market_ids = [m for m in market_ids if m]
+            logger.info("Auto-discovered %d live markets", len(market_ids))
+        except NansenError as e:
+            logger.error("market_screener failed: %s", e)
+            return []
+    else:
+        if len(market_ids) > HARD_MAX_MARKETS_PER_SCAN:
+            logger.warning(
+                "%d market_ids exceed HARD_MAX_MARKETS_PER_SCAN=%d — scanning "
+                "only the first %d, dropping %d",
+                len(market_ids), HARD_MAX_MARKETS_PER_SCAN, HARD_MAX_MARKETS_PER_SCAN,
+                len(market_ids) - HARD_MAX_MARKETS_PER_SCAN,
+            )
+            market_ids = market_ids[:HARD_MAX_MARKETS_PER_SCAN]
+
+    all_signals: list[InsiderSignal] = []
+
+    for i, market_id in enumerate(market_ids):
+        logger.info("Scanning live market %s ...", market_id)
+        try:
+            signals = scan_market(
+                market_id=market_id,
+                dry_run=dry_run,
+                min_suspicion_score=min_suspicion_score,
+                max_wallets=max_wallets_per_market,
+                guard=guard,
+            )
+        except CreditGuardExceeded:
+            logger.warning(
+                "Credit guard exhausted (max_calls=%d) after %d market(s) — "
+                "stopping scan early, returning signals found so far",
+                guard.max_calls, i,
+            )
+            break
+        all_signals.extend(signals)
+        time.sleep(INTER_CALL_DELAY_S)
+
+    all_signals.sort(key=lambda s: s.suspicion_score, reverse=True)
+    return all_signals
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (for standalone use)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Nansen live insider scan (EXPERIMENTAL — dry-run only)")
+    parser.add_argument("--market-id", nargs="*", help="Market IDs to scan (default: auto-discover top 10)")
+    parser.add_argument("--live", action="store_true",
+                        help="NOT SUPPORTED YET — this module is experimental and always dry-run; "
+                             "passing --live prints why and exits without scanning.")
+    parser.add_argument("--min-score", type=int, default=SUSPICION_THRESHOLD,
+                        help=f"Min suspicion score to report (default {SUSPICION_THRESHOLD})")
+    parser.add_argument("--top-markets", type=int, default=10,
+                        help=f"Auto-discover top N markets if no --market-id given (hard-capped at {HARD_MAX_MARKETS_PER_SCAN})")
+    args = parser.parse_args()
+
+    if args.live:
+        print(
+            "[REFUSED] --live is not supported yet: nansen_live_insider_scan is "
+            "experimental and dry-run only until owner/proxy wallet handling and "
+            "NO-side price semantics are confirmed against the live Nansen API. "
+            "See the module docstring in nansen_live_insider_scan.py."
+        )
+        raise SystemExit(1)
+
+    print("[DRY RUN] No orders will be submitted.")
+
+    try:
+        signals = scan_live_markets(
+            market_ids=args.market_id or None,
+            dry_run=True,
+            min_suspicion_score=args.min_score,
+            top_markets=args.top_markets,
+        )
+    except LiveTradingNotSupportedError as e:
+        print(f"[REFUSED] {e}")
+        raise SystemExit(1)
+
+    if not signals:
+        print("No suspicious wallets found.")
+    else:
+        print(f"\nFound {len(signals)} suspicious wallet(s):\n")
+        for s in signals:
+            print(json.dumps(s.as_dict(), indent=2))
+            print()

--- a/skills/nansen-copytrader-overlay/nansen_skill_cli.py
+++ b/skills/nansen-copytrader-overlay/nansen_skill_cli.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+CLI wrapper for the Simmer x Nansen skills — the runnable entry point
+referenced by SKILL.md.
+
+Nansen is a data layer here, nothing more: PM PnL quality overlay
+(pnl-by-market primary signal) + address-summary/wallet quality. This is
+NOT smart-money-labeled copytrading — Nansen's smart-money labels are not
+Polymarket-specific and no code path in this repo calls them.
+
+Subcommands:
+    copytrader-overlay   Rank leaders for a target market. pnl-by-market for
+                         that market is the PRIMARY signal; address-summary
+                         + pnl-by-address/trades-by-address are a secondary
+                         refinement, gated to control credit spend.
+    insider-scan         EXPERIMENTAL — dry-run only. Refuses --live.
+
+Examples:
+    python3 nansen_skill_cli.py copytrader-overlay \\
+        --market-id 12345 --leaders leaders.json --top-n 5
+
+    python3 nansen_skill_cli.py copytrader-overlay \\
+        --market-id 12345 --leaders leaders.json --worldcup
+
+    python3 nansen_skill_cli.py insider-scan --market-id 12345 67890
+
+leaders.json shape:
+    [
+      {"proxy_address": "0x...", "owner_address": "0x...", "wallet_score": 0.8}
+    ]
+    proxy_address is used for PM endpoints (pnl-by-market, pnl-by-address,
+    trades-by-address, address-summary); owner_address for profiler endpoints
+    (historical-balances). owner_address is OPTIONAL — it is read off
+    the pnl-by-market leaderboard row when omitted.
+    `address` is accepted as a legacy alias for proxy_address only.
+
+This is a bring-your-own-key skill: every call spends the user's own Nansen
+credits, so the --max-wallets/--max-calls defaults are deliberately
+conservative. Raise them explicitly if you want a wider sweep.
+"""
+
+import argparse
+import json
+import sys
+
+from nansen_adapter import DEFAULT_MAX_CALLS_PER_RUN
+from nansen_copytrader_overlay_general import DEFAULT_MAX_WALLETS
+
+
+def _cmd_copytrader_overlay(args):
+    with open(args.leaders) as f:
+        leaders = json.load(f)
+
+    if args.worldcup:
+        from nansen_copytrader_overlay_worldcup import enrich_leaders
+    else:
+        from nansen_copytrader_overlay_general import enrich_leaders
+
+    from nansen_adapter import CreditGuard
+    guard = CreditGuard(max_calls=args.max_calls)
+
+    result = enrich_leaders(
+        leaders,
+        market_id=args.market_id,
+        dry_run=not args.live,
+        top_n=args.top_n,
+        max_wallets=args.max_wallets,
+        guard=guard,
+    )
+    print(json.dumps(result, indent=2))
+    print(
+        f"[credits] {guard.calls_made}/{guard.max_calls} Nansen calls used this run",
+        file=sys.stderr,
+    )
+
+
+def _cmd_insider_scan(args):
+    from nansen_live_insider_scan import scan_live_markets, LiveTradingNotSupportedError
+
+    if args.live:
+        print(
+            "[REFUSED] insider-scan is experimental and dry-run only until "
+            "owner/proxy wallet handling and NO-side price semantics are "
+            "confirmed against the live Nansen API. See the module docstring "
+            "in nansen_live_insider_scan.py.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        signals = scan_live_markets(
+            market_ids=args.market_id or None,
+            dry_run=True,
+            top_markets=args.top_markets,
+        )
+    except LiveTradingNotSupportedError as e:
+        print(f"[REFUSED] {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps([s.as_dict() for s in signals], indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="nansen_skill_cli",
+        description="Simmer x Nansen skills CLI — data-layer-only overlays for copytrading",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    overlay = sub.add_parser(
+        "copytrader-overlay",
+        help="Rank leaders for a target market (pnl-by-market is the primary signal)",
+    )
+    overlay.add_argument("--market-id", required=True,
+                          help="Target Polymarket market_id to rank leaders for")
+    overlay.add_argument("--leaders", required=True,
+                          help="Path to a JSON file: list of "
+                               "{proxy_address, owner_address, wallet_score}")
+    overlay.add_argument("--worldcup", action="store_true",
+                          help="Use the World Cup-tuned overlay variant")
+    overlay.add_argument("--top-n", type=int, default=None)
+    # Defaults come from the constants themselves so the help text can never
+    # drift from the actual value again.
+    overlay.add_argument("--max-wallets", type=int, default=DEFAULT_MAX_WALLETS,
+                          help="Hard cap on leaders enriched this run "
+                               f"(credit guard, default {DEFAULT_MAX_WALLETS})")
+    overlay.add_argument("--max-calls", type=int, default=DEFAULT_MAX_CALLS_PER_RUN,
+                          help="Hard cap on Nansen calls this run "
+                               f"(credit guard, default {DEFAULT_MAX_CALLS_PER_RUN})")
+    overlay.add_argument("--live", action="store_true",
+                          help="Mark output dry_run=False. This CLI never places trades "
+                               "itself either way — the caller still owns that gate.")
+    overlay.set_defaults(func=_cmd_copytrader_overlay)
+
+    insider = sub.add_parser(
+        "insider-scan",
+        help="EXPERIMENTAL — dry-run only. --live is refused, not just discouraged.",
+    )
+    insider.add_argument("--market-id", nargs="*", default=None,
+                          help="Market IDs to scan (default: auto-discover top markets)")
+    insider.add_argument("--top-markets", type=int, default=10)
+    insider.add_argument("--live", action="store_true",
+                          help="NOT SUPPORTED YET — prints why and exits nonzero")
+    insider.set_defaults(func=_cmd_insider_scan)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/nansen-copytrader-overlay/nansen_skill_cli.py
+++ b/skills/nansen-copytrader-overlay/nansen_skill_cli.py
@@ -100,6 +100,27 @@ def _cmd_insider_scan(args):
     print(json.dumps([s.as_dict() for s in signals], indent=2))
 
 
+def _positive_int(raw: str) -> int:
+    """argparse type for the credit caps: reject 0 and negatives at parse time.
+
+    Both caps spend the user's own Nansen credits, and both fail badly on a
+    nonpositive value (--max-calls 0 trips the guard on the first request;
+    --max-wallets 0 skips the cap and enriches everything). The library layer
+    raises ValueError for programmatic callers; this turns the CLI case into a
+    normal usage error instead of a traceback.
+    """
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {raw!r}")
+    if value < 1:
+        raise argparse.ArgumentTypeError(
+            f"must be >= 1, got {value} (this is a credit cap; 0 and negative "
+            "values would spend more credits, not fewer)"
+        )
+    return value
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="nansen_skill_cli",
@@ -121,10 +142,10 @@ def main():
     overlay.add_argument("--top-n", type=int, default=None)
     # Defaults come from the constants themselves so the help text can never
     # drift from the actual value again.
-    overlay.add_argument("--max-wallets", type=int, default=DEFAULT_MAX_WALLETS,
+    overlay.add_argument("--max-wallets", type=_positive_int, default=DEFAULT_MAX_WALLETS,
                           help="Hard cap on leaders enriched this run "
                                f"(credit guard, default {DEFAULT_MAX_WALLETS})")
-    overlay.add_argument("--max-calls", type=int, default=DEFAULT_MAX_CALLS_PER_RUN,
+    overlay.add_argument("--max-calls", type=_positive_int, default=DEFAULT_MAX_CALLS_PER_RUN,
                           help="Hard cap on Nansen calls this run "
                                f"(credit guard, default {DEFAULT_MAX_CALLS_PER_RUN})")
     overlay.add_argument("--live", action="store_true",
@@ -138,7 +159,7 @@ def main():
     )
     insider.add_argument("--market-id", nargs="*", default=None,
                           help="Market IDs to scan (default: auto-discover top markets)")
-    insider.add_argument("--top-markets", type=int, default=10)
+    insider.add_argument("--top-markets", type=_positive_int, default=10)
     insider.add_argument("--live", action="store_true",
                           help="NOT SUPPORTED YET — prints why and exits nonzero")
     insider.set_defaults(func=_cmd_insider_scan)

--- a/skills/nansen-copytrader-overlay/scripts/smoke_test.py
+++ b/skills/nansen-copytrader-overlay/scripts/smoke_test.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Core-flow smoke test against the live Nansen API over HTTPS.
+
+Proves the ported adapter works end-to-end without the `nansen` CLI:
+account -> pnl-by-market (primary signal) -> address-summary (secondary
+refinement) -> overlay ranking.
+
+This SPENDS CREDITS. It is deliberately tiny — one market, two wallets,
+a hard eight-call ceiling — so it costs single-digit credits per run.
+Reads NANSEN_API_KEY from the environment; never prints it.
+
+    export NANSEN_API_KEY=...
+    python3 scripts/smoke_test.py --market-id 2063134
+
+Output is a markdown transcript on stdout. Addresses are public on-chain
+identifiers and are left intact; nothing else about the account is echoed
+beyond plan name and credit balance.
+"""
+
+import argparse
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import nansen_adapter as na
+import nansen_copytrader_overlay_general as og
+
+MAX_CALLS = 8
+MAX_WALLETS = 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--market-id", default="2063134",
+                    help="Polymarket market_id to smoke-test against")
+    args = ap.parse_args()
+
+    if not os.environ.get("NANSEN_API_KEY"):
+        print("NANSEN_API_KEY is not set — refusing to run.", file=sys.stderr)
+        return 2
+
+    out = print
+    out(f"# Nansen core-flow smoke test\n")
+    out(f"- Run at: {datetime.datetime.now(datetime.timezone.utc).isoformat()}")
+    out(f"- Market: `{args.market_id}`")
+    out(f"- Transport: direct HTTPS to `{na.NANSEN_API_BASE}` (stdlib urllib, no CLI)")
+    out(f"- Caps: max_calls={MAX_CALLS}, max_wallets={MAX_WALLETS}\n")
+
+    # 1. account — free and uncounted, so this never costs anything.
+    acct = na.account()
+    out("## 1. `GET /account` (free, uncounted)\n")
+    out(f"```\nplan={acct.get('plan')!r} credits_remaining={acct.get('credits_remaining')}\n```\n")
+    start_credits = acct.get("credits_remaining")
+
+    guard = na.CreditGuard(max_calls=MAX_CALLS)
+
+    # 2. pnl-by-market — the primary signal.
+    out("## 2. `POST prediction-market/pnl-by-market` (primary signal)\n")
+    rows = na.pnl_by_market(args.market_id, limit=10, guard=guard)
+    out(f"Returned **{len(rows)} rows**. Top 3 by PnL:\n")
+    out("| # | proxy | owner | total_pnl_usd | net_buy_cost_usd | roi |")
+    out("|---|---|---|---|---|---|")
+    for i, r in enumerate(rows[:3], 1):
+        owner = na.owner_address_from_row(r) or "_(placeholder `0x`)_"
+        roi = na.compute_roi(r.get("net_buy_cost_usd", 0.0),
+                             r.get("total_pnl_usd", 0.0))
+        out(f"| {i} | `{r.get('address', '')}` | `{owner}` | "
+            f"{r.get('total_pnl_usd')} | {r.get('net_buy_cost_usd')} | {roi} |")
+    out("")
+
+    placeholders = sum(1 for r in rows if not na.owner_address_from_row(r))
+    out(f"Owner-address coverage this page: **{len(rows) - placeholders}/{len(rows)}** "
+        f"usable ({placeholders} carried the placeholder `0x`).\n")
+
+    if not rows:
+        out("No rows returned — cannot continue the flow.")
+        return 1
+
+    # 3. address-summary on the top wallet — keyed by PROXY, not owner.
+    top_proxy = rows[0].get("address", "")
+    out("## 3. `POST prediction-market/address-summary` (proxy-keyed)\n")
+    summary = na.address_summary(top_proxy, guard=guard)
+    out(f"Called with the **proxy** address `{top_proxy}`:\n")
+    out("```")
+    for k in ("address", "markets_traded", "markets_won", "resolved_count",
+              "win_rate", "realized_pnl_usd", "total_pnl_usd"):
+        out(f"{k} = {summary.get(k)!r}")
+    out("```\n")
+
+    # 4. the overlay itself, over the same guard so the cap is shared.
+    out("## 4. Overlay ranking (`enrich_leaders`)\n")
+    leaders = [
+        {"proxy_address": r.get("address", ""),
+         "owner_address": na.owner_address_from_row(r),
+         "wallet_score": 1.0}
+        for r in rows[:MAX_WALLETS]
+    ]
+    enriched = og.enrich_leaders(
+        leaders, market_id=args.market_id,
+        max_wallets=MAX_WALLETS, guard=guard,
+    )
+    out("| proxy | original | adjusted | reason_tags |")
+    out("|---|---|---|---|")
+    for lead in enriched:
+        tags = ", ".join(lead.get("reason_tags", [])) or "—"
+        out(f"| `{lead.get('proxy_address', '')}` | {lead.get('wallet_score')} | "
+            f"{lead.get('adjusted_score')} | {tags} |")
+    out("")
+
+    # 5. credit accounting.
+    end = na.account()
+    out("## 5. Credit accounting\n")
+    out("```")
+    out(f"credits before : {start_credits}")
+    out(f"credits after  : {end.get('credits_remaining')}")
+    if isinstance(start_credits, int) and isinstance(end.get("credits_remaining"), int):
+        out(f"spent          : {start_credits - end['credits_remaining']}")
+    out(f"guard calls    : {guard.calls_made}/{MAX_CALLS}")
+    out("```")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nansen-copytrader-overlay/tests/fixtures/historical_balances_new_wallet.json
+++ b/skills/nansen-copytrader-overlay/tests/fixtures/historical_balances_new_wallet.json
@@ -1,0 +1,7 @@
+[
+  {
+    "block_timestamp": "2026-06-28T10:00:00Z",
+    "value_usd": 15000.0,
+    "token_symbol": "USDC"
+  }
+]

--- a/skills/nansen-copytrader-overlay/tests/fixtures/pnl_by_address.json
+++ b/skills/nansen-copytrader-overlay/tests/fixtures/pnl_by_address.json
@@ -1,0 +1,38 @@
+[
+  {
+    "market_id": "101",
+    "question": "Will Brazil win the 2026 World Cup?",
+    "side_held": "yes",
+    "net_buy_cost_usd": 1000.0,
+    "unrealized_value_usd": 0.0,
+    "total_pnl_usd": 850.0,
+    "market_resolved": true
+  },
+  {
+    "market_id": "102",
+    "question": "Will France win Group D?",
+    "side_held": "yes",
+    "net_buy_cost_usd": 500.0,
+    "unrealized_value_usd": 0.0,
+    "total_pnl_usd": 400.0,
+    "market_resolved": true
+  },
+  {
+    "market_id": "103",
+    "question": "Bitcoin above $100k by end of 2026?",
+    "side_held": "no",
+    "net_buy_cost_usd": 200.0,
+    "unrealized_value_usd": 0.0,
+    "total_pnl_usd": -200.0,
+    "market_resolved": true
+  },
+  {
+    "market_id": "104",
+    "question": "Will the US win the FIFWC knockout round?",
+    "side_held": "yes",
+    "net_buy_cost_usd": 300.0,
+    "unrealized_value_usd": 120.0,
+    "total_pnl_usd": 0.0,
+    "market_resolved": false
+  }
+]

--- a/skills/nansen-copytrader-overlay/tests/fixtures/trades_by_address.json
+++ b/skills/nansen-copytrader-overlay/tests/fixtures/trades_by_address.json
@@ -1,0 +1,38 @@
+[
+  {
+    "timestamp": "2026-06-01T10:00:00Z",
+    "market_id": "101",
+    "market_question": "Will Brazil win the 2026 World Cup?",
+    "side": "yes",
+    "price": 0.35,
+    "size": 2857.14,
+    "usdc_value": 1000.0,
+    "taker_action": "buy",
+    "buyer": "0xABC123def456",
+    "seller": "0xSELLER1"
+  },
+  {
+    "timestamp": "2026-06-10T12:00:00Z",
+    "market_id": "102",
+    "market_question": "Will France win Group D?",
+    "side": "yes",
+    "price": 0.60,
+    "size": 833.33,
+    "usdc_value": 500.0,
+    "taker_action": "buy",
+    "buyer": "0xABC123def456",
+    "seller": "0xSELLER2"
+  },
+  {
+    "timestamp": "2026-06-15T09:00:00Z",
+    "market_id": "103",
+    "market_question": "Bitcoin above $100k by end of 2026?",
+    "side": "no",
+    "price": 0.55,
+    "size": 363.64,
+    "usdc_value": 200.0,
+    "taker_action": "buy",
+    "buyer": "0xABC123def456",
+    "seller": "0xSELLER3"
+  }
+]

--- a/skills/nansen-copytrader-overlay/tests/fixtures/trades_by_market_live.json
+++ b/skills/nansen-copytrader-overlay/tests/fixtures/trades_by_market_live.json
@@ -1,0 +1,50 @@
+[
+  {
+    "timestamp": "2026-07-01T22:00:00Z",
+    "market_id": "999",
+    "market_question": "Will Argentina win the 2026 World Cup Semi-Final?",
+    "side": "yes",
+    "price": 0.82,
+    "size": 6097.56,
+    "usdc_value": 5000.0,
+    "taker_action": "buy",
+    "buyer": "0xSUSPICIOUS001",
+    "seller": "0xSELLER_MM"
+  },
+  {
+    "timestamp": "2026-07-01T22:10:00Z",
+    "market_id": "999",
+    "market_question": "Will Argentina win the 2026 World Cup Semi-Final?",
+    "side": "yes",
+    "price": 0.83,
+    "size": 3614.46,
+    "usdc_value": 3000.0,
+    "taker_action": "buy",
+    "buyer": "0xSUSPICIOUS001",
+    "seller": "0xSELLER_MM"
+  },
+  {
+    "timestamp": "2026-07-01T22:20:00Z",
+    "market_id": "999",
+    "market_question": "Will Argentina win the 2026 World Cup Semi-Final?",
+    "side": "yes",
+    "price": 0.84,
+    "size": 2380.95,
+    "usdc_value": 2000.0,
+    "taker_action": "buy",
+    "buyer": "0xSUSPICIOUS001",
+    "seller": "0xSELLER_MM"
+  },
+  {
+    "timestamp": "2026-06-30T15:00:00Z",
+    "market_id": "999",
+    "market_question": "Will Argentina win the 2026 World Cup Semi-Final?",
+    "side": "no",
+    "price": 0.18,
+    "size": 1000.0,
+    "usdc_value": 180.0,
+    "taker_action": "buy",
+    "buyer": "0xNORMAL_BUYER",
+    "seller": "0xSELLER_MM"
+  }
+]

--- a/skills/nansen-copytrader-overlay/tests/test_live_insider_scan.py
+++ b/skills/nansen-copytrader-overlay/tests/test_live_insider_scan.py
@@ -1,0 +1,323 @@
+"""Tests for nansen_live_insider_scan.py — mocked, no Nansen calls."""
+
+import json
+import sys
+import os
+from datetime import datetime, timezone, timedelta
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from unittest.mock import patch
+import pytest
+
+import nansen_live_insider_scan as lis
+from nansen_live_insider_scan import InsiderSignal, SUSPICION_THRESHOLD, HIGH_RISK_THRESHOLD
+
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+def load_fixture(name):
+    with open(os.path.join(FIXTURE_DIR, name)) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# _score_wallet
+# ---------------------------------------------------------------------------
+
+def test_score_wallet_suspicious_new_wallet():
+    """NEW_WALLET + SINGLE_MARKET + HIGH_YES_ENTRY + LARGE_POSITION + RAPID_ACCUMULATION = high score."""
+    market_trades = load_fixture("trades_by_market_live.json")
+    balances = load_fixture("historical_balances_new_wallet.json")
+
+    # The fixture wallet 0xSUSPICIOUS001 has:
+    # - 3 trades in the last 24h (RAPID_ACCUMULATION)
+    # - entry prices 0.82, 0.83, 0.84 (HIGH_YES_ENTRY)
+    # - total ~$10k position (LARGE_POSITION)
+    single_market_trades = [
+        t for t in market_trades if t.get("buyer") == "0xSUSPICIOUS001"
+    ]
+
+    with patch("nansen_live_insider_scan.trades_by_address", return_value=single_market_trades), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=balances), \
+         patch("time.sleep"):
+
+        signal = lis._score_wallet("0xSUSPICIOUS001", "999", market_trades, dry_run=True)
+
+    assert signal is not None
+    assert signal.suspicion_score >= SUSPICION_THRESHOLD
+    assert signal.side == "yes"
+    assert signal.dry_run is True
+    assert "HIGH_YES_ENTRY" in signal.reason_tags
+
+
+def test_score_wallet_new_wallet_flag():
+    """Wallet funded 2 days ago → NEW_WALLET flag."""
+    two_days_ago = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    balances = [{"block_timestamp": two_days_ago, "value_usd": 5000.0, "token_symbol": "USDC"}]
+
+    market_trades = [
+        {
+            "timestamp": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+            "market_id": "888",
+            "market_question": "Will X happen?",
+            "side": "yes",
+            "price": 0.80,
+            "size": 1000.0,
+            "usdc_value": 800.0,
+            "taker_action": "buy",
+            "buyer": "0xNEWBUYER",
+            "seller": "0xSELLER",
+        }
+    ]
+
+    with patch("nansen_live_insider_scan.trades_by_address", return_value=market_trades), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=balances), \
+         patch("time.sleep"):
+
+        signal = lis._score_wallet("0xNEWBUYER", "888", market_trades, dry_run=True)
+
+    # Score = NEW_WALLET(3) + SINGLE_MARKET(3) + HIGH_YES_ENTRY(2) = 8 ≥ threshold
+    assert signal is not None
+    assert "NEW_WALLET" in signal.reason_tags
+
+
+def test_score_wallet_known_entity_discount():
+    """Address on the known-entity allowlist reduces suspicion score."""
+    recent_ts = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    recent_ts2 = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    recent_ts3 = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+
+    market_trades = [
+        {"timestamp": recent_ts, "market_id": "777", "market_question": "Q",
+         "side": "yes", "price": 0.82, "size": 1000, "usdc_value": 820,
+         "taker_action": "buy", "buyer": "0xFUND", "seller": "0xS"},
+        {"timestamp": recent_ts2, "market_id": "777", "market_question": "Q",
+         "side": "yes", "price": 0.83, "size": 600, "usdc_value": 498,
+         "taker_action": "buy", "buyer": "0xFUND", "seller": "0xS"},
+        {"timestamp": recent_ts3, "market_id": "777", "market_question": "Q",
+         "side": "yes", "price": 0.84, "size": 357, "usdc_value": 300,
+         "taker_action": "buy", "buyer": "0xFUND", "seller": "0xS"},
+    ]
+    old_balance = [{"block_timestamp": "2020-01-01T00:00:00Z", "value_usd": 1000000.0,
+                    "token_symbol": "USDC"}]
+
+    with patch("nansen_live_insider_scan.trades_by_address", return_value=market_trades), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=old_balance), \
+         patch("nansen_live_insider_scan.KNOWN_ENTITY_ADDRESSES", {"0xfund"}), \
+         patch("time.sleep"):
+
+        signal = lis._score_wallet("0xFUND", "777", market_trades, dry_run=True)
+
+    if signal:
+        assert "KNOWN_ENTITY" in signal.reason_tags
+        assert signal.has_known_label is True
+
+
+def test_score_wallet_below_threshold_returns_none():
+    """Normal wallet with low entry and small position should not be flagged."""
+    market_trades = [
+        {
+            "timestamp": "2026-06-15T10:00:00Z",
+            "market_id": "555",
+            "market_question": "Normal market Q",
+            "side": "yes",
+            "price": 0.45,
+            "size": 100.0,
+            "usdc_value": 45.0,
+            "taker_action": "buy",
+            "buyer": "0xNORMAL",
+            "seller": "0xS",
+        }
+    ]
+    old_wallet_balance = [
+        {"block_timestamp": "2024-01-01T00:00:00Z", "value_usd": 1000.0, "token_symbol": "USDC"}
+    ]
+    many_markets = [
+        {"market_id": str(i), "market_question": f"Q{i}", "side": "yes",
+         "price": 0.5, "size": 10, "usdc_value": 5, "taker_action": "buy",
+         "buyer": "0xNORMAL", "seller": "0xS", "timestamp": "2026-01-01T00:00:00Z"}
+        for i in range(20)
+    ]
+
+    with patch("nansen_live_insider_scan.trades_by_address", return_value=many_markets), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=old_wallet_balance), \
+         patch("time.sleep"):
+
+        signal = lis._score_wallet("0xNORMAL", "555", market_trades, dry_run=True)
+
+    # Score: no age flag (old wallet) + no market focus flag (20 markets) + no high entry
+    # + no large position + no rapid accumulation = 0
+    assert signal is None
+
+
+# ---------------------------------------------------------------------------
+# dry_run gate
+# ---------------------------------------------------------------------------
+
+def test_dry_run_signals_always_have_dry_run_true():
+    """dry_run=True signals are emitted but callers must not act on them."""
+    market_trades = load_fixture("trades_by_market_live.json")
+    balances = load_fixture("historical_balances_new_wallet.json")
+    single_market = [t for t in market_trades if t.get("buyer") == "0xSUSPICIOUS001"]
+
+    with patch("nansen_live_insider_scan.trades_by_address", return_value=single_market), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=balances), \
+         patch("time.sleep"):
+
+        signal = lis._score_wallet("0xSUSPICIOUS001", "999", market_trades, dry_run=True)
+
+    if signal:
+        assert signal.dry_run is True
+
+
+def test_live_flag_propagates():
+    """When dry_run=False the signal.dry_run is False (caller enables real orders)."""
+    market_trades = load_fixture("trades_by_market_live.json")
+    balances = load_fixture("historical_balances_new_wallet.json")
+    single_market = [t for t in market_trades if t.get("buyer") == "0xSUSPICIOUS001"]
+
+    with patch("nansen_live_insider_scan.trades_by_address", return_value=single_market), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=balances), \
+         patch("time.sleep"):
+
+        signal = lis._score_wallet("0xSUSPICIOUS001", "999", market_trades, dry_run=False)
+
+    if signal:
+        assert signal.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# scan_live_markets
+# ---------------------------------------------------------------------------
+
+def test_scan_live_markets_no_markets_found():
+    with patch("nansen_live_insider_scan.market_screener", return_value=[]), \
+         patch("time.sleep"):
+        signals = lis.scan_live_markets(market_ids=None, dry_run=True)
+    assert signals == []
+
+
+def test_scan_live_markets_explicit_ids():
+    """Providing explicit market_ids skips auto-discovery."""
+    market_trades = load_fixture("trades_by_market_live.json")
+    balances = load_fixture("historical_balances_new_wallet.json")
+
+    def mock_trades_by_address(addr, **kwargs):
+        return [t for t in market_trades if t.get("buyer") == addr]
+
+    with patch("nansen_live_insider_scan.trades_by_market", return_value=market_trades), \
+         patch("nansen_live_insider_scan.trades_by_address", side_effect=mock_trades_by_address), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=balances), \
+         patch("time.sleep"):
+
+        signals = lis.scan_live_markets(market_ids=["999"], dry_run=True, min_suspicion_score=3)
+
+    # Should find 0xSUSPICIOUS001 as suspicious
+    suspicious_addrs = {s.wallet_address for s in signals}
+    assert "0xSUSPICIOUS001" in suspicious_addrs
+
+
+def test_scan_live_markets_sorted_by_score():
+    """Results should be sorted by suspicion_score descending."""
+    market_trades = load_fixture("trades_by_market_live.json")
+    balances = load_fixture("historical_balances_new_wallet.json")
+
+    def mock_trades_by_address(addr, **kwargs):
+        return [t for t in market_trades if t.get("buyer") == addr]
+
+    with patch("nansen_live_insider_scan.trades_by_market", return_value=market_trades), \
+         patch("nansen_live_insider_scan.trades_by_address", side_effect=mock_trades_by_address), \
+         patch("nansen_live_insider_scan.historical_balances", return_value=balances), \
+         patch("time.sleep"):
+
+        signals = lis.scan_live_markets(market_ids=["999"], dry_run=True)
+
+    scores = [s.suspicion_score for s in signals]
+    assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# InsiderSignal.as_dict
+# ---------------------------------------------------------------------------
+
+def test_insider_signal_as_dict_is_serialisable():
+    s = InsiderSignal(
+        market_id="123",
+        market_question="Will X happen?",
+        wallet_address="0xABC",
+        side="yes",
+        confidence=0.75,
+        edge=0.3,
+        suspicion_score=7,
+        reason_tags=["NEW_WALLET", "SINGLE_MARKET"],
+        entry_price=0.82,
+        position_usd=5000.0,
+        wallet_age_days=3.0,
+        distinct_markets_traded=1,
+        has_known_label=False,
+        dry_run=True,
+    )
+    d = s.as_dict()
+    assert d["market_id"] == "123"
+    assert d["side"] == "yes"
+    assert d["dry_run"] is True
+    # Confirm all required keys present
+    for key in ("market_id", "market_question", "wallet_address", "side",
+                 "confidence", "edge", "suspicion_score", "reason_tags",
+                 "entry_price", "position_usd", "dry_run"):
+        assert key in d
+
+
+def test_scan_live_markets_hard_refuses_live_mode():
+    """scan_live_markets(dry_run=False) must hard-raise — this module is
+    experimental until owner/proxy handling and price semantics are
+    confirmed against the live API."""
+    with pytest.raises(lis.LiveTradingNotSupportedError):
+        lis.scan_live_markets(market_ids=["1"], dry_run=False)
+
+
+def test_scan_live_markets_hard_refuses_live_mode_before_any_api_call():
+    """The refusal must happen before any Nansen call — no market_screener,
+    no trades_by_market, nothing — so a --live typo can't spend credits."""
+    with patch("nansen_live_insider_scan.market_screener") as mock_screener, \
+         patch("nansen_live_insider_scan.trades_by_market") as mock_trades:
+        with pytest.raises(lis.LiveTradingNotSupportedError):
+            lis.scan_live_markets(dry_run=False)
+
+    mock_screener.assert_not_called()
+    mock_trades.assert_not_called()
+
+
+def test_live_trading_not_supported_is_a_nansen_error():
+    from nansen_adapter import NansenError
+    assert issubclass(lis.LiveTradingNotSupportedError, NansenError)
+
+
+def test_scan_live_markets_credit_guard_stops_scan_early():
+    """When the shared CreditGuard's budget is exhausted mid-scan, remaining
+    markets are skipped rather than continuing to spend credits."""
+    from nansen_adapter import CreditGuard
+
+    guard = CreditGuard(max_calls=100)
+
+    def raise_on_second_market(market_id, **kwargs):
+        if market_id == "2":
+            raise lis.CreditGuardExceeded("budget exhausted")
+        return []
+
+    with patch("nansen_live_insider_scan.trades_by_market", side_effect=raise_on_second_market), \
+         patch("time.sleep"):
+        signals = lis.scan_live_markets(market_ids=["1", "2", "3"], dry_run=True, guard=guard)
+
+    assert signals == []
+
+
+def test_insider_signal_deterministic():
+    """Same inputs → same signal (no randomness)."""
+    s1 = InsiderSignal(market_id="1", market_question="Q", wallet_address="0xA",
+                       side="yes", confidence=0.5, edge=0.3, suspicion_score=5,
+                       reason_tags=["NEW_WALLET"])
+    s2 = InsiderSignal(market_id="1", market_question="Q", wallet_address="0xA",
+                       side="yes", confidence=0.5, edge=0.3, suspicion_score=5,
+                       reason_tags=["NEW_WALLET"])
+    assert s1.as_dict() == s2.as_dict()

--- a/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
@@ -512,3 +512,21 @@ def test_pnl_by_market_scrubs_owner_placeholder():
 
     assert rows[0]["owner_address"] == ""
     assert rows[0]["address"] == "0xPROXY"
+
+
+# --- Credit-cap validation (Greptile P1, simmer-sdk#306) ------------------
+#
+# A nonpositive budget is never what a caller means, and both caps spend the
+# user's own Nansen credits. Before this guard, CreditGuard(max_calls=0) tripped
+# on the very first request and surfaced as a traceback rather than the tagged
+# CREDIT_GUARD_EXHAUSTED recovery path.
+
+@pytest.mark.parametrize("bad", [0, -1, -40])
+def test_credit_guard_rejects_nonpositive_budget(bad):
+    with pytest.raises(ValueError, match="max_calls must be >= 1"):
+        na.CreditGuard(max_calls=bad)
+
+
+def test_credit_guard_accepts_a_budget_of_one():
+    guard = na.CreditGuard(max_calls=1)
+    assert guard.max_calls == 1

--- a/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
@@ -1,0 +1,514 @@
+"""Tests for nansen_adapter.py — mocked, never calls the real Nansen API."""
+
+import io
+import json
+import sys
+import os
+import urllib.error
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+import nansen_adapter as na
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _fake_api_key():
+    """Every test runs as if NANSEN_API_KEY were set."""
+    with patch("nansen_adapter._api_key", return_value="test-key"):
+        yield
+
+
+def _mock_post(data):
+    """Return a patch target that makes _post return `data`."""
+    return patch("nansen_adapter._post", return_value=data)
+
+
+def _mock_http(payload):
+    """Patch urlopen to return `payload` (a JSON-serialisable object)."""
+    body = json.dumps(payload).encode()
+
+    class _Resp:
+        def read(self):
+            return body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    return patch("urllib.request.urlopen", return_value=_Resp())
+
+
+def _http_error(code, detail=b'{"error":"boom"}'):
+    return urllib.error.HTTPError(
+        url="https://api.nansen.ai/api/v1/x", code=code,
+        msg="err", hdrs=None, fp=io.BytesIO(detail),
+    )
+
+
+# ---------------------------------------------------------------------------
+# pnl_by_market
+# ---------------------------------------------------------------------------
+
+def test_pnl_by_market_normalises_list_response():
+    raw = [
+        {
+            "address": "0xABC",
+            "owner_address": "0xOWNER",
+            "side_held": "YES",
+            "net_buy_cost_usd": 500.0,
+            "unrealized_value_usd": 0.0,
+            "total_pnl_usd": 300.0,
+        }
+    ]
+    with _mock_post(raw):
+        rows = na.pnl_by_market("42")
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["address"] == "0xABC"
+    assert r["side_held"] == "yes"        # normalised to lower
+    assert r["total_pnl_usd"] == 300.0
+
+
+def test_pnl_by_market_normalises_wrapped_response():
+    raw = {"data": [{"address": "0xXYZ", "side_held": "No", "net_buy_cost_usd": 100.0,
+                     "total_pnl_usd": -50.0, "unrealized_value_usd": 0.0}]}
+    with _mock_post(raw):
+        rows = na.pnl_by_market("99")
+
+    assert rows[0]["side_held"] == "no"
+    assert rows[0]["total_pnl_usd"] == -50.0
+
+
+# ---------------------------------------------------------------------------
+# pnl_quality_score
+# ---------------------------------------------------------------------------
+
+def test_quality_score_basic():
+    rows = [
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": 80.0, "question": "Q1"},
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": 90.0, "question": "Q2"},
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": 70.0, "question": "Q3"},
+    ]
+    result = na.pnl_quality_score(rows, min_resolved=3)
+    assert result["win_rate"] == 1.0
+    assert result["avg_roi"] == pytest.approx(0.8, abs=0.01)
+    assert result["resolved_count"] == 3
+    assert result["consistency"] is not None
+    assert 0.0 <= result["consistency"] <= 1.0
+
+
+def test_quality_score_insufficient_history():
+    rows = [
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": 50.0, "question": "Q1"},
+    ]
+    result = na.pnl_quality_score(rows, min_resolved=3)
+    assert result["avg_roi"] is None
+    assert result["resolved_count"] == 1
+
+
+def test_quality_score_no_resolved():
+    rows = [
+        {"market_resolved": False, "net_buy_cost_usd": 100.0, "total_pnl_usd": 0.0, "question": "Q1"},
+    ]
+    result = na.pnl_quality_score(rows)
+    assert result["win_rate"] is None
+    assert result["resolved_count"] == 0
+
+
+def test_quality_score_mixed_wins_losses():
+    rows = [
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": 50.0, "question": "Q1"},
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": -30.0, "question": "Q2"},
+        {"market_resolved": True, "net_buy_cost_usd": 100.0, "total_pnl_usd": 20.0, "question": "Q3"},
+    ]
+    result = na.pnl_quality_score(rows, min_resolved=3)
+    assert result["win_rate"] == pytest.approx(2/3, abs=0.01)
+    assert result["resolved_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# compute_roi
+# ---------------------------------------------------------------------------
+
+def test_compute_roi_positive():
+    assert na.compute_roi(100.0, 50.0) == pytest.approx(0.5)
+
+
+def test_compute_roi_negative():
+    assert na.compute_roi(100.0, -30.0) == pytest.approx(-0.3)
+
+
+def test_compute_roi_zero_cost():
+    assert na.compute_roi(0.0, 100.0) is None
+
+
+def test_compute_roi_negative_cost():
+    assert na.compute_roi(-10.0, 100.0) is None
+
+
+# ---------------------------------------------------------------------------
+# wallet_age_days
+# ---------------------------------------------------------------------------
+
+def test_wallet_age_days_recent():
+    from datetime import datetime, timezone, timedelta
+    three_days_ago = (datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
+    balances = [
+        {"block_timestamp": three_days_ago, "value_usd": 1000.0, "token_symbol": "USDC"}
+    ]
+    age = na.wallet_age_days(balances)
+    assert age is not None
+    assert 2.5 < age < 3.5
+
+
+def test_wallet_age_days_no_funded_records():
+    balances = [
+        {"block_timestamp": "2026-01-01T00:00:00Z", "value_usd": 0.0, "token_symbol": "USDC"}
+    ]
+    age = na.wallet_age_days(balances)
+    assert age is None
+
+
+def test_wallet_age_days_empty():
+    assert na.wallet_age_days([]) is None
+
+
+# ---------------------------------------------------------------------------
+# _post transport: auth, retry, status-code mapping
+# ---------------------------------------------------------------------------
+
+def test_post_returns_parsed_json():
+    with _mock_http({"data": [{"foo": "bar"}]}):
+        data = na._post("prediction-market/address-summary", {"address": "0x1"})
+
+    assert data == {"data": [{"foo": "bar"}]}
+
+
+def test_post_sends_apikey_header_and_browser_ua():
+    """Regression: the header must be `apiKey`, and the UA must not be urllib's
+    default — Cloudflare 403s the default, and a missing key returns a 402."""
+    captured = {}
+
+    class _Resp:
+        def read(self): return b'{"data": []}'
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["headers"] = dict(req.headers)
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return _Resp()
+
+    with patch("urllib.request.urlopen", _fake_urlopen):
+        na._post("prediction-market/address-summary", {"address": "0xabc"})
+
+    # urllib title-cases header keys
+    assert captured["headers"]["Apikey"] == "test-key"
+    assert "Authorization" not in captured["headers"]
+    assert "X-api-key" not in captured["headers"]
+    assert "Mozilla/5.0" in captured["headers"]["User-agent"]
+    assert captured["method"] == "POST"
+    assert captured["url"].startswith("https://api.nansen.ai/api/v1/")
+    assert captured["body"] == {"address": "0xabc"}
+
+
+def test_post_without_api_key_raises_auth_error_before_sending():
+    """A bare request comes back as a confusing 402 x402 paywall, so fail early."""
+    with patch("nansen_adapter._api_key", return_value=""):
+        with patch("urllib.request.urlopen") as mock_open:
+            with pytest.raises(na.NansenAuthError):
+                na._post("prediction-market/address-summary", {"address": "0x1"})
+    mock_open.assert_not_called()
+
+
+@pytest.mark.parametrize("code,exc", [
+    (401, na.NansenAuthError),
+    (402, na.NansenPaymentRequiredError),
+    (403, na.NansenAccessDeniedError),
+    (404, na.NansenRouteError),
+    (422, na.NansenRequestError),
+])
+def test_post_maps_status_codes_to_distinct_exceptions(code, exc):
+    """401/402/403/404 mean four different things and must not be conflated."""
+    with patch("urllib.request.urlopen", side_effect=_http_error(code)):
+        with pytest.raises(exc):
+            na._post("prediction-market/address-summary", {"address": "0x1"})
+
+
+@pytest.mark.parametrize("code", [401, 402, 403, 404, 422])
+def test_post_does_not_retry_hard_failures(code):
+    """Retrying these cannot change the outcome — and 403 would burn credits."""
+    with patch("urllib.request.urlopen", side_effect=_http_error(code)) as mock_open:
+        with patch("time.sleep"):
+            with pytest.raises(na.NansenError):
+                na._post("prediction-market/address-summary", {"address": "0x1"}, retries=3)
+
+    assert mock_open.call_count == 1
+
+
+def test_post_retries_transient_5xx():
+    with patch("urllib.request.urlopen", side_effect=_http_error(500)) as mock_open:
+        with patch("time.sleep"):  # skip backoff delay in tests
+            with pytest.raises(na.NansenError):
+                na._post("prediction-market/address-summary", {"address": "0x1"}, retries=2)
+
+    assert mock_open.call_count == 2
+
+
+def test_payment_required_is_not_an_access_problem():
+    """402 means the request went out unauthenticated, NOT that quota ran out."""
+    assert not issubclass(na.NansenPaymentRequiredError, na.NansenAccessDeniedError)
+    assert not issubclass(na.NansenAccessDeniedError, na.NansenPaymentRequiredError)
+
+
+def test_credits_exhausted_name_is_a_backcompat_alias():
+    """The old name asserted a cause the API never reports; keep it working
+    but make sure it is the same ambiguous 403 class."""
+    assert na.NansenCreditsExhaustedError is na.NansenAccessDeniedError
+
+
+def test_no_profiler_labels_wrapper():
+    """Deliberately absent: unverified endpoint we've decided not to use.
+    See README limitation 10 before re-adding."""
+    assert not hasattr(na, "profiler_labels")
+
+
+def test_account_is_a_free_get_and_takes_no_guard():
+    """GET /account reports plan + remaining credits and must not be billed
+    against a CreditGuard — it's the tool for telling a 403 apart."""
+    captured = {}
+
+    class _Resp:
+        def read(self): return b'{"plan": "free", "credits_remaining": 27}'
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["method"] = req.get_method()
+        captured["url"] = req.full_url
+        captured["data"] = req.data
+        return _Resp()
+
+    with patch("urllib.request.urlopen", _fake_urlopen):
+        result = na.account()
+
+    assert result == {"plan": "free", "credits_remaining": 27}
+    assert captured["method"] == "GET"
+    assert captured["data"] is None
+    assert captured["url"].endswith("/account")
+
+
+# ---------------------------------------------------------------------------
+# CreditGuard
+# ---------------------------------------------------------------------------
+
+def test_credit_guard_raises_when_budget_exhausted():
+    guard = na.CreditGuard(max_calls=1)
+
+    with _mock_http({"data": [{"a": 1}]}):
+        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        with pytest.raises(na.CreditGuardExceeded):
+            na._post("prediction-market/pnl-by-market", {"market_id": "2"}, guard=guard)
+
+
+def test_credit_guard_exceeded_is_a_nansen_error():
+    assert issubclass(na.CreditGuardExceeded, na.NansenError)
+
+
+def test_credit_guard_cache_hit_does_not_consume_budget():
+    guard = na.CreditGuard(max_calls=1)
+
+    with _mock_http({"data": [{"a": 1}]}) as mock_open:
+        first = na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        second = na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+
+    assert first == second == {"data": [{"a": 1}]}
+    assert mock_open.call_count == 1  # only one real HTTP call
+
+
+def test_credit_guard_cache_key_includes_body():
+    """Same path, different body must not collide in the cache."""
+    guard = na.CreditGuard(max_calls=5)
+
+    with _mock_http({"data": []}) as mock_open:
+        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        na._post("prediction-market/pnl-by-market", {"market_id": "2"}, guard=guard)
+
+    assert mock_open.call_count == 2
+    assert guard.calls_made == 2
+
+
+def test_credit_guard_cache_expires_after_ttl():
+    guard = na.CreditGuard(max_calls=5, cache_ttl_s=0.0)  # expire immediately
+
+    with _mock_http({"data": [{"a": 1}]}) as mock_open:
+        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+
+    assert mock_open.call_count == 2
+
+
+def test_credit_guard_no_guard_means_unbounded_default():
+    """Backward compatible: guard=None (the default) never raises/caches."""
+    with _mock_http({"data": [{"a": 1}]}) as mock_open:
+        na._post("prediction-market/pnl-by-market", {"market_id": "1"})
+        na._post("prediction-market/pnl-by-market", {"market_id": "1"})
+
+    assert mock_open.call_count == 2  # no cache without a guard
+
+
+# ---------------------------------------------------------------------------
+# address_summary
+# ---------------------------------------------------------------------------
+
+# Verified live payload — see artifacts/nansen/address_summary_raw.json.
+VERIFIED_ADDRESS_SUMMARY = {
+    "pagination": {"page": 1, "per_page": 10, "is_last_page": True},
+    "data": [{
+        "address": "0xac4a1fabdac2438d6afa2a9e8e83845310a0bf1e",
+        "first_seen": "2026-02-23",
+        "wallet_age_days": 154,
+        "realized_pnl_usd": 12766.979439999992,
+        "unrealized_pnl_usd": 243807.194637681,
+        "total_pnl_usd": 256574.17407768097,
+        "markets_won": 2541,
+        "markets_traded": 6375,
+        "win_rate": 0.39858823529411763,
+        "p2p_tokens_sent": 7943718.163580999,
+        "p2p_tokens_received": 9259098.775497003,
+    }],
+}
+
+
+def test_address_summary_normalises_verified_live_shape():
+    with _mock_post(VERIFIED_ADDRESS_SUMMARY):
+        result = na.address_summary("0xac4a1fabdac2438d6afa2a9e8e83845310a0bf1e")
+
+    assert result["win_rate"] == pytest.approx(0.3986, abs=1e-4)
+    assert result["markets_traded"] == 6375
+    assert result["markets_won"] == 2541
+    assert result["wallet_age_days"] == 154
+    assert result["first_seen"] == "2026-02-23"
+    assert result["total_pnl_usd"] == pytest.approx(256574.17, abs=0.01)
+    assert result["realized_pnl_usd"] == pytest.approx(12766.98, abs=0.01)
+    assert result["p2p_tokens_received"] == pytest.approx(9259098.78, abs=0.01)
+
+
+def test_address_summary_resolved_count_aliases_markets_traded():
+    """Callers gate history depth on resolved_count; this endpoint only
+    reports markets_traded, so the alias must track it."""
+    with _mock_post(VERIFIED_ADDRESS_SUMMARY):
+        result = na.address_summary("0xPROXY")
+
+    assert result["resolved_count"] == 6375
+
+
+def test_address_summary_avg_roi_not_offered_by_endpoint():
+    with _mock_post(VERIFIED_ADDRESS_SUMMARY):
+        assert na.address_summary("0xPROXY")["avg_roi"] is None
+
+
+def test_address_summary_posts_to_prediction_market_route():
+    captured = {}
+
+    def _fake_post(path, body, **kw):
+        captured["path"] = path
+        captured["body"] = body
+        return VERIFIED_ADDRESS_SUMMARY
+
+    with patch("nansen_adapter._post", _fake_post):
+        na.address_summary("0xPROXY")
+
+    assert captured["path"] == "prediction-market/address-summary"
+    assert captured["body"] == {"address": "0xPROXY"}
+
+
+def test_address_summary_handles_empty_data():
+    with _mock_post({"pagination": {}, "data": []}):
+        result = na.address_summary("0xPROXY")
+
+    assert result["resolved_count"] == 0
+    assert result["win_rate"] is None
+    assert result["address"] == "0xPROXY"
+
+
+# ---------------------------------------------------------------------------
+# get_proxy_address / get_owner_address
+# ---------------------------------------------------------------------------
+
+def test_get_proxy_address_prefers_explicit_field():
+    leader = {"proxy_address": "0xPROXY", "address": "0xLEGACY"}
+    assert na.get_proxy_address(leader) == "0xPROXY"
+
+
+def test_get_proxy_address_falls_back_to_legacy_address():
+    leader = {"address": "0xLEGACY"}
+    assert na.get_proxy_address(leader) == "0xLEGACY"
+
+
+def test_get_proxy_address_missing_returns_empty_string():
+    assert na.get_proxy_address({}) == ""
+
+
+def test_get_owner_address_no_fallback():
+    """Unlike proxy, owner address has no fallback — profiler data keyed by
+    the wrong wallet type silently returns the wrong wallet's history."""
+    leader = {"address": "0xLEGACY", "proxy_address": "0xPROXY"}
+    assert na.get_owner_address(leader) == ""
+
+
+def test_get_owner_address_explicit_field():
+    leader = {"owner_address": "0xOWNER"}
+    assert na.get_owner_address(leader) == "0xOWNER"
+
+
+def test_get_owner_address_reads_from_leaderboard_row():
+    """owner_address rides along free on every pnl_by_market row, so callers
+    shouldn't have to pass it in."""
+    leader = {"proxy_address": "0xPROXY"}
+    row = {"address": "0xPROXY", "owner_address": "0xOWNERFROMROW"}
+    assert na.get_owner_address(leader, row) == "0xOWNERFROMROW"
+
+
+def test_get_owner_address_prefers_explicit_over_row():
+    leader = {"owner_address": "0xEXPLICIT"}
+    row = {"owner_address": "0xFROMROW"}
+    assert na.get_owner_address(leader, row) == "0xEXPLICIT"
+
+
+@pytest.mark.parametrize("placeholder", [
+    "0x", "0X", "0x0", "0x0000000000000000000000000000000000000000", "", None,
+])
+def test_owner_address_placeholders_treated_as_absent(placeholder):
+    """~60% of live pnl_by_market rows carry "0x" rather than a real owner.
+    Passing that to a profiler endpoint queries a nonexistent wallet and
+    silently returns empty history, so it must resolve to ""."""
+    assert na.owner_address_from_row({"owner_address": placeholder}) == ""
+    assert na.get_owner_address({}, {"owner_address": placeholder}) == ""
+
+
+def test_owner_address_from_row_returns_real_address():
+    row = {"owner_address": "0xf59dbfaf900afab856fe71f6ca241d5f1d03f10d"}
+    assert na.owner_address_from_row(row) == "0xf59dbfaf900afab856fe71f6ca241d5f1d03f10d"
+
+
+def test_pnl_by_market_scrubs_owner_placeholder():
+    raw = {"data": [{"address": "0xPROXY", "owner_address": "0x",
+                     "side_held": "Yes", "net_buy_cost_usd": 1.0,
+                     "total_pnl_usd": 2.0, "unrealized_value_usd": 0.0}]}
+    with _mock_post(raw):
+        rows = na.pnl_by_market("1")
+
+    assert rows[0]["owner_address"] == ""
+    assert rows[0]["address"] == "0xPROXY"

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
@@ -304,3 +304,27 @@ def test_enrich_leaders_top_n():
 
     assert len(result) == 3
     assert result[0]["adjusted_rank"] == 1
+
+
+# --- max_wallets cap validation (Greptile P1, simmer-sdk#306) -------------
+#
+# `if max_wallets and len(leaders) > max_wallets` made 0 falsy, so the cap
+# branch was skipped and EVERY leader got enriched; -1 became a slice bound
+# (ranked[:-1]), enriching all but the last. Both spent MORE of the caller's
+# credits than the number they passed. Reproduced by Greptile against the real
+# enrich_leaders path: 6 leaders + max_wallets=0 -> 6 enrichments, -1 -> 5.
+
+@pytest.mark.parametrize("bad", [0, -1, -30])
+def test_enrich_leaders_rejects_nonpositive_max_wallets(bad):
+    leaders = [{"proxy_address": f"0x{i:040x}", "wallet_score": 0.5} for i in range(6)]
+    with pytest.raises(ValueError, match="max_wallets must be >= 1"):
+        og.enrich_leaders(leaders, market_id="1", max_wallets=bad)
+
+
+def test_enrich_leaders_validates_before_spending_any_credits():
+    """The cap check must run before the first Nansen call, not after."""
+    leaders = [{"proxy_address": f"0x{i:040x}", "wallet_score": 0.5} for i in range(6)]
+    guard = CreditGuard(max_calls=40)
+    with pytest.raises(ValueError):
+        og.enrich_leaders(leaders, market_id="1", max_wallets=0, guard=guard)
+    assert guard.calls_made == 0

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
@@ -1,0 +1,306 @@
+"""Tests for nansen_copytrader_overlay_general.py — mocked, no Nansen calls."""
+
+import json
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from unittest.mock import patch
+import pytest
+
+import nansen_copytrader_overlay_general as og
+from nansen_adapter import CreditGuard, CreditGuardExceeded, NansenError
+
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+def load_fixture(name):
+    with open(os.path.join(FIXTURE_DIR, name)) as f:
+        return json.load(f)
+
+
+def market_row(address, net_buy_cost_usd, total_pnl_usd, owner_address=None):
+    return {
+        "address": address,
+        "owner_address": owner_address or f"{address}-OWNER",
+        "side_held": "yes",
+        "net_buy_cost_usd": net_buy_cost_usd,
+        "unrealized_value_usd": 0.0,
+        "total_pnl_usd": total_pnl_usd,
+    }
+
+
+def summary(resolved_count=10, win_rate=0.7, avg_roi=0.5):
+    return {"address": "x", "win_rate": win_rate, "avg_roi": avg_roi,
+            "resolved_count": resolved_count, "total_pnl_usd": 100.0}
+
+
+# ---------------------------------------------------------------------------
+# _compute_quality_score (general/secondary signal)
+# ---------------------------------------------------------------------------
+
+def test_quality_score_high_win_rate():
+    features = {
+        "win_rate": 0.80,
+        "avg_roi": 1.5,
+        "consistency": 0.75,
+        "concentration": 0.30,
+        "resolved_count": 15,
+    }
+    score, tags = og._compute_quality_score(features, distinct_markets=12)
+    assert score > 0.5
+    assert "HIGH_WIN_RATE" in tags
+    assert "STRONG_ROI" in tags
+    assert "CONSISTENT_PNL" in tags
+
+
+def test_quality_score_insufficient_history():
+    features = {
+        "win_rate": 0.80,
+        "avg_roi": 2.0,
+        "consistency": 0.9,
+        "concentration": 0.1,
+        "resolved_count": 2,   # below MIN_RESOLVED_MARKETS=3
+    }
+    score, tags = og._compute_quality_score(features, distinct_markets=5)
+    assert score == 0.0
+    assert any("INSUFFICIENT_HISTORY" in t for t in tags)
+
+
+def test_quality_score_applies_concentration_penalty():
+    features = {
+        "win_rate": 0.70,
+        "avg_roi": 1.0,
+        "consistency": 0.7,
+        "concentration": 0.90,  # very high — should penalise
+        "resolved_count": 10,
+    }
+    score_high_conc, tags_high = og._compute_quality_score(features, distinct_markets=5)
+
+    features_low = {**features, "concentration": 0.10}
+    score_low_conc, tags_low = og._compute_quality_score(features_low, distinct_markets=5)
+
+    assert score_low_conc > score_high_conc
+    assert "HIGH_CONCENTRATION_RISK" in tags_high
+
+
+def test_quality_score_negative_roi_penalised():
+    features = {
+        "win_rate": 0.30,
+        "avg_roi": -0.5,
+        "consistency": 0.5,
+        "concentration": 0.3,
+        "resolved_count": 5,
+    }
+    score, tags = og._compute_quality_score(features, distinct_markets=8)
+    assert "NEGATIVE_AVG_ROI" in tags
+    assert "LOW_WIN_RATE" in tags
+
+
+# ---------------------------------------------------------------------------
+# _compute_market_score (primary, pnl-by-market signal)
+# ---------------------------------------------------------------------------
+
+def test_market_score_profitable_high_roi():
+    row = {"total_pnl_usd": 800.0, "net_buy_cost_usd": 400.0}  # ROI = 2.0
+    score, tags = og._compute_market_score(row, rank=0, leaderboard_size=10)
+    assert score == 1.0
+    assert "MARKET_PROFITABLE" in tags
+    assert "MARKET_TOP_PNL" in tags  # rank 0 of 10 → top 20%
+
+
+def test_market_score_unprofitable():
+    row = {"total_pnl_usd": -100.0, "net_buy_cost_usd": 200.0}
+    score, tags = og._compute_market_score(row, rank=8, leaderboard_size=10)
+    assert score == 0.0
+    assert "MARKET_UNPROFITABLE" in tags
+    assert "MARKET_TOP_PNL" not in tags
+
+
+def test_market_score_no_cost_basis_but_profitable():
+    row = {"total_pnl_usd": 50.0, "net_buy_cost_usd": 0.0}
+    score, tags = og._compute_market_score(row, rank=None, leaderboard_size=0)
+    assert score == 0.6
+    assert "MARKET_PROFITABLE" in tags
+
+
+# ---------------------------------------------------------------------------
+# enrich_leaders — market-first path (market_id given, the primary signal)
+# ---------------------------------------------------------------------------
+
+def test_enrich_leaders_requires_market_id_for_primary_signal():
+    """Without market_id, enrich_leaders falls back to legacy broad-history
+    ranking and logs a warning — market-first is the recommended path."""
+    leaders = [{"proxy_address": "0xABC", "owner_address": "0xABC-OWNER", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_address", return_value=[]), \
+         patch("nansen_copytrader_overlay_general.trades_by_address", return_value=[]), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, dry_run=True)
+
+    assert len(result) == 1
+    assert "market_score" in result[0]["nansen_features"]
+
+
+def test_enrich_leaders_market_first_uses_pnl_by_market_as_primary():
+    market_rows = [
+        market_row("0xGOOD", net_buy_cost_usd=100.0, total_pnl_usd=150.0),  # ROI 1.5
+    ]
+    leaders = [{"proxy_address": "0xGOOD", "owner_address": "0xGOOD-OWNER", "wallet_score": 0.4}]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary", return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    r = result[0]
+    assert r["nansen_features"]["market_score"] is not None
+    assert "MARKET_PROFITABLE" in r["reason_tags"]
+    # address_summary gated out the expensive pull (resolved_count=1 < MIN_RESOLVED_MARKETS)
+    assert any("INSUFFICIENT_HISTORY" in t for t in r["reason_tags"])
+
+
+def test_enrich_leaders_not_in_market_leaderboard_gets_discount_not_blend():
+    market_rows = [market_row("0xOTHER", 100.0, 50.0)]
+    leaders = [{"proxy_address": "0xNOTFOUND", "owner_address": "0xO", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    r = result[0]
+    assert "NOT_IN_MARKET_LEADERBOARD" in r["reason_tags"]
+    assert r["adjusted_score"] == pytest.approx(0.5 * 0.9, abs=0.001)
+
+
+def test_enrich_leaders_missing_proxy_address():
+    leaders = [{"owner_address": "0xOWNER", "wallet_score": 0.5}]  # no proxy_address, no address
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=[]), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    assert "MISSING_PROXY_ADDRESS" in result[0]["reason_tags"]
+    assert result[0]["adjusted_score"] == pytest.approx(0.5 * 0.9, abs=0.001)
+
+
+def test_enrich_leaders_legacy_address_key_used_as_proxy():
+    """`address` is accepted as a legacy alias for proxy_address."""
+    market_rows = [market_row("0xLEGACY", 100.0, 50.0)]
+    leaders = [{"address": "0xLEGACY", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    assert "NOT_IN_MARKET_LEADERBOARD" not in result[0]["reason_tags"]
+    assert "MISSING_PROXY_ADDRESS" not in result[0]["reason_tags"]
+
+
+def test_enrich_leaders_market_fetch_error_keeps_original_score():
+    leaders = [{"proxy_address": "0xABC", "owner_address": "0xO", "wallet_score": 0.7}]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market",
+               side_effect=NansenError("rate limit")), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    r = result[0]
+    assert "MARKET_FETCH_ERROR" in r["reason_tags"]
+    assert r["adjusted_score"] == pytest.approx(0.7 * 0.9, abs=0.001)
+
+
+def test_enrich_leaders_market_ranking_ordering():
+    """Wallet with better market-specific ROI should outrank a wallet with a
+    higher original score but worse in-market PnL."""
+    market_rows = [
+        market_row("0xGOOD", 100.0, 150.0),   # ROI 1.5
+        market_row("0xPOOR", 100.0, -50.0),   # loss
+    ]
+    leaders = [
+        {"proxy_address": "0xGOOD", "owner_address": "0xGO", "wallet_score": 0.4},
+        {"proxy_address": "0xPOOR", "owner_address": "0xPO", "wallet_score": 0.9},
+    ]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary", return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    assert result[0]["proxy_address"] == "0xGOOD"
+    assert result[1]["proxy_address"] == "0xPOOR"
+
+
+def test_enrich_leaders_secondary_signal_pulled_after_summary_passes():
+    market_rows = [market_row("0xGOOD", 100.0, 150.0)]
+    pnl_data = load_fixture("pnl_by_address.json")
+    trades_data = load_fixture("trades_by_address.json")
+    leaders = [{"proxy_address": "0xGOOD", "owner_address": "0xGOOD-OWNER", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary", return_value=summary(resolved_count=10)), \
+         patch("nansen_copytrader_overlay_general.pnl_by_address", return_value=pnl_data), \
+         patch("nansen_copytrader_overlay_general.trades_by_address", return_value=trades_data), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    r = result[0]
+    assert r["nansen_features"]["win_rate"] is not None
+    assert r["nansen_features"]["market_score"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Credit guards — max_wallets and CreditGuard exhaustion
+# ---------------------------------------------------------------------------
+
+def test_enrich_leaders_max_wallets_caps_enrichment():
+    market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(5)]
+    leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}", "wallet_score": i * 0.1}
+               for i in range(5)]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary", return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True, max_wallets=2)
+
+    capped = [r for r in result if "CREDIT_GUARD_MAX_WALLETS" in r["reason_tags"]]
+    assert len(capped) == 3
+
+
+def test_enrich_leaders_credit_guard_exhaustion_keeps_remaining_at_original_score():
+    market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(3)]
+    leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}", "wallet_score": 0.5}
+               for i in range(3)]
+
+    guard = CreditGuard(max_calls=1)  # exhausted after the single pnl_by_market call
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary",
+               side_effect=CreditGuardExceeded("budget spent")), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True, guard=guard)
+
+    exhausted = [r for r in result if "CREDIT_GUARD_EXHAUSTED" in r["reason_tags"]]
+    assert len(exhausted) >= 1
+
+
+# ---------------------------------------------------------------------------
+# top_n
+# ---------------------------------------------------------------------------
+
+def test_enrich_leaders_empty_list():
+    assert og.enrich_leaders([]) == []
+
+
+def test_enrich_leaders_top_n():
+    market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(5)]
+    leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}", "wallet_score": i * 0.1}
+               for i in range(5)]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary", return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True, top_n=3)
+
+    assert len(result) == 3
+    assert result[0]["adjusted_rank"] == 1

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_worldcup.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_worldcup.py
@@ -221,3 +221,16 @@ def test_wc_enrich_leaders_legacy_missing_proxy_address():
     result = wc.enrich_leaders(leaders, dry_run=True)
 
     assert "MISSING_PROXY_ADDRESS" in result[0]["reason_tags"]
+
+
+# --- max_wallets cap validation (simmer-sdk#306) --------------------------
+#
+# Same bug as the general overlay, in the World Cup variant. Greptile only
+# flagged the general one; this file carried the identical
+# `if max_wallets and ...` falsy-zero cap bypass.
+
+@pytest.mark.parametrize("bad", [0, -1, -30])
+def test_enrich_leaders_rejects_nonpositive_max_wallets(bad):
+    leaders = [{"proxy_address": f"0x{i:040x}", "wallet_score": 0.5} for i in range(6)]
+    with pytest.raises(ValueError, match="max_wallets must be >= 1"):
+        wc.enrich_leaders(leaders, market_id="1", max_wallets=bad)

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_worldcup.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_worldcup.py
@@ -1,0 +1,223 @@
+"""Tests for nansen_copytrader_overlay_worldcup.py — mocked, no Nansen calls."""
+
+import json
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from unittest.mock import patch
+import pytest
+
+import nansen_copytrader_overlay_worldcup as wc
+from nansen_adapter import NansenError
+
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+def load_fixture(name):
+    with open(os.path.join(FIXTURE_DIR, name)) as f:
+        return json.load(f)
+
+
+def market_row(address, net_buy_cost_usd, total_pnl_usd, owner_address=None):
+    return {
+        "address": address,
+        "owner_address": owner_address or f"{address}-OWNER",
+        "side_held": "yes",
+        "net_buy_cost_usd": net_buy_cost_usd,
+        "unrealized_value_usd": 0.0,
+        "total_pnl_usd": total_pnl_usd,
+    }
+
+
+def summary(resolved_count=10, win_rate=0.7, avg_roi=0.5):
+    return {"address": "x", "win_rate": win_rate, "avg_roi": avg_roi,
+            "resolved_count": resolved_count, "total_pnl_usd": 100.0}
+
+
+# ---------------------------------------------------------------------------
+# _is_wc_market
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("question,expected", [
+    ("Will Brazil win the 2026 World Cup?", True),
+    ("Will France win Group D at fifwc?", True),
+    ("Will USA advance in WC 2026 knockout?", True),
+    ("Bitcoin above $100k by end of 2026?", False),
+    ("Will Messi score in the Semi-Final 2026?", True),
+    ("Will it rain in London tomorrow?", False),
+    ("fifwc group winner Argentina", True),
+])
+def test_is_wc_market(question, expected):
+    assert wc._is_wc_market(question) == expected
+
+
+# ---------------------------------------------------------------------------
+# _compute_wc_quality_score (secondary signal)
+# ---------------------------------------------------------------------------
+
+def test_wc_quality_score_specialist():
+    general_features = {
+        "win_rate": 0.75,
+        "avg_roi": 1.2,
+        "consistency": 0.70,
+        "concentration": 0.30,
+        "resolved_count": 10,
+    }
+    wc_features = {
+        "wc_resolved_count": 8,   # 80% WC focus → specialist
+        "wc_win_rate": 0.80,
+        "wc_avg_roi": 2.5,
+    }
+    score, tags = wc._compute_wc_quality_score(general_features, wc_features, distinct_markets=10)
+    assert score > 0.5
+    assert "WC_SPECIALIST" in tags
+    assert "WC_HIGH_WIN_RATE" in tags
+
+
+def test_wc_quality_score_novice():
+    general_features = {
+        "win_rate": 0.60,
+        "avg_roi": 0.5,
+        "consistency": 0.6,
+        "concentration": 0.4,
+        "resolved_count": 20,
+    }
+    wc_features = {
+        "wc_resolved_count": 1,   # only 1 WC market → novice
+        "wc_win_rate": 1.0,
+        "wc_avg_roi": 5.0,
+    }
+    score, tags = wc._compute_wc_quality_score(general_features, wc_features, distinct_markets=18)
+    assert "WC_NOVICE" in tags
+
+
+def test_wc_quality_score_insufficient_history():
+    general_features = {
+        "win_rate": None, "avg_roi": None, "consistency": None,
+        "concentration": None, "resolved_count": 1,
+    }
+    wc_features = {"wc_resolved_count": 0, "wc_win_rate": None, "wc_avg_roi": None}
+    score, tags = wc._compute_wc_quality_score(general_features, wc_features, distinct_markets=1)
+    assert score == 0.0
+    assert any("INSUFFICIENT_HISTORY" in t for t in tags)
+
+
+# ---------------------------------------------------------------------------
+# enrich_leaders (WC variant) — market-first path
+# ---------------------------------------------------------------------------
+
+def test_wc_enrich_leaders_empty():
+    assert wc.enrich_leaders([]) == []
+
+
+def test_wc_enrich_leaders_market_first_primary_signal():
+    market_rows = [market_row("0xABC", 100.0, 80.0)]
+    leaders = [{"proxy_address": "0xABC", "owner_address": "0xABC-OWNER", "wallet_score": 0.70}]
+
+    with patch("nansen_copytrader_overlay_worldcup.fetch_market_leaderboard",
+               return_value=({"0xabc": (0, market_rows[0])}, 1)), \
+         patch("nansen_copytrader_overlay_worldcup.address_summary", return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = wc.enrich_leaders(leaders, market_id="999", dry_run=True)
+
+    assert len(result) == 1
+    r = result[0]
+    assert r["dry_run"] is True
+    assert r["nansen_features"]["market_score"] is not None
+    assert "wc_resolved_count" in r["nansen_features"]
+    assert r["adjusted_rank"] == 1
+
+
+def test_wc_enrich_leaders_detects_wc_markets_in_secondary_signal():
+    """WC markets in the fixture should be counted in wc_resolved_count
+    once the address_summary pre-filter passes and the full pull runs."""
+    market_rows = [market_row("0xABC", 100.0, 80.0)]
+    pnl_data = load_fixture("pnl_by_address.json")
+    trades_data = load_fixture("trades_by_address.json")
+
+    # The fixture has "Brazil win the 2026 World Cup" (WC) and
+    # "France win Group D" (WC) and "Bitcoin" (not WC) — both WC markets
+    # are resolved → wc_resolved_count should be 2.
+    leaders = [{"proxy_address": "0xABC", "owner_address": "0xABC-OWNER", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_worldcup.fetch_market_leaderboard",
+               return_value=({"0xabc": (0, market_rows[0])}, 1)), \
+         patch("nansen_copytrader_overlay_worldcup.address_summary", return_value=summary(resolved_count=10)), \
+         patch("nansen_copytrader_overlay_worldcup.pnl_by_address", return_value=pnl_data), \
+         patch("nansen_copytrader_overlay_worldcup.trades_by_address", return_value=trades_data), \
+         patch("time.sleep"):
+        result = wc.enrich_leaders(leaders, market_id="999", dry_run=True)
+
+    assert result[0]["nansen_features"]["wc_resolved_count"] == 2
+
+
+def test_wc_enrich_leaders_not_in_market_leaderboard():
+    leaders = [{"proxy_address": "0xNOTFOUND", "owner_address": "0xO", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_worldcup.fetch_market_leaderboard",
+               return_value=({}, 0)), \
+         patch("time.sleep"):
+        result = wc.enrich_leaders(leaders, market_id="999", dry_run=True)
+
+    assert "NOT_IN_MARKET_LEADERBOARD" in result[0]["reason_tags"]
+    assert result[0]["adjusted_score"] == pytest.approx(0.5 * 0.9, abs=0.001)
+
+
+def test_wc_enrich_leaders_missing_proxy_address():
+    leaders = [{"owner_address": "0xOWNER", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_worldcup.fetch_market_leaderboard",
+               return_value=({}, 0)), \
+         patch("time.sleep"):
+        result = wc.enrich_leaders(leaders, market_id="999", dry_run=True)
+
+    assert "MISSING_PROXY_ADDRESS" in result[0]["reason_tags"]
+
+
+def test_wc_enrich_leaders_market_ordering():
+    """Wallet with better in-market PnL should outrank one with a higher
+    original score but worse market-specific performance."""
+    market_rows = [
+        market_row("0xSPECIALIST", 100.0, 150.0),  # ROI 1.5
+        market_row("0xGENERALIST", 100.0, -20.0),  # loss
+    ]
+    leaderboard = {
+        "0xspecialist": (0, market_rows[0]),
+        "0xgeneralist": (1, market_rows[1]),
+    }
+    leaders = [
+        {"proxy_address": "0xSPECIALIST", "owner_address": "0xS", "wallet_score": 0.4},
+        {"proxy_address": "0xGENERALIST", "owner_address": "0xG", "wallet_score": 0.8},
+    ]
+
+    with patch("nansen_copytrader_overlay_worldcup.fetch_market_leaderboard",
+               return_value=(leaderboard, 2)), \
+         patch("nansen_copytrader_overlay_worldcup.address_summary", return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = wc.enrich_leaders(leaders, market_id="999", dry_run=True)
+
+    assert result[0]["proxy_address"] == "0xSPECIALIST"
+
+
+# ---------------------------------------------------------------------------
+# enrich_leaders (WC variant) — legacy path (no market_id)
+# ---------------------------------------------------------------------------
+
+def test_wc_enrich_leaders_legacy_nansen_error_graceful():
+    leaders = [{"proxy_address": "0xFAIL", "owner_address": "0xFAIL-OWNER", "wallet_score": 0.5}]
+
+    with patch("nansen_copytrader_overlay_worldcup.address_summary",
+               side_effect=NansenError("timeout")), \
+         patch("time.sleep"):
+        result = wc.enrich_leaders(leaders, dry_run=True)
+
+    assert "NANSEN_FETCH_ERROR" in result[0]["reason_tags"]
+
+
+def test_wc_enrich_leaders_legacy_missing_proxy_address():
+    leaders = [{"owner_address": "0xOWNER", "wallet_score": 0.5}]
+
+    result = wc.enrich_leaders(leaders, dry_run=True)
+
+    assert "MISSING_PROXY_ADDRESS" in result[0]["reason_tags"]


### PR DESCRIPTION
Ports [`alyna123t/simmer-nansen-skills`](https://github.com/alyna123t/simmer-nansen-skills) @ tag `v0.1.1-handoff` into the official skills tree.

The skill re-ranks Polymarket copytrading leaders using Nansen's **per-market realised PnL** as the primary signal. Data layer only: it never places a trade, and no code path calls Nansen's smart-money labels (they are not Polymarket-specific, so "smart-money copytrading" framing would overclaim).

## Not publish-ready, and that is deliberate

`clawhub.json` carries `published: false` with a reason. Publishing is a manual `npx clawhub publish` step, so nothing here auto-ships. Before it goes in front of users:

- [ ] **Forward lift unproven** (the blocker). The 50/50 blend, `MIN_RESOLVED_MARKETS` and the tag penalties are reasoned defaults, never fitted or backtested. Closing this means running the overlay through our own backtest/replay infra (SIM-3070).
- [ ] Co-branding copy signed off with Nansen
- [ ] Decide whether Module 3 (insider scan) ships at all, or stays held back

## What was ported as-is

`nansen_adapter.py`, both overlays, the insider scan, the CLI, the smoke test and all 109 tests. **No behaviour changes.** The pinned tag is the review boundary.

## Simmer-side additions

| File | Why |
|---|---|
| `clawhub.json` | `sensitivity: standard`, `published: false` + reason |
| `DISCLAIMER.md` | Research tooling, not financial advice, does not trade, scoring unvalidated |
| `SKILL.md` frontmatter | `author: Simmer`, `credit: "by Alyna Takahashi"`, version `0.1.0` |
| `SKILL.md` Credits section | Nick credited as reviewer (the credit block only holds one name) |
| `SKILL.md` onboarding | `nsn.ai/simmer` referral link + measured credit table + plan guidance |
| `.github/workflows/ci.yml` | no-subprocess guard |

**The no-subprocess guard matters.** The adapter shelled out to the local `nansen` CLI through two rounds of review before this port; her repo added a CI job to lock the fix and dropping it on port would have been a silent safety regression. Her 109 tests are already picked up by the existing `skill-tests` job (verified locally: `ok nansen-copytrader-overlay 109 passed`).

## Credit costs: measured, not taken from docs

Measured against the live API on 2026-08-11:

| Endpoint | Measured | Nansen docs |
|---|---|---|
| `pnl-by-market` | **5** | 1 |
| `top-holders` | 5 | 5 |
| `address-summary`, `pnl-by-address`, `trades-by-address`, `market-screener` | 1 | 1 |
| `account` | 0 | 0 |

Only `pnl-by-market` is mispriced in their docs. A capped run costs ~45 credits, so Nansen's free tier (100 starter + 10/day) covers roughly two runs and Pro (2,000/month) covers ~45. The SKILL.md tells users to budget from the measured table, not Nansen's.

This also explains the 14-credits-over-6-calls figure in her handoff: two 5-credit calls plus four 1-credit ones. No free-plan multiplier exists.

## Attribution

Per Adrian's 2026-07-24 decision: Alyna is the author (`credit` block, `label: by`), Nick is credited as reviewer. `Co-Authored-By` uses her GitHub noreply rather than the local machine email on her commits, so it attributes properly and does not publish a hostname.

## Not ported

`artifacts/` (raw API payloads + smoke transcript) and `HANDOFF.md` stay in her repo at the tag. They are evidence, not runtime, and `HANDOFF.md` is internal.

## Test plan

- `bash scripts/run_skill_tests.sh` → `ok nansen-copytrader-overlay 109 passed`
- `python3 scripts/check-skill-governance.py --all` → this skill passes (the `polymarket-dca-eval-trader` sensitivity error is pre-existing and untouched)
- No-subprocess guard passes against the ported tree
- No key material in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ABNNQ9xcWKz1MR6RnY1wk