### PR TITLE
fix(nansen-overlay): never rank unmeasured leaders above measured ones

### DIFF
--- a/skills/nansen-copytrader-overlay/SKILL.md
+++ b/skills/nansen-copytrader-overlay/SKILL.md
@@ -7,7 +7,7 @@ tags:
   - nansen
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.2.0"
+  version: "0.2.1"
   displayName: Nansen Copytrader Overlay
   difficulty: intermediate
   simmer:
@@ -153,6 +153,22 @@ skipped (kept at its original score, discounted). Missing `owner_address`
 is tagged `MISSING_OWNER_ADDRESS` for the record but does **not** gate the
 secondary signal — every call in that path is proxy-keyed.
 
+## Measured leaders always rank above unmeasured ones
+
+Each returned leader carries `nansen_measured`. Leaders with a usable Nansen
+signal are ranked as one block **above** every leader without one; within each
+block the order is by `adjusted_score`.
+
+This matters whenever your leader list is longer than `max_wallets`, or when
+some lookups fail. The two scores are not on the same scale — an unmeasured
+leader keeps `base * 0.9`, a measured one gets `0.5*base + 0.5*quality`, which
+only exceeds `0.9` when quality is above `0.8`. Ranking them together would
+promote wallets the overlay could not evaluate above nearly every wallet it
+did, which is the opposite of the point.
+
+If every leader is measured (the intended use), ranking is purely by
+`adjusted_score` and this rule changes nothing.
+
 ## Credit guards (hard, not advisory)
 
 Nansen bills per call against **your** key, so every enrichment run is
@@ -160,7 +176,8 @@ protected by:
 
 - **`max_wallets`** (default 30): leaders beyond the cap are never
   enriched — they keep their original score, tagged
-  `CREDIT_GUARD_MAX_WALLETS`.
+  `CREDIT_GUARD_MAX_WALLETS`, and are **ranked below every leader that was
+  measured** (see below).
 - **`CreditGuard(max_credits=...)`** (default 45): a hard ceiling on the
   **credits** spent across the whole run, with a 5-minute TTL cache so
   re-fetching the same market/wallet doesn't double-spend. It charges the real

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
@@ -109,6 +109,12 @@ MAX_CONCENTRATION = 0.70  # concentration above this gets max penalty
 # or the market fetch itself failed) — in each case we don't have a real
 # signal to blend, so the leader's original score should barely move rather
 # than take a ~50% haircut.
+#
+# This score is NOT comparable with a blended one, and must never be ranked
+# against it — see _blend_and_rank. For base=1.0 it yields 0.9, while a measured
+# leader yields 0.5 + 0.5*quality, which only exceeds 0.9 when quality > 0.8.
+# Ranking the two together therefore promotes every wallet we could not measure
+# above almost every wallet we did.
 NO_ADJUSTMENT_DISCOUNT = 0.9
 
 DEFAULT_MAX_WALLETS = 30       # hard cap on leaders enriched per call
