### PR TITLE
copy: agent-layer positioning in README + canonical SKILL.md (skill 1.24.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![PyPI version](https://badge.fury.io/py/simmer-sdk.svg)](https://pypi.org/project/simmer-sdk/)
 
-Simmer is the leading prediction market interface for AI agents. Autonomous trading agents place trades on venues like Polymarket and Kalshi through a unified API and SDK — with self-custody wallets, safety rails, and smart context.
+Simmer is the agent layer for prediction markets. Your agent gets a persistent identity, one self-custody wallet, and a cross-venue track record that spans Polymarket, Kalshi, and more — with safety rails, autoresearch, and a loop that makes your strategies better over time.
 
-- **AI-native trading platform** — designed for autonomous agents, with full support for manual trading too. Users install trading skills and let their agents trade autonomously.
-- **$SIM simulated trading** — paper-trade with virtual currency before risking real funds.
-- **Multi-venue** — trade Polymarket and Kalshi through one unified API.
+- **Agent account** — persistent identity, self-custody wallet, and a cross-venue track record that compounds over time.
+- **$SIM practice venue** — paper-trade with virtual currency before risking real funds.
+- **Polymarket + Kalshi** — real-money trading on the two largest prediction market venues.
 
 ## Installation
 

--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: simmer
-description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
+description: The agent layer for prediction markets. One persistent identity, one self-custody wallet, one cross-venue track record — with safety rails and a loop that makes your strategies better over time.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.9"
+  version: "1.24.10"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -19,7 +19,7 @@ metadata:
 
 # Simmer
 
-Trade prediction markets as an AI agent. One SDK across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, agent-native API.
+Your agent's persistent account for prediction markets. One identity, one self-custody wallet, and a track record that spans every venue you trade — across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, and a loop that makes your strategies better over time.
 
 ## Safety rails (read first)
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: simmer
-description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
+description: The agent layer for prediction markets. One persistent identity, one self-custody wallet, one cross-venue track record — with safety rails and a loop that makes your strategies better over time.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.9"
+  version: "1.24.10"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -19,7 +19,7 @@ metadata:
 
 # Simmer
 
-Trade prediction markets as an AI agent. One SDK across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, agent-native API.
+Your agent's persistent account for prediction markets. One identity, one self-custody wallet, and a track record that spans every venue you trade — across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, and a loop that makes your strategies better over time.
 
 ## Safety rails (read first)
 


### PR DESCRIPTION
Supersedes #274 (opened Jul 7, went stale on both the version bump and the CHANGELOG anchor).

**What changes:** the positioning sentence in `README.md` and the `description` + opening paragraph of `skills/simmer/SKILL.md`. No code.

**Why it's worth a release cycle:** `_product-strategy/context.md` says explicitly *do not* position as "unified market access" — that's pmxt's Layer 0, where we lose 15 venues to 3. The copy live on PyPI and ClawHub right now is that exact frame. The replacement is the ratified edge definition, loop included.

Track record is phrased as the agent's own record, consistent with the PRIVATE-first spec — it is a retention feature and the loop's proof, not a public credential.

**Skill version:** 1.24.9 → **1.24.10**. Main had already taken 1.24.9 for another change while #274 waited.

## ⚠️ Two follow-ups required after merge, in order

1. **simmer repo:** `cd website && npm run sync-skill` and commit the regenerated `website/public/skill.md`. The `skill-drift` CI job **fetches** this canonical and fails when the committed website copy diverges — so merging this alone turns simmer CI red. PR prepared alongside.
2. **ClawHub republish** so installs pick up 1.24.10.

No CHANGELOG entry: no SDK version bump, and every heading in that file is a release.