### PR TITLE
fix(nansen-overlay): no-cost-basis ROI contributes zero, not a flat 0.6

### DIFF
--- a/skills/nansen-copytrader-overlay/SKILL.md
+++ b/skills/nansen-copytrader-overlay/SKILL.md
@@ -7,7 +7,7 @@ tags:
   - nansen
 metadata:
   author: Simmer (@simmer_markets)
-  version: "0.2.1"
+  version: "0.2.2"
   displayName: Nansen Copytrader Overlay
   difficulty: intermediate
   simmer:
@@ -149,7 +149,16 @@ owner, which is treated as absent.
 | `owner_address` (optional) | General on-chain wallet quality | `historical-balances` |
 
 A leader missing `proxy_address` is tagged `MISSING_PROXY_ADDRESS` and
-skipped (kept at its original score, discounted). Missing `owner_address`
+skipped (kept at its original score, discounted).
+
+A leader whose market position has **no usable cost basis** — none at all
+(airdropped/gifted) or dust under \$10 — is tagged `NO_COST_BASIS` /
+`DUST_COST_BASIS` and its ROI component contributes **zero** rather than a
+flat stand-in. It keeps its profit/loss tag and stays eligible for the
+leaderboard-rank bonus (realised PnL rank is real evidence). Rationale: the
+typical *measured* ROI score is ~0.09, so any generous default for an
+uncomputable ROI would rank the wallets we know least about above the ones we
+measured. Missing `owner_address`
 is tagged `MISSING_OWNER_ADDRESS` for the record but does **not** gate the
 secondary signal — every call in that path is proxy-keyed.
 

--- a/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/nansen_copytrader_overlay_general.py
@@ -120,6 +120,13 @@ NO_ADJUSTMENT_DISCOUNT = 0.9
 DEFAULT_MAX_WALLETS = 30       # hard cap on leaders enriched per call
 DEFAULT_MARKET_LEADERBOARD_LIMIT = 100
 
+# ROI computed on a cost basis below this is treated as no cost basis at all.
+# min(1, roi/2) caps at 1.0, so a $1-cost wallet with $50 of PnL would score
+# the theoretical maximum — above every wallet with real capital at risk (max
+# observed real-cost score: 0.49). Degenerate evidence must not beat solid
+# evidence. $10 is deliberately low: it only has to exclude dust.
+MIN_COST_BASIS_USD = 10.0
+
 
 @dataclass
 class LeaderEnrichment:
