### PR TITLE
fix(nansen): CreditGuard tracks credits, not calls (SIM-4486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- **Nansen CreditGuard now tracks credits, not calls.** `CreditGuard` previously capped the number of API calls uniformly, but endpoints cost different amounts: `pnl-by-market` and `top-holders` cost 5 credits each (measured live; Nansen's own docs say 1 and are wrong), while all other prediction-market endpoints cost 1. The guard now accepts `max_credits` (replacing `max_calls`) and deducts the correct per-endpoint cost, so the budget cap means what users expect. The default budget is 45 credits (≈ one 5-credit anchor call plus 40 single-credit enrichment calls). The CLI flag is `--max-credits` (was `--max-calls`).
+
 ### Added
 
 - **Hyperliquid trading with pmxt-constructed orders (SIM-4222).**

--- a/skills/nansen-copytrader-overlay/SKILL.md
+++ b/skills/nansen-copytrader-overlay/SKILL.md
@@ -7,7 +7,7 @@ tags:
   - nansen
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.1.0"
+  version: "0.2.0"
   displayName: Nansen Copytrader Overlay
   difficulty: intermediate
   simmer:

--- a/skills/nansen-copytrader-overlay/SKILL.md
+++ b/skills/nansen-copytrader-overlay/SKILL.md
@@ -58,7 +58,7 @@ export NANSEN_API_KEY=...   # your own Nansen key — sent as the `apiKey` heade
 
 No `nansen` CLI required: calls go straight to `https://api.nansen.ai/api/v1`
 over HTTPS. Bring-your-own-key — every call spends **your** Nansen credits,
-so `--max-wallets` (default 30) and `--max-calls` (default 40) are
+so `--max-wallets` (default 30) and `--max-credits` (default 45) are
 deliberately conservative.
 
 ### Getting a Nansen key
@@ -161,12 +161,19 @@ protected by:
 - **`max_wallets`** (default 30): leaders beyond the cap are never
   enriched — they keep their original score, tagged
   `CREDIT_GUARD_MAX_WALLETS`.
-- **`CreditGuard(max_calls=...)`** (default 40): a hard ceiling on live
-  Nansen calls for the whole run, with a 5-minute TTL cache so re-fetching
-  the same market/wallet doesn't double-spend. If the budget runs out
-  mid-run, remaining leaders are tagged `CREDIT_GUARD_EXHAUSTED` and kept
-  at their original score — the run does not crash, and it does not keep
-  spending.
+- **`CreditGuard(max_credits=...)`** (default 45): a hard ceiling on the
+  **credits** spent across the whole run, with a 5-minute TTL cache so
+  re-fetching the same market/wallet doesn't double-spend. It charges the real
+  per-endpoint cost (5 for `pnl-by-market` and `top-holders`, 1 for the rest),
+  not one unit per call, so the number means what you think it means. If the
+  budget runs out mid-run, remaining leaders are tagged
+  `CREDIT_GUARD_EXHAUSTED` and kept at their original score — the run does not
+  crash, and it does not keep spending.
+- **Preflight balance check**: before spending anything, the CLI calls the free
+  `account()` endpoint. If your balance can't cover even the primary
+  `pnl-by-market` call it refuses outright; if your balance is below the budget
+  it warns and proceeds, since the budget is a cap rather than a prediction and
+  most runs spend well under it. A failed balance check never blocks the run.
 - **No `profiler labels` wrapper exists**, so nothing here can call it
   (100 credits for common labels, 500 for premium). The live insider scan's
   known-entity discount uses a free local allowlist instead.
@@ -175,8 +182,8 @@ protected by:
   `address_summary` win-rate/resolved-count check clears
   `MIN_RESOLVED_MARKETS` first.
 
-Tune both via the CLI (`--max-wallets`, `--max-calls`) or by passing
-`max_wallets=` / `guard=CreditGuard(max_calls=...)` directly.
+Tune both via the CLI (`--max-wallets`, `--max-credits`) or by passing
+`max_wallets=` / `guard=CreditGuard(max_credits=...)` directly.
 
 ## Live insider scan — experimental, dry-run only
 

--- a/skills/nansen-copytrader-overlay/nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/nansen_adapter.py
@@ -379,6 +379,78 @@ def account() -> dict:
     return raw if isinstance(raw, dict) else {}
 
 
+# Preflight verdicts. `ok` = balance covers the whole budget; `partial` = the
+# run can start but may stop early; `insufficient` = not even the primary
+# signal is affordable; `unknown` = the balance check itself failed.
+PREFLIGHT_OK = "ok"
+PREFLIGHT_PARTIAL = "partial"
+PREFLIGHT_INSUFFICIENT = "insufficient"
+PREFLIGHT_UNKNOWN = "unknown"
+
+
+def preflight_credits(max_credits: int = DEFAULT_MAX_CREDITS_PER_RUN) -> dict:
+    """
+    Check the account balance against a run's budget BEFORE spending anything.
+
+    This is a bring-your-own-key skill, so a run that dies halfway leaves the
+    user having paid for a partial ranking. `account()` is free, so asking
+    first costs nothing.
+
+    Note `max_credits` is a CAP, not a projection: most runs spend well under
+    it. So a balance below the cap is a WARNING, not a refusal — refusing there
+    would block runs that would have completed fine. The only hard stop is a
+    balance that cannot afford the primary signal at all, because without
+    pnl_by_market there is no market-specific ranking to produce.
+
+    Never raises. A failed balance check returns `unknown` and the caller
+    proceeds — a flaky /account must not block a run the user asked for.
+
+    Returns {"verdict", "remaining", "plan", "max_credits", "message"}.
+    """
+    try:
+        info = account()
+        remaining = int(info.get("credits_remaining"))
+        plan = str(info.get("plan") or "unknown")
+    except Exception as exc:  # noqa: BLE001 - advisory check, never fatal
+        return {
+            "verdict": PREFLIGHT_UNKNOWN,
+            "remaining": None,
+            "plan": None,
+            "max_credits": max_credits,
+            "message": f"could not check Nansen balance ({exc}); proceeding anyway",
+        }
+
+    common = {"remaining": remaining, "plan": plan, "max_credits": max_credits}
+
+    if remaining < CREDITS_PNL_BY_MARKET:
+        return {
+            **common,
+            "verdict": PREFLIGHT_INSUFFICIENT,
+            "message": (
+                f"{remaining} credits remaining, but the primary signal "
+                f"(pnl-by-market) costs {CREDITS_PNL_BY_MARKET}. Top up at "
+                "https://nsn.ai/simmer before running."
+            ),
+        }
+
+    if remaining < max_credits:
+        return {
+            **common,
+            "verdict": PREFLIGHT_PARTIAL,
+            "message": (
+                f"{remaining} credits remaining but the budget allows up to "
+                f"{max_credits}. The run will start and may stop early, leaving "
+                "some leaders at their original score (CREDIT_GUARD_EXHAUSTED)."
+            ),
+        }
+
+    return {
+        **common,
+        "verdict": PREFLIGHT_OK,
+        "message": f"{remaining} credits remaining, budget {max_credits}.",
+    }
+
+
 def pnl_by_market(market_id: str, limit: int = 50,
                    guard: Optional[CreditGuard] = None) -> list[dict]:
     """

--- a/skills/nansen-copytrader-overlay/nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/nansen_adapter.py
@@ -265,8 +265,13 @@ def _post(path: str, body: Optional[dict], retries: int = MAX_RETRIES,
         cached = guard.get_cached(cache_key)
         if cached is not None:
             return cached
-        guard.consume(cache_key, cost)
 
+    # Validate the key BEFORE charging the guard. A request rejected locally
+    # never reaches Nansen and so costs the user nothing — charging for it is
+    # phantom spend, not conservative accounting. It also cascades: the budget
+    # burns down on a config error, and once the key is fixed a later genuine
+    # request is refused with CreditGuardExceeded for credits that were never
+    # actually spent. Charge only once we are truly about to send something.
     key = _api_key()
     if not key:
         # Fail loudly here rather than letting the request go out bare and
@@ -276,6 +281,9 @@ def _post(path: str, body: Optional[dict], retries: int = MAX_RETRIES,
             "An unauthenticated request returns a 402 x402 paywall error, "
             "which is an auth bug, not a quota problem."
         )
+
+    if guard is not None:
+        guard.consume(cache_key, cost)
 
     url = f"{NANSEN_API_BASE}/{path.lstrip('/')}"
     payload = json.dumps(body).encode("utf-8") if body is not None else None

--- a/skills/nansen-copytrader-overlay/nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/nansen_adapter.py
@@ -127,7 +127,7 @@ class NansenRequestError(NansenError):
 
 
 class CreditGuardExceeded(NansenError):
-    """Raised when a CreditGuard's max_calls budget is exhausted mid-run."""
+    """Raised when a CreditGuard's credit budget would be exceeded mid-run."""
     pass
 
 
@@ -155,39 +155,56 @@ def _api_key() -> str:
 
 
 # ---------------------------------------------------------------------------
-# Credit guard — hard cap on live Nansen calls per run, with a TTL cache so
+# Credit guard — hard cap on Nansen credits per run, with a TTL cache so
 # repeated lookups (e.g. the same market_id across several leaders) don't
 # both count against the budget and re-spend credits.
+#
+# Credit costs measured live 2026-08-11:
+#   pnl-by-market     5 credits   (Nansen docs say 1 — they are wrong)
+#   top-holders       5 credits
+#   address-summary   1 credit
+#   pnl-by-address    1 credit
+#   trades-by-address 1 credit
+#   market-screener   1 credit
+#   account           0 credits   (free; no guard needed)
 # ---------------------------------------------------------------------------
 
-DEFAULT_MAX_CALLS_PER_RUN = 40
+CREDITS_PNL_BY_MARKET = 5   # measured live 2026-08-11
+CREDITS_TOP_HOLDERS = 5     # measured live 2026-08-11
+CREDITS_DEFAULT = 1         # all other prediction-market endpoints
+
+DEFAULT_MAX_CREDITS_PER_RUN = 45   # ~1 pnl-by-market + ~1 top-holders + 35 single-credit calls
 DEFAULT_CACHE_TTL_S = 300.0  # 5 minutes
 
 
 class CreditGuard:
     """
-    Tracks a hard call budget and a short-lived cache for one enrichment run.
+    Tracks a hard credit budget and a short-lived cache for one enrichment run.
 
     Every module in this repo that calls into `nansen_adapter` should be
     given a CreditGuard instance (or construct a default one) rather than
     calling `_post` unbounded — credits, not rate limits, are the binding
     constraint on this account (see README "Credits" section).
+
+    Endpoints cost different numbers of credits per call (see CREDITS_* constants
+    above). The guard tracks total credits spent, not call count, so the cap
+    means what a user thinks it means.
     """
 
-    def __init__(self, max_calls: int = DEFAULT_MAX_CALLS_PER_RUN,
+    def __init__(self, max_credits: int = DEFAULT_MAX_CREDITS_PER_RUN,
                  cache_ttl_s: float = DEFAULT_CACHE_TTL_S):
         # A nonpositive budget is never what a caller means. It makes the very
         # first request raise CreditGuardExceeded, which surfaces as a traceback
         # rather than the tagged CREDIT_GUARD_EXHAUSTED recovery path the
         # overlays implement. Fail here, where the number came from.
-        if max_calls < 1:
+        if max_credits < 1:
             raise ValueError(
-                f"max_calls must be >= 1, got {max_calls}. A budget below 1 "
+                f"max_credits must be >= 1, got {max_credits}. A budget below 1 "
                 "trips the guard on the first call."
             )
-        self.max_calls = max_calls
+        self.max_credits = max_credits
         self.cache_ttl_s = cache_ttl_s
-        self.calls_made = 0
+        self.credits_spent = 0
         self._cache: dict[tuple, tuple[float, Any]] = {}
 
     def get_cached(self, key: tuple) -> Optional[Any]:
@@ -199,14 +216,14 @@ class CreditGuard:
             return None
         return value
 
-    def consume(self, key: tuple) -> None:
-        """Charge one call against the budget. Raises if the budget is spent."""
-        if self.calls_made >= self.max_calls:
+    def consume(self, key: tuple, cost: int = CREDITS_DEFAULT) -> None:
+        """Charge `cost` credits against the budget. Raises if budget would be exceeded."""
+        if self.credits_spent + cost > self.max_credits:
             raise CreditGuardExceeded(
-                f"credit guard tripped: max_calls={self.max_calls} exhausted "
-                f"(next call was: {key[:3]})"
+                f"credit guard tripped: max_credits={self.max_credits} would be exceeded "
+                f"(spent={self.credits_spent}, next cost={cost}, key={key[:3]})"
             )
-        self.calls_made += 1
+        self.credits_spent += cost
 
     def put_cache(self, key: tuple, value: Any) -> None:
         self._cache[key] = (time.time(), value)
@@ -230,14 +247,15 @@ _STATUS_EXCEPTIONS = {
 
 
 def _post(path: str, body: Optional[dict], retries: int = MAX_RETRIES,
-          guard: Optional[CreditGuard] = None, method: str = "POST") -> Any:
+          guard: Optional[CreditGuard] = None, method: str = "POST",
+          cost: int = CREDITS_DEFAULT) -> Any:
     """
     POST `body` to `NANSEN_API_BASE/path` and return parsed JSON.
 
     If `guard` is given: a cache hit within `guard.cache_ttl_s` short-circuits
-    the call entirely (no credits spent, no budget consumed); otherwise the
-    call is charged against `guard.max_calls` before it runs, raising
-    CreditGuardExceeded if the budget is already spent.
+    the call entirely (no credits spent, no budget consumed); otherwise `cost`
+    credits are charged against `guard.max_credits` before the call runs, raising
+    CreditGuardExceeded if the budget would be exceeded.
 
     Raises the NansenError subclass matching the HTTP status (see module
     docstring). Transient statuses are retried with exponential backoff.
@@ -247,7 +265,7 @@ def _post(path: str, body: Optional[dict], retries: int = MAX_RETRIES,
         cached = guard.get_cached(cache_key)
         if cached is not None:
             return cached
-        guard.consume(cache_key)
+        guard.consume(cache_key, cost)
 
     key = _api_key()
     if not key:
@@ -384,7 +402,7 @@ def pnl_by_market(market_id: str, limit: int = 50,
         "market_id": str(market_id),
         "order_by": _order_by("total_pnl_usd"),
         "pagination": _paginate(limit),
-    }, guard=guard)
+    }, guard=guard, cost=CREDITS_PNL_BY_MARKET)
     return [_normalise_pnl_row(r) for r in _rows(raw)]
 
 
@@ -508,7 +526,7 @@ def top_holders(market_id: str, limit: int = 30,
         "market_id": str(market_id),
         "order_by": _order_by("position_size"),
         "pagination": _paginate(limit),
-    }, guard=guard)
+    }, guard=guard, cost=CREDITS_TOP_HOLDERS)
     return _rows(raw)
 
 

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
@@ -48,7 +48,7 @@ Proxy vs owner wallets:
 
 Credit guards:
     Every call goes through a CreditGuard (see nansen_adapter.py): a hard
-    max_calls budget plus a short TTL cache so re-enriching the same
+    max_credits budget plus a short TTL cache so re-enriching the same
     market/wallet within a run doesn't re-spend credits. `max_wallets`
     caps how many leaders get enriched at all — the rest keep their
     original score, tagged CREDIT_GUARD_MAX_WALLETS. If the call budget
@@ -544,8 +544,8 @@ def _enrich_pairs_for_market(
             except CreditGuardExceeded:
                 guard_exhausted = True
                 logger.warning(
-                    "Credit guard exhausted (max_calls=%d) mid-run — remaining "
-                    "leaders keep their original score", guard.max_calls,
+                    "Credit guard exhausted (max_credits=%d) mid-run — remaining "
+                    "leaders keep their original score", guard.max_credits,
                 )
                 enrichment = LeaderEnrichment(
                     address=get_proxy_address(leader) or leader.get("wallet_address", ""),
@@ -608,8 +608,8 @@ def _enrich_pairs_legacy(
         except CreditGuardExceeded:
             guard_exhausted = True
             logger.warning(
-                "Credit guard exhausted (max_calls=%d) mid-run — remaining "
-                "leaders keep their original score", guard.max_calls,
+                "Credit guard exhausted (max_credits=%d) mid-run — remaining "
+                "leaders keep their original score", guard.max_credits,
             )
             enrichment.reason_tags = ["CREDIT_GUARD_EXHAUSTED"]
         except NansenError as e:

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_worldcup.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_worldcup.py
@@ -359,8 +359,8 @@ def enrich_leaders(
                 except CreditGuardExceeded:
                     guard_exhausted = True
                     logger.warning(
-                        "Credit guard exhausted (max_calls=%d) mid-run — remaining "
-                        "leaders keep their original score", guard.max_calls,
+                        "Credit guard exhausted (max_credits=%d) mid-run — remaining "
+                        "leaders keep their original score", guard.max_credits,
                     )
                     enrichment = WCLeaderEnrichment(
                         address=proxy or leader.get("wallet_address", ""),
@@ -382,8 +382,8 @@ def enrich_leaders(
                 except CreditGuardExceeded:
                     guard_exhausted = True
                     logger.warning(
-                        "Credit guard exhausted (max_calls=%d) mid-run — remaining "
-                        "leaders keep their original score", guard.max_calls,
+                        "Credit guard exhausted (max_credits=%d) mid-run — remaining "
+                        "leaders keep their original score", guard.max_credits,
                     )
                     enrichment = WCLeaderEnrichment(
                         address=proxy or leader.get("wallet_address", ""),

--- a/skills/nansen-copytrader-overlay/nansen_live_insider_scan.py
+++ b/skills/nansen-copytrader-overlay/nansen_live_insider_scan.py
@@ -494,9 +494,9 @@ def scan_live_markets(
             )
         except CreditGuardExceeded:
             logger.warning(
-                "Credit guard exhausted (max_calls=%d) after %d market(s) — "
+                "Credit guard exhausted (max_credits=%d) after %d market(s) — "
                 "stopping scan early, returning signals found so far",
-                guard.max_calls, i,
+                guard.max_credits, i,
             )
             break
         all_signals.extend(signals)

--- a/skills/nansen-copytrader-overlay/nansen_skill_cli.py
+++ b/skills/nansen-copytrader-overlay/nansen_skill_cli.py
@@ -113,7 +113,7 @@ def _positive_int(raw: str) -> int:
     """argparse type for the credit caps: reject 0 and negatives at parse time.
 
     Both caps spend the user's own Nansen credits, and both fail badly on a
-    nonpositive value (--max-calls 0 trips the guard on the first request;
+    nonpositive value (--max-credits 0 trips the guard on the first request;
     --max-wallets 0 skips the cap and enriches everything). The library layer
     raises ValueError for programmatic callers; this turns the CLI case into a
     normal usage error instead of a traceback.

--- a/skills/nansen-copytrader-overlay/nansen_skill_cli.py
+++ b/skills/nansen-copytrader-overlay/nansen_skill_cli.py
@@ -56,7 +56,16 @@ def _cmd_copytrader_overlay(args):
     else:
         from nansen_copytrader_overlay_general import enrich_leaders
 
-    from nansen_adapter import CreditGuard
+    from nansen_adapter import CreditGuard, preflight_credits, PREFLIGHT_INSUFFICIENT
+
+    # Ask before spending. account() is free, so this costs nothing and stops
+    # a run that would strand the user with a half-finished ranking they paid
+    # for. Only a balance too low for the primary signal is a hard stop.
+    pre = preflight_credits(args.max_credits)
+    print(f"[credits] {pre['message']}", file=sys.stderr)
+    if pre["verdict"] == PREFLIGHT_INSUFFICIENT:
+        sys.exit(1)
+
     guard = CreditGuard(max_credits=args.max_credits)
 
     result = enrich_leaders(

--- a/skills/nansen-copytrader-overlay/nansen_skill_cli.py
+++ b/skills/nansen-copytrader-overlay/nansen_skill_cli.py
@@ -35,7 +35,7 @@ leaders.json shape:
     `address` is accepted as a legacy alias for proxy_address only.
 
 This is a bring-your-own-key skill: every call spends the user's own Nansen
-credits, so the --max-wallets/--max-calls defaults are deliberately
+credits, so the --max-wallets/--max-credits defaults are deliberately
 conservative. Raise them explicitly if you want a wider sweep.
 """
 
@@ -43,7 +43,7 @@ import argparse
 import json
 import sys
 
-from nansen_adapter import DEFAULT_MAX_CALLS_PER_RUN
+from nansen_adapter import DEFAULT_MAX_CREDITS_PER_RUN
 from nansen_copytrader_overlay_general import DEFAULT_MAX_WALLETS
 
 
@@ -57,7 +57,7 @@ def _cmd_copytrader_overlay(args):
         from nansen_copytrader_overlay_general import enrich_leaders
 
     from nansen_adapter import CreditGuard
-    guard = CreditGuard(max_calls=args.max_calls)
+    guard = CreditGuard(max_credits=args.max_credits)
 
     result = enrich_leaders(
         leaders,
@@ -69,7 +69,7 @@ def _cmd_copytrader_overlay(args):
     )
     print(json.dumps(result, indent=2))
     print(
-        f"[credits] {guard.calls_made}/{guard.max_calls} Nansen calls used this run",
+        f"[credits] {guard.credits_spent}/{guard.max_credits} Nansen credits used this run",
         file=sys.stderr,
     )
 
@@ -145,9 +145,9 @@ def main():
     overlay.add_argument("--max-wallets", type=_positive_int, default=DEFAULT_MAX_WALLETS,
                           help="Hard cap on leaders enriched this run "
                                f"(credit guard, default {DEFAULT_MAX_WALLETS})")
-    overlay.add_argument("--max-calls", type=_positive_int, default=DEFAULT_MAX_CALLS_PER_RUN,
-                          help="Hard cap on Nansen calls this run "
-                               f"(credit guard, default {DEFAULT_MAX_CALLS_PER_RUN})")
+    overlay.add_argument("--max-credits", type=_positive_int, default=DEFAULT_MAX_CREDITS_PER_RUN,
+                          help="Hard cap on Nansen credits spent this run "
+                               f"(credit guard, default {DEFAULT_MAX_CREDITS_PER_RUN})")
     overlay.add_argument("--live", action="store_true",
                           help="Mark output dry_run=False. This CLI never places trades "
                                "itself either way — the caller still owns that gate.")

--- a/skills/nansen-copytrader-overlay/scripts/smoke_test.py
+++ b/skills/nansen-copytrader-overlay/scripts/smoke_test.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import nansen_adapter as na
 import nansen_copytrader_overlay_general as og
 
-MAX_CALLS = 8
+MAX_CREDITS = 20   # ~1 pnl-by-market (5) + a handful of 1-credit calls
 MAX_WALLETS = 2
 
 
@@ -47,7 +47,7 @@ def main() -> int:
     out(f"- Run at: {datetime.datetime.now(datetime.timezone.utc).isoformat()}")
     out(f"- Market: `{args.market_id}`")
     out(f"- Transport: direct HTTPS to `{na.NANSEN_API_BASE}` (stdlib urllib, no CLI)")
-    out(f"- Caps: max_calls={MAX_CALLS}, max_wallets={MAX_WALLETS}\n")
+    out(f"- Caps: max_credits={MAX_CREDITS}, max_wallets={MAX_WALLETS}\n")
 
     # 1. account — free and uncounted, so this never costs anything.
     acct = na.account()
@@ -55,7 +55,7 @@ def main() -> int:
     out(f"```\nplan={acct.get('plan')!r} credits_remaining={acct.get('credits_remaining')}\n```\n")
     start_credits = acct.get("credits_remaining")
 
-    guard = na.CreditGuard(max_calls=MAX_CALLS)
+    guard = na.CreditGuard(max_credits=MAX_CREDITS)
 
     # 2. pnl-by-market — the primary signal.
     out("## 2. `POST prediction-market/pnl-by-market` (primary signal)\n")
@@ -118,7 +118,7 @@ def main() -> int:
     out(f"credits after  : {end.get('credits_remaining')}")
     if isinstance(start_credits, int) and isinstance(end.get("credits_remaining"), int):
         out(f"spent          : {start_credits - end['credits_remaining']}")
-    out(f"guard calls    : {guard.calls_made}/{MAX_CALLS}")
+    out(f"guard credits  : {guard.credits_spent}/{MAX_CREDITS}")
     out("```")
     return 0
 

--- a/skills/nansen-copytrader-overlay/tests/test_live_insider_scan.py
+++ b/skills/nansen-copytrader-overlay/tests/test_live_insider_scan.py
@@ -298,7 +298,7 @@ def test_scan_live_markets_credit_guard_stops_scan_early():
     markets are skipped rather than continuing to spend credits."""
     from nansen_adapter import CreditGuard
 
-    guard = CreditGuard(max_calls=100)
+    guard = CreditGuard(max_credits=100)
 
     def raise_on_second_market(market_id, **kwargs):
         if market_id == "2":

--- a/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
@@ -623,3 +623,36 @@ def test_preflight_spends_no_credits():
     with _acct(500):
         na.preflight_credits(45)
     assert guard.credits_spent == 0
+
+
+CREDITS_FOR_ONE_PNL_CALL = na.CREDITS_PNL_BY_MARKET
+
+
+# --- Locally-rejected requests must not charge credits (Greptile P1, #307) --
+#
+# guard.consume() used to run BEFORE the API-key check, so a request that never
+# left the machine still burned budget. Not conservative accounting — phantom
+# spend, and it cascades: fix the key, re-run on the same guard, and a genuine
+# request is refused for credits Nansen never billed.
+
+def test_missing_api_key_does_not_charge_the_guard():
+    guard = na.CreditGuard(max_credits=45)
+    with patch.object(na, "_api_key", return_value=""):
+        with pytest.raises(na.NansenAuthError):
+            na.pnl_by_market("123", guard=guard)
+    assert guard.credits_spent == 0
+
+
+def test_budget_survives_a_config_error_and_is_usable_after_the_fix():
+    """The cascade Greptile described: the fixed key must still have budget."""
+    guard = na.CreditGuard(max_credits=CREDITS_FOR_ONE_PNL_CALL)
+    with patch.object(na, "_api_key", return_value=""):
+        for _ in range(5):
+            with pytest.raises(na.NansenAuthError):
+                na.pnl_by_market("123", guard=guard)
+    assert guard.credits_spent == 0
+
+    # Key fixed — the one call the budget was sized for must still go through.
+    with _mock_http({"data": []}):
+        na.pnl_by_market("123", guard=guard)
+    assert guard.credits_spent == CREDITS_FOR_ONE_PNL_CALL

--- a/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
@@ -569,3 +569,57 @@ def test_credit_guard_rejects_nonpositive_budget(bad):
 def test_credit_guard_accepts_a_budget_of_one():
     guard = na.CreditGuard(max_credits=1)
     assert guard.max_credits == 1
+
+
+# --- Preflight balance check (SIM-4486) -----------------------------------
+#
+# BYO-key skill: a run that dies halfway leaves the user having paid for a
+# partial ranking. account() is free, so asking first costs nothing.
+#
+# max_credits is a CAP, not a projection — most runs spend well under it. So a
+# balance below the budget must WARN, not refuse; refusing there would block
+# runs that would have completed fine.
+
+def _acct(remaining, plan="free"):
+    return patch.object(na, "account",
+                        return_value={"plan": plan, "credits_remaining": remaining})
+
+
+def test_preflight_ok_when_balance_covers_the_whole_budget():
+    with _acct(500):
+        assert na.preflight_credits(45)["verdict"] == na.PREFLIGHT_OK
+
+
+def test_preflight_warns_but_does_not_refuse_below_budget():
+    """Budget is a cap, not a prediction — this run may well complete."""
+    with _acct(20):
+        out = na.preflight_credits(45)
+    assert out["verdict"] == na.PREFLIGHT_PARTIAL
+    assert out["remaining"] == 20
+
+
+def test_preflight_refuses_when_primary_signal_unaffordable():
+    """Below the pnl-by-market cost there is no market-specific ranking at all."""
+    with _acct(na.CREDITS_PNL_BY_MARKET - 1):
+        assert na.preflight_credits(45)["verdict"] == na.PREFLIGHT_INSUFFICIENT
+
+
+def test_preflight_boundary_exactly_affords_primary_signal():
+    with _acct(na.CREDITS_PNL_BY_MARKET):
+        assert na.preflight_credits(45)["verdict"] != na.PREFLIGHT_INSUFFICIENT
+
+
+def test_preflight_never_raises_when_the_balance_check_itself_fails():
+    """A flaky /account must not block a run the user asked for."""
+    with patch.object(na, "account", side_effect=RuntimeError("network down")):
+        out = na.preflight_credits(45)
+    assert out["verdict"] == na.PREFLIGHT_UNKNOWN
+    assert out["remaining"] is None
+
+
+def test_preflight_spends_no_credits():
+    """It must use the free account() endpoint and charge nothing to a guard."""
+    guard = na.CreditGuard(max_credits=45)
+    with _acct(500):
+        na.preflight_credits(45)
+    assert guard.credits_spent == 0

--- a/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
+++ b/skills/nansen-copytrader-overlay/tests/test_nansen_adapter.py
@@ -314,12 +314,12 @@ def test_account_is_a_free_get_and_takes_no_guard():
 # ---------------------------------------------------------------------------
 
 def test_credit_guard_raises_when_budget_exhausted():
-    guard = na.CreditGuard(max_calls=1)
+    guard = na.CreditGuard(max_credits=1)
 
     with _mock_http({"data": [{"a": 1}]}):
-        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        na._post("prediction-market/address-summary", {"address": "0x1"}, guard=guard)
         with pytest.raises(na.CreditGuardExceeded):
-            na._post("prediction-market/pnl-by-market", {"market_id": "2"}, guard=guard)
+            na._post("prediction-market/address-summary", {"address": "0x2"}, guard=guard)
 
 
 def test_credit_guard_exceeded_is_a_nansen_error():
@@ -327,11 +327,11 @@ def test_credit_guard_exceeded_is_a_nansen_error():
 
 
 def test_credit_guard_cache_hit_does_not_consume_budget():
-    guard = na.CreditGuard(max_calls=1)
+    guard = na.CreditGuard(max_credits=1)
 
     with _mock_http({"data": [{"a": 1}]}) as mock_open:
-        first = na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
-        second = na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        first = na._post("prediction-market/address-summary", {"address": "0x1"}, guard=guard)
+        second = na._post("prediction-market/address-summary", {"address": "0x1"}, guard=guard)
 
     assert first == second == {"data": [{"a": 1}]}
     assert mock_open.call_count == 1  # only one real HTTP call
@@ -339,22 +339,22 @@ def test_credit_guard_cache_hit_does_not_consume_budget():
 
 def test_credit_guard_cache_key_includes_body():
     """Same path, different body must not collide in the cache."""
-    guard = na.CreditGuard(max_calls=5)
+    guard = na.CreditGuard(max_credits=10)
 
     with _mock_http({"data": []}) as mock_open:
-        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
-        na._post("prediction-market/pnl-by-market", {"market_id": "2"}, guard=guard)
+        na._post("prediction-market/address-summary", {"address": "0x1"}, guard=guard)
+        na._post("prediction-market/address-summary", {"address": "0x2"}, guard=guard)
 
     assert mock_open.call_count == 2
-    assert guard.calls_made == 2
+    assert guard.credits_spent == 2
 
 
 def test_credit_guard_cache_expires_after_ttl():
-    guard = na.CreditGuard(max_calls=5, cache_ttl_s=0.0)  # expire immediately
+    guard = na.CreditGuard(max_credits=10, cache_ttl_s=0.0)  # expire immediately
 
     with _mock_http({"data": [{"a": 1}]}) as mock_open:
-        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
-        na._post("prediction-market/pnl-by-market", {"market_id": "1"}, guard=guard)
+        na._post("prediction-market/address-summary", {"address": "0x1"}, guard=guard)
+        na._post("prediction-market/address-summary", {"address": "0x1"}, guard=guard)
 
     assert mock_open.call_count == 2
 
@@ -366,6 +366,45 @@ def test_credit_guard_no_guard_means_unbounded_default():
         na._post("prediction-market/pnl-by-market", {"market_id": "1"})
 
     assert mock_open.call_count == 2  # no cache without a guard
+
+
+def test_credit_guard_pnl_by_market_costs_five_credits():
+    """pnl-by-market is 5 credits/call (measured live 2026-08-11)."""
+    guard = na.CreditGuard(max_credits=10)
+
+    with _mock_http({"data": []}):
+        na.pnl_by_market("1", guard=guard)
+
+    assert guard.credits_spent == na.CREDITS_PNL_BY_MARKET  # 5
+
+
+def test_credit_guard_top_holders_costs_five_credits():
+    """top-holders is 5 credits/call (measured live 2026-08-11)."""
+    guard = na.CreditGuard(max_credits=10)
+
+    with _mock_http({"data": []}):
+        na.top_holders("1", guard=guard)
+
+    assert guard.credits_spent == na.CREDITS_TOP_HOLDERS  # 5
+
+
+def test_credit_guard_address_summary_costs_one_credit():
+    """Single-credit endpoints leave credits_spent == 1."""
+    guard = na.CreditGuard(max_credits=5)
+
+    with _mock_http({"data": []}):
+        na.address_summary("0x1", guard=guard)
+
+    assert guard.credits_spent == na.CREDITS_DEFAULT  # 1
+
+
+def test_credit_guard_pnl_by_market_exceeds_small_budget():
+    """A 4-credit budget is enough for four 1-credit calls but not one pnl-by-market."""
+    guard = na.CreditGuard(max_credits=4)
+
+    with _mock_http({"data": []}):
+        with pytest.raises(na.CreditGuardExceeded):
+            na.pnl_by_market("1", guard=guard)
 
 
 # ---------------------------------------------------------------------------
@@ -517,16 +556,16 @@ def test_pnl_by_market_scrubs_owner_placeholder():
 # --- Credit-cap validation (Greptile P1, simmer-sdk#306) ------------------
 #
 # A nonpositive budget is never what a caller means, and both caps spend the
-# user's own Nansen credits. Before this guard, CreditGuard(max_calls=0) tripped
+# user's own Nansen credits. Before this guard, CreditGuard(max_credits=0) tripped
 # on the very first request and surfaced as a traceback rather than the tagged
 # CREDIT_GUARD_EXHAUSTED recovery path.
 
 @pytest.mark.parametrize("bad", [0, -1, -40])
 def test_credit_guard_rejects_nonpositive_budget(bad):
-    with pytest.raises(ValueError, match="max_calls must be >= 1"):
-        na.CreditGuard(max_calls=bad)
+    with pytest.raises(ValueError, match="max_credits must be >= 1"):
+        na.CreditGuard(max_credits=bad)
 
 
 def test_credit_guard_accepts_a_budget_of_one():
-    guard = na.CreditGuard(max_calls=1)
-    assert guard.max_calls == 1
+    guard = na.CreditGuard(max_credits=1)
+    assert guard.max_credits == 1

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
@@ -272,7 +272,7 @@ def test_enrich_leaders_credit_guard_exhaustion_keeps_remaining_at_original_scor
     leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}", "wallet_score": 0.5}
                for i in range(3)]
 
-    guard = CreditGuard(max_calls=1)  # exhausted after the single pnl_by_market call
+    guard = CreditGuard(max_credits=5)  # one pnl_by_market call (5 credits) exhausts the budget
 
     with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
          patch("nansen_copytrader_overlay_general.address_summary",
@@ -324,7 +324,7 @@ def test_enrich_leaders_rejects_nonpositive_max_wallets(bad):
 def test_enrich_leaders_validates_before_spending_any_credits():
     """The cap check must run before the first Nansen call, not after."""
     leaders = [{"proxy_address": f"0x{i:040x}", "wallet_score": 0.5} for i in range(6)]
-    guard = CreditGuard(max_calls=40)
+    guard = CreditGuard(max_credits=40)
     with pytest.raises(ValueError):
         og.enrich_leaders(leaders, market_id="1", max_wallets=0, guard=guard)
-    assert guard.calls_made == 0
+    assert guard.credits_spent == 0


### PR DESCRIPTION
Convert the Nansen `CreditGuard` from a call-count budget to a credit budget. Endpoints are not 1:1 with credits — `pnl-by-market` and `top-holders` each cost 5 credits (verified live 2026-08-11; Nansen's own docs say 1 and are wrong).

## Changes

- `nansen_adapter.py`: `max_calls` → `max_credits`, `calls_made` → `credits_spent`; `consume(key, cost)` deducts the actual credit cost; `_post()` gains a `cost` kwarg; `pnl_by_market` + `top_holders` pass `cost=5`; `DEFAULT_MAX_CREDITS_PER_RUN = 45`; named `CREDITS_*` constants exported for tests
- `nansen_skill_cli.py`: `--max-calls` → `--max-credits`; stderr output updated to say "credits used"
- `nansen_copytrader_overlay_general/worldcup/live_insider_scan.py`: log messages updated (`max_calls` → `max_credits`)
- `tests/test_nansen_adapter.py`: 4 new tests for per-endpoint credit costs; existing tests updated for renamed attributes
- `tests/test_overlay_general/test_live_insider_scan.py`: CreditGuard init updated

## Tests

```
124 passed in 0.25s
```

All 124 tests pass. No new failures.

Closes SIM-4486