@@ -401,14 +407,16 @@ def _blend_and_rank(
     output = []
     for leader, enrichment in enriched_pairs:
         base = float(leader.get(base_score_key) or 0.0)
+        measured = _has_usable_signal(enrichment)
 
-        if _has_usable_signal(enrichment):
+        if measured:
             adjusted = 0.5 * base + 0.5 * enrichment.quality_score
         else:
             adjusted = base * NO_ADJUSTMENT_DISCOUNT
 
         output.append({
             **leader,
+            "nansen_measured": measured,
             "nansen_features": {
                 "market_score": enrichment.market_score,
                 "market_total_pnl_usd": enrichment.market_total_pnl_usd,
@@ -428,7 +436,20 @@ def _blend_and_rank(
             "dry_run": dry_run,
         })
 
-    output.sort(key=lambda x: x["adjusted_score"], reverse=True)
+    # Measured leaders rank as one block, ABOVE every unmeasured one.
+    #
+    # The two scores are not on the same scale: an unmeasured leader keeps
+    # base*0.9, a measured one gets 0.5*base + 0.5*quality, and the latter only
+    # wins when quality > 0.8. Sorting them together therefore promotes wallets
+    # we could not evaluate above nearly every wallet we did — the opposite of
+    # what this overlay is for. Observed live 2026-08-12: with 100 leaders and
+    # max_wallets=8, the 8 enriched landed at ranks 25-38 while unmeasured
+    # wallets took ranks 1-4.
+    #
+    # Absence of evidence must not outrank evidence. Within each block the
+    # ordering is unchanged, so a fully-enriched call (the intended use) behaves
+    # exactly as before.
+    output.sort(key=lambda x: (x["nansen_measured"], x["adjusted_score"]), reverse=True)
     for i, item in enumerate(output):
         item["adjusted_rank"] = i + 1
 

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
@@ -267,6 +267,78 @@ def test_enrich_leaders_max_wallets_caps_enrichment():
     assert len(capped) == 3
 
 
+def test_unmeasured_leaders_never_outrank_measured_ones():
+    """
+    REGRESSION (observed live 2026-08-12): an unmeasured leader keeps
+    base*NO_ADJUSTMENT_DISCOUNT (0.9) while a measured one gets
+    0.5*base + 0.5*quality, which only exceeds 0.9 when quality > 0.8. Ranking
+    them on score alone therefore promoted wallets we could not evaluate above
+    nearly every wallet we did — with 100 leaders and max_wallets=8, the 8
+    enriched landed at ranks 25-38 while unmeasured wallets took ranks 1-4.
+
+    Absence of evidence must not outrank evidence.
+    """
+    market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(6)]
+    # Unmeasured leaders carry the HIGHEST base scores, so a score-only sort
+    # would put them on top.
+    leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}",
+                "wallet_score": 1.0 - i * 0.1} for i in range(6)]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary",
+               return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True, max_wallets=2)
+
+    measured = [r for r in result if r["nansen_measured"]]
+    unmeasured = [r for r in result if not r["nansen_measured"]]
+    assert measured and unmeasured, "test needs both blocks present"
+
+    worst_measured_rank = max(r["adjusted_rank"] for r in measured)
+    best_unmeasured_rank = min(r["adjusted_rank"] for r in unmeasured)
+    assert worst_measured_rank < best_unmeasured_rank, (
+        f"an unmeasured leader ranked {best_unmeasured_rank}, above a measured "
+        f"one at {worst_measured_rank}"
+    )
+
+
+def test_fully_enriched_ranking_is_unchanged_by_the_block_sort():
+    """The intended path — every leader measured — must order purely on score."""
+    market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(3)]
+    leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}",
+                "wallet_score": 0.3 * (i + 1)} for i in range(3)]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary",
+               return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True)
+
+    assert all(r["nansen_measured"] for r in result)
+    scores = [r["adjusted_score"] for r in result]
+    assert scores == sorted(scores, reverse=True)
+    assert [r["adjusted_rank"] for r in result] == list(range(1, len(result) + 1))
+
+
+def test_top_n_prefers_measured_leaders():
+    """top_n truncation must not hand back wallets we never evaluated."""
+    market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(6)]
+    leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}",
+                "wallet_score": 1.0 - i * 0.1} for i in range(6)]
+
+    with patch("nansen_copytrader_overlay_general.pnl_by_market", return_value=market_rows), \
+         patch("nansen_copytrader_overlay_general.address_summary",
+               return_value=summary(resolved_count=1)), \
+         patch("time.sleep"):
+        result = og.enrich_leaders(leaders, market_id="42", dry_run=True,
+                                   max_wallets=2, top_n=2)
+
+    assert len(result) == 2
+    assert all(r["nansen_measured"] for r in result), (
+        "top_n returned an unmeasured leader while measured ones existed"
+    )
+
+
 def test_enrich_leaders_credit_guard_exhaustion_keeps_remaining_at_original_score():
     market_rows = [market_row(f"0xW{i}", 100.0, 50.0) for i in range(3)]
     leaders = [{"proxy_address": f"0xW{i}", "owner_address": f"0xO{i}", "wallet_score": 0.5}


### PR DESCRIPTION
## The defect

An unmeasured leader keeps `base * NO_ADJUSTMENT_DISCOUNT` (0.9). A measured one gets `0.5*base + 0.5*quality`, which only exceeds 0.9 when **quality > 0.8**. Sorting both on score alone promotes wallets the overlay could not evaluate above nearly every wallet it did.

Observed live 2026-08-12 against real Nansen data — 100 leaders, `max_wallets=8`:

| baseline rank | adjusted rank | measured? |
|---|---|---|
| 1 (PnL $15,460) | 25 | yes — STRONG_ROI, EXPERIENCED_TRADER |
| 8 ($727) | 33 | yes — STRONG_ROI, EXPERIENCED_TRADER |
| 9 ($680) | **1** | no — `CREDIT_GUARD_MAX_WALLETS` |
| 11 ($611) | **3** | no — `CREDIT_GUARD_MAX_WALLETS` |

Real quality scores sit around **0.23**, so the 0.8 threshold is essentially never cleared. The inversion is the normal case, not an edge case.

**This is not specific to Simmer's caller.** It fires for anyone whose leader list exceeds `max_wallets` (default 30) or who has some lookups fail — i.e. anyone feeding it a realistic candidate list.

## The fix

Ordering semantics, not a tuned constant. Leaders now carry `nansen_measured`; measured leaders rank as one block **above** unmeasured ones, ordered by `adjusted_score` within each block. Absence of evidence must not outrank evidence.

`top_n` truncation also now prefers measured leaders, so it cannot return wallets that were never evaluated while evaluated ones existed.

**A fully-enriched call — the intended use — is unchanged.** All 132 pre-existing tests pass untouched, which is the evidence for that claim.

## Tests

135 (132 existing + 3). New: the inversion regression with unmeasured leaders holding the *highest* base scores, the fully-enriched path ordering purely on score, and `top_n` preferring measured.

## Version

0.2.0 → 0.2.1. `published: false`, so nothing ships to ClawHub. The bump gives Simmer's shadow recorder (SIM-4485) provenance to separate pre-fix rows — recorded under 0.2.0, where `adjusted_rank` is unusable — from corrected ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D42zoCG1FoAbNoCgQr5waH