@@ -239,16 +246,28 @@ def _compute_market_score(row: dict, rank: Optional[int], leaderboard_size: int)
     """
     tags: list[str] = []
     total_pnl = row.get("total_pnl_usd", 0.0)
-    roi = compute_roi(row.get("net_buy_cost_usd", 0.0), total_pnl)
+    cost = row.get("net_buy_cost_usd", 0.0) or 0.0
+    roi = compute_roi(cost, total_pnl)
 
     tags.append("MARKET_PROFITABLE" if total_pnl > 0 else "MARKET_UNPROFITABLE")
 
-    if roi is not None:
+    if roi is not None and cost >= MIN_COST_BASIS_USD:
         score = min(1.0, max(0.0, roi / 2.0))
     else:
-        # No cost basis to compute ROI (e.g. a fully airdropped/gifted
-        # position) — fall back to a coarse profit/loss signal.
-        score = 0.6 if total_pnl > 0 else 0.0
+        # No usable cost basis — either none at all (airdropped/gifted position)
+        # or dust below MIN_COST_BASIS_USD, where min(1, roi/2) would let a $1
+        # position score the theoretical maximum.
+        #
+        # The ROI component contributes ZERO here, not a flat stand-in. The old
+        # fallback of 0.6 sat ~6x above the typical measured ROI score (~0.09,
+        # max observed 0.49), so a wallet whose efficiency we could not compute
+        # outranked every wallet whose efficiency we measured — observed live
+        # 2026-08-12 as a 0-history wallet at adjusted_rank 1. Missing evidence
+        # must never score above the floor of measured evidence. The wallet
+        # keeps its profit/loss tag and stays eligible for the leaderboard-rank
+        # bonus below, because realised PnL rank is real evidence.
+        score = 0.0
+        tags.append("NO_COST_BASIS" if roi is None else "DUST_COST_BASIS")
 
     if rank is not None and leaderboard_size > 0:
         if (rank + 1) / leaderboard_size <= 0.2:

--- a/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
+++ b/skills/nansen-copytrader-overlay/tests/test_overlay_general.py
@@ -117,11 +117,56 @@ def test_market_score_unprofitable():
     assert "MARKET_TOP_PNL" not in tags
 
 
-def test_market_score_no_cost_basis_but_profitable():
+def test_market_score_no_cost_basis_contributes_zero_roi_signal():
+    """
+    REGRESSION (observed live 2026-08-12): the old fallback scored an
+    uncomputable ROI at a flat 0.6 — ~6x the typical measured ROI score
+    (~0.09, max observed 0.49) — so a wallet with zero history and no cost
+    basis took adjusted_rank 1, above wallets with 45 resolved markets.
+    Missing evidence must never score above the floor of measured evidence.
+    """
     row = {"total_pnl_usd": 50.0, "net_buy_cost_usd": 0.0}
     score, tags = og._compute_market_score(row, rank=None, leaderboard_size=0)
-    assert score == 0.6
+    assert score == 0.0
     assert "MARKET_PROFITABLE" in tags
+    assert "NO_COST_BASIS" in tags
+
+
+def test_market_score_no_cost_basis_never_beats_measured_roi():
+    """The wallet the overlay knows least about must not outrank a measured one."""
+    unknown = {"total_pnl_usd": 5_000.0, "net_buy_cost_usd": 0.0}
+    measured = {"total_pnl_usd": 8.0, "net_buy_cost_usd": 400.0}  # ROI = 2% — mediocre
+    s_unknown, _ = og._compute_market_score(unknown, rank=0, leaderboard_size=10)
+    s_measured, _ = og._compute_market_score(measured, rank=0, leaderboard_size=10)
+    assert s_unknown <= s_measured
+
+
+def test_market_score_dust_cost_basis_cannot_hit_the_cap():
+    """
+    min(1, roi/2) caps at 1.0, so a $1-cost wallet with $50 PnL (ROI 50x) would
+    score the theoretical maximum while the best real-cost wallet observed
+    scores 0.49. Dust below MIN_COST_BASIS_USD is treated as no cost basis.
+    """
+    dust = {"total_pnl_usd": 50.0, "net_buy_cost_usd": 1.0}
+    score, tags = og._compute_market_score(dust, rank=None, leaderboard_size=0)
+    assert score == 0.0
+    assert "DUST_COST_BASIS" in tags
+
+
+def test_market_score_min_cost_basis_boundary_is_real_evidence():
+    """At exactly MIN_COST_BASIS_USD the ROI is measured and scores normally."""
+    row = {"total_pnl_usd": og.MIN_COST_BASIS_USD, "net_buy_cost_usd": og.MIN_COST_BASIS_USD}
+    score, tags = og._compute_market_score(row, rank=None, leaderboard_size=0)  # ROI = 1.0
+    assert score == 0.5
+    assert "NO_COST_BASIS" not in tags and "DUST_COST_BASIS" not in tags
+
+
+def test_market_score_rank_bonus_still_applies_without_cost_basis():
+    """Leaderboard rank is real evidence and survives the missing-ROI floor."""
+    row = {"total_pnl_usd": 50.0, "net_buy_cost_usd": 0.0}
+    score, tags = og._compute_market_score(row, rank=0, leaderboard_size=10)
+    assert score == 0.15
+    assert "MARKET_TOP_PNL" in tags
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the third (and a latent fourth) instance of the one failure family in this scoring model: **a default for missing data set above the realistic range of the measured metric.**

## Observed live (run 2 of the SIM-4485 shadow recorder)

The overlay's top pick for market 2252242 was a wallet with **0 resolved markets and no computable ROI**, scored ~50% above wallets with 45 resolved markets:

| adj_rank | resolved | market_roi | market_score |
|---|---|---|---|
| **1** | **0** | **null** | **0.750** |
| 2 | 50 | 0.01 | 0.154 |
| 5 | 45 | 0.01 | 0.156 |

Cause: `score = 0.6 if total_pnl > 0` when ROI can't be computed, vs measured ROI scores of 0.005–0.49 (typical ~0.09). A wallet needs **ROI ≥ 120%** to beat the fallback.

## The fix

- No cost basis → ROI component contributes **zero**, tagged `NO_COST_BASIS`. Profit/loss tag and leaderboard-rank bonus survive — those are real evidence.
- Cost basis under **$10** (`MIN_COST_BASIS_USD`) → same, tagged `DUST_COST_BASIS`. Closes the latent case where `min(1, roi/2)` lets a $1-cost wallet score the theoretical maximum.

## The audit behind it

Adrian paused the measurement clock and asked for a whole-model review rather than a third one-off patch. Every scoring constant/fallback is now audited against observed distributions (n=40 live rows) in simmer `_dev/active/_connectors/nansen-scoring-model-review.md` — items 1–4 fixed (this PR + #308 + simmer #1806), items 5–10 reviewed-and-accepted with written rationale.

Version 0.2.1 → 0.2.2 (`published: false`; the bump is provenance for the shadow recorder — rows below 0.2.2 are excluded from slice 2). 139 tests (5 new, 1 rewritten from pinning the old 0.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D42zoCG1FoAbNoCgQr5waH