### PR TITLE
Revert "copy: agent-layer positioning in README + canonical SKILL.md" (#310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![PyPI version](https://badge.fury.io/py/simmer-sdk.svg)](https://pypi.org/project/simmer-sdk/)
 
-Simmer is the agent layer for prediction markets. Your agent gets a persistent identity, one self-custody wallet, and a cross-venue track record that spans Polymarket, Kalshi, and more — with safety rails, autoresearch, and a loop that makes your strategies better over time.
+Simmer is the leading prediction market interface for AI agents. Autonomous trading agents place trades on venues like Polymarket and Kalshi through a unified API and SDK — with self-custody wallets, safety rails, and smart context.
 
-- **Agent account** — persistent identity, self-custody wallet, and a cross-venue track record that compounds over time.
-- **$SIM practice venue** — paper-trade with virtual currency before risking real funds.
-- **Polymarket + Kalshi** — real-money trading on the two largest prediction market venues.
+- **AI-native trading platform** — designed for autonomous agents, with full support for manual trading too. Users install trading skills and let their agents trade autonomously.
+- **$SIM simulated trading** — paper-trade with virtual currency before risking real funds.
+- **Multi-venue** — trade Polymarket and Kalshi through one unified API.
 
 ## Installation
 

--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: simmer
-description: The agent layer for prediction markets. One persistent identity, one self-custody wallet, one cross-venue track record — with safety rails and a loop that makes your strategies better over time.
+description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.10"
+  version: "1.24.9"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -19,7 +19,7 @@ metadata:
 
 # Simmer
 
-Your agent's persistent account for prediction markets. One identity, one self-custody wallet, and a track record that spans every venue you trade — across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, and a loop that makes your strategies better over time.
+Trade prediction markets as an AI agent. One SDK across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, agent-native API.
 
 ## Safety rails (read first)
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: simmer
-description: The agent layer for prediction markets. One persistent identity, one self-custody wallet, one cross-venue track record — with safety rails and a loop that makes your strategies better over time.
+description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.10"
+  version: "1.24.9"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -19,7 +19,7 @@ metadata:
 
 # Simmer
 
-Your agent's persistent account for prediction markets. One identity, one self-custody wallet, and a track record that spans every venue you trade — across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, and a loop that makes your strategies better over time.
+Trade prediction markets as an AI agent. One SDK across two real venues (Polymarket, Kalshi) plus a virtual venue ($SIM) for practice. Self-custody, safety rails, agent-native API.
 
 ## Safety rails (read first)
 


### PR DESCRIPTION
Reverts `6512997` (#310), merged earlier today. Adrian's call.

**Why:**

1. **Worse as copy.** The replacement ran 30 words, led with "agent layer" (jargon), and buried the noun. `The prediction market interface for AI agents` is 8 words and says what the thing is. That `description:` field renders as a one-line summary in a skill registry — a marketing slot, not a positioning slot.
2. **The strategy directive behind it is up for revisit.** Rewriting the copy now would mean changing it twice.

**Root cause, so it doesn't recur:** the ratified edge definition ("one identity, one wallet, one track record, and a loop that makes it better") is an internal *analytical* statement for deciding what to build. It got transplanted verbatim into user-facing copy. The edge definition was ratified; this wording never was.

**Blast radius: none.** ClawHub stayed at 1.24.9 (never published), PyPI still serves the old README (no SDK release), and the website sync PR (simmer#1827) was closed unmerged. Skill version returns to 1.24.9 so repo and registry agree.

All three consumers reverted together: `skills/simmer/SKILL.md` (canonical), `README.md`, `mcp/bundled-skills/simmer/SKILL.md`.