### PR TITLE
feat(mcp): open the discovery surface — 3 keyless tools become 9

### DIFF
--- a/mcp/CONTRIBUTING.md
+++ b/mcp/CONTRIBUTING.md
@@ -25,16 +25,19 @@ Run these before tagging a release:
 npm test
 npm run check:bundle-skills
 
-# 2. Free-tier: exactly 3 tools (no API key)
+# 2. Keyless discovery tier: exactly 9 tools (no API key)
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}' | \
 printf '%s\n{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n' | \
 SIMMER_API_KEY="" node dist/mcp-server.js 2>/dev/null | grep '"id":2'
-# Expected: tools array with 3 entries (list_skills, get_skill_docs, troubleshoot_error)
+# Expected: tools array with 9 entries — list_skills, get_skill_docs, troubleshoot_error,
+# simmer_browse_markets, simmer_get_leaderboard, and the 4 Tier-A instruction-only skills
+# (simmer_simmer, simmer_simmer_briefing, simmer_simmer_mcp_setup, simmer_simmer_wallet_setup).
+# No key-requiring tool may appear here — simmer_preflight in particular is Tier B and must NOT.
 
-# 3. Pro-tier: 21 tools (with API key)
+# 3. Pro-tier: 23 tools (with API key)
 printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n' | \
 SIMMER_API_KEY="sk_test_any" node dist/mcp-server.js 2>/dev/null | grep '"id":2'
-# Expected: tools array with 21 entries (3 free + 4 autoresearch + 9 raw market/trade/data + 5 core bundled skills)
+# Expected: tools array with 23 entries (9 keyless + 4 autoresearch + 9 raw market/trade/data + 1 Tier-B skill)
 
 # 4. Resources absent
 printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n{"jsonrpc":"2.0","id":2,"method":"resources/list","params":{}}\n' | \
@@ -48,7 +51,7 @@ npm pack --dry-run
 
 # 6. Startup log looks correct
 SIMMER_API_KEY="" node dist/mcp-server.js </dev/null 2>&1 | head -5
-# Expected: [simmer-mcp] v<version> | tools: 3 (free only) | skills: 5 bundled
+# Expected: [simmer-mcp] v<version> | tools: 9 (discovery only, 9 keyless) | skills: 5 bundled
 ```
 
 ## Test structure
@@ -58,7 +61,8 @@ SIMMER_API_KEY="" node dist/mcp-server.js </dev/null 2>&1 | head -5
 | `tests/api.test.ts` | `SimmerApi.checkPro()` + `backtest()` BackendError relay |
 | `tests/pro-gate.test.ts` | 403 Pro-gate MCP response shape |
 | `tests/troubleshoot.test.ts` | `troubleshootError()` live API + local fallback |
-| `tests/mcp-protocol.test.ts` | Full JSON-RPC wire protocol (tools/list count, resources/list) |
+| `tests/mcp-protocol.test.ts` | Full JSON-RPC wire protocol (tools/list count, resources/list, keyless surface) |
+| `tests/public-api.test.ts` | Keyless public reads — no Authorization header, URL shape, timeout, errors |
 | `tests/docs-tools.test.ts` | `listSkills()`, `getSkillDocs()`, `listDocResources()` |
 | `tests/env-translation.test.ts` | Live-trading gate (dry_run/SIMMER_MCP_ALLOW_LIVE) |
 | `tests/blocked-flags.test.ts` | CLI flag sanitization for extra_args |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -34,15 +34,27 @@ Get your API key from [simmer.markets/dashboard](https://simmer.markets/dashboar
 
 ## Tools by tier
 
-### Free (no API key)
+### Discovery (no API key — 9 tools)
+
+Everything needed to evaluate Simmer before you have an account.
 
 | Tool | Description |
 |---|---|
 | `list_skills` | List the core bundled Simmer skills with tier and Pro requirements |
 | `get_skill_docs` | Get full SKILL.md for a specific skill |
 | `troubleshoot_error` | Look up a Simmer API error and get a fix |
+| `simmer_browse_markets` | Browse or search the public market catalogue |
+| `simmer_get_leaderboard` | Public leaderboard: SDK agents, native agents, Polymarket, Kalshi |
+| `simmer_simmer` | The Simmer overview playbook |
+| `simmer_simmer_briefing` | The briefing-loop playbook |
+| `simmer_simmer_mcp_setup` | How to set up this MCP server |
+| `simmer_simmer_wallet_setup` | How to set up an agent wallet |
 
-### Pro (requires SIMMER_API_KEY)
+The four `simmer_simmer*` tools are instruction-only skills — they return a
+playbook from disk and make no network calls. Two of them are onboarding docs,
+so gating them behind a key would lock out the only readers who need them.
+
+### Pro (requires SIMMER_API_KEY — 14 tools)
 
 | Tool | Description |
 |---|---|
@@ -50,8 +62,11 @@ Get your API key from [simmer.markets/dashboard](https://simmer.markets/dashboar
 | `run_experiment` | Run a shell command as a timed experiment |
 | `log_experiment` | Record experiment result (keep/discard/crash) with git commit |
 | `backtest_experiment` | Replay historical trades against new config (server-side) |
-| `simmer_<slug>` × 5 | Read or execute a core bundled Simmer skill in paper or live mode |
-| Raw market/trade tools | `simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, portfolio and position tools |
+| `simmer_preflight` | Wallet identity, venue status, spendable balance, `ok_to_trade` verdict |
+| Raw market/trade tools | `simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, `simmer_cancel_order`, portfolio and position tools |
+
+`simmer_get_markets` returns a richer payload than `simmer_browse_markets`
+(venue filtering, volume sort, agent context) — prefer it once a key is set.
 
 ### MCP Resources
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.9",
+  "version": "3.5.0",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "repository": {

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -111,6 +111,7 @@ import { BackendError } from "./errors.js";
 import { discoverSkills } from "./skill-discovery.js";
 import { buildToolSchema, buildToolDescription, invokeSkillTool } from "./per-skill-tools.js";
 import { listSkills, getSkillDocs } from "./docs-tools.js";
+import { browseMarkets, getLeaderboard } from "./public-api.js";
 import { troubleshootError } from "./troubleshoot.js";
 import { executeTrade, executeCancelOrder } from "./trade-primitives.js";
 import { registerTool } from "./tool-registry.js";
@@ -129,7 +130,7 @@ const workspaceDir = process.cwd();
 const simmer = apiKey ? new SimmerApi(apiKey, apiUrl, BUNDLED_VERSION) : null;
 
 if (!apiKey) {
-  console.error("[simmer-mcp] No SIMMER_API_KEY set — only free tools available (list_skills, get_skill_docs, troubleshoot_error).");
+  console.error("[simmer-mcp] No SIMMER_API_KEY set — discovery tools only (skills, docs, market browse, leaderboard, troubleshooting). Trading and portfolio tools need a key: https://simmer.markets");
 } else if (!apiKey.startsWith("sk_live_")) {
   console.error("[simmer-mcp] WARNING: SIMMER_API_KEY does not start with sk_live_ — key may be corrupted. Common cause: clipboard contamination during install (pbpaste reading the install command instead of the key). Inspect via: printenv SIMMER_API_KEY | cut -c1-20");
 }
@@ -259,6 +260,97 @@ server.tool(
     return { content: [{ type: "text" as const, text: parts.join("\n\n") }] };
   },
 );
+
+server.tool(
+  "simmer_browse_markets",
+  [
+    "Browse or search Simmer's public market catalogue. No API key required —",
+    "use this to evaluate what Simmer carries before setting up an account.",
+    "Returns question, prices, volume, status, and a URL per market.",
+    "For venue filtering, volume sorting, and your own position context, use",
+    "simmer_get_markets instead (needs SIMMER_API_KEY).",
+  ].join("\n"),
+  {
+    q: z.string().optional().describe("Text search over the market question (case-insensitive)"),
+    limit: z.number().optional().describe("Max markets to return (default 50, capped at 200)"),
+    status: z.string().optional().describe("'active', 'resolved', 'trending', 'new', or 'ending'"),
+    tags: z.string().optional().describe("Comma-separated tags (e.g. 'weather,crypto')"),
+    min_volume: z.number().optional().describe("Minimum 24h volume"),
+  },
+  { readOnlyHint: true },
+  async (args) => {
+    try {
+      const data = await browseMarkets(apiUrl, args);
+      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (e) {
+      if (e instanceof BackendError) return e.toMcpResponse();
+      return {
+        content: [{ type: "text" as const, text: `❌ Market browse failed: ${e instanceof Error ? e.message : String(e)}` }],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.tool(
+  "simmer_get_leaderboard",
+  [
+    "Get Simmer's public leaderboard. No API key required.",
+    "Returns four ranked legs in one call: SDK agents, native agents,",
+    "Polymarket traders, and Kalshi traders — each with P&L and trade counts.",
+    "Use this to see how agents are actually performing before you build one.",
+  ].join("\n"),
+  {
+    limit: z.number().optional().describe("Entries per leg (default 20, capped at 50)"),
+  },
+  { readOnlyHint: true },
+  async ({ limit }) => {
+    try {
+      const data = await getLeaderboard(apiUrl, { limit });
+      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+    } catch (e) {
+      if (e instanceof BackendError) return e.toMcpResponse();
+      return {
+        content: [{ type: "text" as const, text: `❌ Leaderboard fetch failed: ${e instanceof Error ? e.message : String(e)}` }],
+        isError: true,
+      };
+    }
+  },
+);
+
+// ===========================================================================
+// TIER-A SKILL TOOLS — instruction-only, no API key required
+// ===========================================================================
+//
+// Tier A skills have no entrypoint: invokeSkillTool short-circuits and reads
+// SKILL.md off disk. No network, no key. Two of them (simmer-mcp-setup,
+// simmer-wallet-setup) are onboarding docs whose entire audience is agents
+// that do not have a working key yet — gating them locked out the only
+// people who needed them.
+//
+// Tier B (preflight) has an entrypoint that hard-requires SIMMER_API_KEY,
+// so it stays inside the gate below. `entrypoint` is the discriminator
+// already used at skill-discovery.ts:128 and per-skill-tools.ts:97.
+
+function registerSkillTool(skill: typeof skills[number]): void {
+  registerTool(server, {
+    name: skill.toolName,
+    description: buildToolDescription(skill),
+    schema: buildToolSchema(skill),
+    mutates: false,
+    // readOnlyHint is derived from the skill's `readOnly` field, which is computed at
+    // discovery time: Tier A (no entrypoint) → true; Tier B → from `read_only` frontmatter
+    // in SKILL.md, default false. This is NOT derivable from `entrypoint` alone — having
+    // an entrypoint means "executes", not "mutates" (preflight has an entrypoint and IS
+    // read-only). See SIM-4439.
+    annotations: { readOnlyHint: skill.readOnly },
+    handler: async (args, _ctx) => invokeSkillTool(skill, args as Record<string, unknown>),
+  });
+}
+
+for (const skill of skills) {
+  if (!skill.entrypoint) registerSkillTool(skill);
+}
 
 // ===========================================================================
 // PRO TOOLS — requires SIMMER_API_KEY
@@ -855,8 +947,16 @@ if (simmer) {
     schema: {},
     mutates: false,
     handler: async (_args, _ctx) => {
-      const data = await simmer!.getPortfolio();
-      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      try {
+        const data = await simmer!.getPortfolio();
+        return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Portfolio fetch failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
     },
   });
 
@@ -871,8 +971,16 @@ if (simmer) {
     },
     mutates: false,
     handler: async ({ venue }: { venue?: string }, _ctx) => {
-      const data = await simmer!.getPositions({ venue });
-      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      try {
+        const data = await simmer!.getPositions({ venue });
+        return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Positions fetch failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
     },
   });
 
@@ -884,8 +992,16 @@ if (simmer) {
     },
     mutates: false,
     handler: async ({ hours }: { hours?: number }, _ctx) => {
-      const data = await simmer!.getExpiringPositions({ hours });
-      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      try {
+        const data = await simmer!.getExpiringPositions({ hours });
+        return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Expiring positions fetch failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
     },
   });
 
@@ -898,28 +1014,22 @@ if (simmer) {
     schema: {},
     mutates: false,
     handler: async (_args, _ctx) => {
-      const data = await simmer!.getFleetSummary();
-      return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      try {
+        const data = await simmer!.getFleetSummary();
+        return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+      } catch (e) {
+        if (e instanceof BackendError) return e.toMcpResponse();
+        return {
+          content: [{ type: "text" as const, text: `❌ Fleet summary fetch failed: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
     },
   });
 
+  // Tier-B skills only — Tier A is registered keyless above.
   for (const skill of skills) {
-    const capturedSkill = skill; // closure capture
-    registerTool(server, {
-      name: capturedSkill.toolName,
-      description: buildToolDescription(capturedSkill),
-      schema: buildToolSchema(capturedSkill),
-      mutates: false,
-      // readOnlyHint is derived from the skill's `readOnly` field, which is computed at
-      // discovery time: Tier A (no entrypoint) → true; Tier B → from `read_only` frontmatter
-      // in SKILL.md, default false. This is NOT derivable from `entrypoint` alone — having
-      // an entrypoint means "executes", not "mutates" (preflight has an entrypoint and IS
-      // read-only). See SIM-4439.
-      annotations: { readOnlyHint: capturedSkill.readOnly },
-      handler: async (args, _ctx) => {
-        return invokeSkillTool(capturedSkill, args as Record<string, unknown>);
-      },
-    });
+    if (skill.entrypoint) registerSkillTool(skill);
   }
 
 } // end if (simmer)
@@ -937,13 +1047,17 @@ async function main() {
     `git: ${probe.git.detected ? `v${probe.git.version}` : `not found`}`,
   ].join(" | ");
 
-  const freeCount = 3;
-  const proCount = simmer ? 13 + skills.length : 0; // 4 autoresearch + 9 raw market/trade/data tools
-  const totalTools = freeCount + proCount;
-  const tier = simmer ? "free + autoresearch + per-skill" : "free only";
+  // 5 hand-registered keyless tools (list_skills, get_skill_docs,
+  // troubleshoot_error, simmer_browse_markets, simmer_get_leaderboard) plus
+  // every Tier-A skill. Tier-B skills and the 13 authed tools are gated.
+  const tierASkills = skills.filter((s) => !s.entrypoint).length;
+  const keylessCount = 5 + tierASkills;
+  const gatedCount = simmer ? 13 + (skills.length - tierASkills) : 0;
+  const totalTools = keylessCount + gatedCount;
+  const tier = simmer ? "discovery + autoresearch + trading" : "discovery only";
 
   console.error(
-    `[simmer-mcp] v${BUNDLED_VERSION} | tools: ${totalTools} (${tier}) | skills: ${skills.length} bundled`
+    `[simmer-mcp] v${BUNDLED_VERSION} | tools: ${totalTools} (${tier}, ${keylessCount} keyless) | skills: ${skills.length} bundled`
   );
   console.error(`[simmer-mcp] runtime: ${probeLines}`);
 

--- a/mcp/src/public-api.ts
+++ b/mcp/src/public-api.ts
@@ -35,30 +35,37 @@ export interface PublicResult {
 const MARKETS_TIMEOUT_MS = 20_000;
 const LEADERBOARD_TIMEOUT_MS = 15_000;
 
-async function timedFetch(url: string, timeoutMs: number): Promise<Response> {
+/**
+ * GET + parse, with the abort timer held open through body parsing.
+ *
+ * Clearing the timer as soon as headers arrive (the pattern in api.ts) leaves
+ * a hole: a server that returns 200 and then stalls mid-body hangs the tool
+ * forever, because nothing is watching any more. `/api/markets` already takes
+ * 4-11s, so a slow body here is not hypothetical.
+ *
+ * Exported for tests — the timeout constants are module-level, and the abort
+ * path is only observable if a caller can pass a short one.
+ */
+export async function fetchPublicJson(url: string, timeoutMs: number): Promise<PublicResult> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    return await fetch(url, {
+    const resp = await fetch(url, {
       signal: ctrl.signal,
       headers: { "Content-Type": "application/json" },
     });
+    if (!resp.ok) {
+      let detail = `HTTP ${resp.status}`;
+      try {
+        const body = (await resp.json()) as Record<string, unknown>;
+        if (typeof body.detail === "string") detail = body.detail;
+      } catch { /* non-JSON error body */ }
+      throw new BackendError(resp.status, detail);
+    }
+    return (await resp.json()) as PublicResult;
   } finally {
     clearTimeout(timer);
   }
-}
-
-async function getJson(url: string, timeoutMs: number): Promise<PublicResult> {
-  const resp = await timedFetch(url, timeoutMs);
-  if (!resp.ok) {
-    let detail = `HTTP ${resp.status}`;
-    try {
-      const body = (await resp.json()) as Record<string, unknown>;
-      if (typeof body.detail === "string") detail = body.detail;
-    } catch { /* non-JSON error body */ }
-    throw new BackendError(resp.status, detail);
-  }
-  return (await resp.json()) as PublicResult;
 }
 
 /**
@@ -79,7 +86,7 @@ export async function browseMarkets(
   if (params.tags) qs.set("tags", params.tags);
   if (params.min_volume != null) qs.set("min_volume", String(params.min_volume));
   const query = qs.toString();
-  return getJson(`${apiUrl}/api/markets${query ? `?${query}` : ""}`, MARKETS_TIMEOUT_MS);
+  return fetchPublicJson(`${apiUrl}/api/markets${query ? `?${query}` : ""}`, MARKETS_TIMEOUT_MS);
 }
 
 /**
@@ -93,5 +100,5 @@ export async function getLeaderboard(
   const qs = new URLSearchParams();
   if (params.limit != null) qs.set("limit", String(Math.min(params.limit, 50)));
   const query = qs.toString();
-  return getJson(`${apiUrl}/api/leaderboard/all${query ? `?${query}` : ""}`, LEADERBOARD_TIMEOUT_MS);
+  return fetchPublicJson(`${apiUrl}/api/leaderboard/all${query ? `?${query}` : ""}`, LEADERBOARD_TIMEOUT_MS);
 }

--- a/mcp/src/public-api.ts
+++ b/mcp/src/public-api.ts
@@ -1,0 +1,97 @@
+/**
+ * Keyless reads against Simmer's public endpoints.
+ *
+ * Deliberately separate from `SimmerApi`: that class always sends
+ * `Authorization: Bearer <key>`, and here there is no key to send. An agent
+ * evaluating Simmer can browse the catalogue and the leaderboard before it
+ * has an account — the discovery surface should not require one.
+ *
+ * Both endpoints below are unauthenticated server-side. If that ever changes,
+ * these calls start returning 401 and the tools surface a BackendError rather
+ * than failing silently.
+ */
+
+import { BackendError } from "./errors.js";
+
+export interface BrowseMarketsParams {
+  q?: string;
+  limit?: number;
+  status?: string;
+  tags?: string;
+  min_volume?: number;
+}
+
+export interface PublicResult {
+  [key: string]: unknown;
+}
+
+// Measured against production 2026-08-15, warm and cold:
+//   /api/markets?limit=2      4.4 – 5.4s
+//   /api/markets?limit=200   10.3 – 10.8s
+//   /api/leaderboard/all      1.7 –  6.5s
+// The 5s default used elsewhere in this package aborts a plain market browse
+// outright. Don't lower these without re-measuring — a too-tight timeout here
+// reads to the agent as "Simmer is down", not "Simmer is slow".
+const MARKETS_TIMEOUT_MS = 20_000;
+const LEADERBOARD_TIMEOUT_MS = 15_000;
+
+async function timedFetch(url: string, timeoutMs: number): Promise<Response> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      signal: ctrl.signal,
+      headers: { "Content-Type": "application/json" },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function getJson(url: string, timeoutMs: number): Promise<PublicResult> {
+  const resp = await timedFetch(url, timeoutMs);
+  if (!resp.ok) {
+    let detail = `HTTP ${resp.status}`;
+    try {
+      const body = (await resp.json()) as Record<string, unknown>;
+      if (typeof body.detail === "string") detail = body.detail;
+    } catch { /* non-JSON error body */ }
+    throw new BackendError(resp.status, detail);
+  }
+  return (await resp.json()) as PublicResult;
+}
+
+/**
+ * Browse the public market catalogue. GET /api/markets — no auth.
+ *
+ * This is the discovery view. The authenticated `simmer_get_markets`
+ * (GET /api/sdk/markets) returns a richer payload with venue filtering and
+ * volume sorting; prefer it when a key is configured.
+ */
+export async function browseMarkets(
+  apiUrl: string,
+  params: BrowseMarketsParams = {},
+): Promise<PublicResult> {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set("q", params.q);
+  if (params.limit != null) qs.set("limit", String(Math.min(params.limit, 200)));
+  if (params.status) qs.set("status", params.status);
+  if (params.tags) qs.set("tags", params.tags);
+  if (params.min_volume != null) qs.set("min_volume", String(params.min_volume));
+  const query = qs.toString();
+  return getJson(`${apiUrl}/api/markets${query ? `?${query}` : ""}`, MARKETS_TIMEOUT_MS);
+}
+
+/**
+ * Public leaderboard across all four legs. GET /api/leaderboard/all — no auth.
+ * The endpoint fans out server-side; one call beats four.
+ */
+export async function getLeaderboard(
+  apiUrl: string,
+  params: { limit?: number } = {},
+): Promise<PublicResult> {
+  const qs = new URLSearchParams();
+  if (params.limit != null) qs.set("limit", String(Math.min(params.limit, 50)));
+  const query = qs.toString();
+  return getJson(`${apiUrl}/api/leaderboard/all${query ? `?${query}` : ""}`, LEADERBOARD_TIMEOUT_MS);
+}

--- a/mcp/tests/mcp-protocol.test.ts
+++ b/mcp/tests/mcp-protocol.test.ts
@@ -73,23 +73,45 @@ async function mcpCall(
 
 // --- tools/list ---
 
-test("tools/list without SIMMER_API_KEY returns exactly 3 free tools", async () => {
+test("tools/list without SIMMER_API_KEY returns the 9 keyless discovery tools", async () => {
   const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "" });
   assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
   const tools = (resp.result?.tools ?? []) as Array<{ name: string }>;
-  assert.equal(tools.length, 3, `Expected 3 tools, got ${tools.length}: ${tools.map((t) => t.name).join(", ")}`);
   const names = tools.map((t) => t.name);
+  // 5 hand-registered + 4 Tier-A instruction-only skills.
+  assert.equal(tools.length, 9, `Expected 9 tools, got ${tools.length}: ${names.join(", ")}`);
   assert.ok(names.includes("list_skills"), "list_skills missing");
   assert.ok(names.includes("get_skill_docs"), "get_skill_docs missing");
   assert.ok(names.includes("troubleshoot_error"), "troubleshoot_error missing");
+  assert.ok(names.includes("simmer_browse_markets"), "simmer_browse_markets missing");
+  assert.ok(names.includes("simmer_get_leaderboard"), "simmer_get_leaderboard missing");
+  // Tier A: instruction-only, pure SKILL.md reads — no key needed.
+  assert.ok(names.includes("simmer_simmer"), "simmer_simmer missing");
+  assert.ok(names.includes("simmer_simmer_briefing"), "simmer_simmer_briefing missing");
+  assert.ok(names.includes("simmer_simmer_mcp_setup"), "simmer_simmer_mcp_setup missing");
+  assert.ok(names.includes("simmer_simmer_wallet_setup"), "simmer_simmer_wallet_setup missing");
+});
+
+test("tools/list without SIMMER_API_KEY exposes no key-requiring tool", async () => {
+  const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "" });
+  const names = ((resp.result?.tools ?? []) as Array<{ name: string }>).map((t) => t.name);
+  // preflight is Tier B — its entrypoint hard-requires SIMMER_API_KEY and exits 2 without one.
+  for (const gated of [
+    "simmer_preflight", "simmer_trade", "simmer_cancel_order", "simmer_get_markets",
+    "simmer_get_market_context", "simmer_get_briefing", "get_portfolio", "get_positions",
+    "get_expiring_positions", "get_fleet_summary", "init_experiment", "run_experiment",
+    "log_experiment", "backtest_experiment",
+  ]) {
+    assert.equal(names.includes(gated), false, `${gated} must not be exposed without a key`);
+  }
 });
 
 test("tools/list with SIMMER_API_KEY returns core bundle plus raw market tools", async () => {
   const resp = await mcpCall("tools/list", {}, { SIMMER_API_KEY: "sk_test_key" });
   assert.ok(!resp.error, `Expected no error, got: ${JSON.stringify(resp.error)}`);
   const tools = (resp.result?.tools ?? []) as Array<{ name: string }>;
-  // 3 free + 4 autoresearch + 9 raw market/trade/data + 5 core bundled skills = 21
-  assert.equal(tools.length, 21, `Expected 21 tools with API key, got ${tools.length}: ${tools.map((t) => t.name).join(", ")}`);
+  // 9 keyless + 4 autoresearch + 9 raw market/trade/data + 1 Tier-B skill (preflight) = 23
+  assert.equal(tools.length, 23, `Expected 23 tools with API key, got ${tools.length}: ${tools.map((t) => t.name).join(", ")}`);
   const names = tools.map((t) => t.name);
   // Free tools always present
   assert.ok(names.includes("list_skills"), "list_skills missing");

--- a/mcp/tests/public-api.test.ts
+++ b/mcp/tests/public-api.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { browseMarkets, getLeaderboard } from "../dist/public-api.js";
+import { browseMarkets, getLeaderboard, fetchPublicJson } from "../dist/public-api.js";
 import { BackendError } from "../dist/errors.js";
 
 type FetchFn = typeof global.fetch;
@@ -95,6 +95,31 @@ describe("public-api — error surface", () => {
         return true;
       },
     );
+  });
+
+  it("aborts when the body stalls after headers arrive", async () => {
+    // Regression guard: clearing the abort timer as soon as fetch() resolves
+    // leaves a server that sends 200-then-nothing able to hang the tool
+    // forever. The timer must stay armed through body parsing.
+    // @ts-expect-error global override for testing
+    global.fetch = async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal;
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"markets":'));
+          // ...and never closes. Only the abort signal can end this.
+          signal?.addEventListener("abort", () => {
+            try { controller.error(new Error("aborted")); } catch { /* already errored */ }
+          });
+        },
+      });
+      return new Response(body, { status: 200, headers: { "Content-Type": "application/json" } });
+    };
+
+    const started = Date.now();
+    await assert.rejects(() => fetchPublicJson("https://api.simmer.markets/api/markets", 150));
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed < 5_000, `Expected abort near the 150ms deadline, hung for ${elapsed}ms`);
   });
 
   it("falls back to the status code when the error body is not JSON", async () => {

--- a/mcp/tests/public-api.test.ts
+++ b/mcp/tests/public-api.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the keyless public-endpoint reads.
+ *
+ * The property that matters most here is the NEGATIVE one: these calls must
+ * never send an Authorization header. They exist so an agent with no account
+ * can browse Simmer, and a stray header would 401 the very callers they serve.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { browseMarkets, getLeaderboard } from "../dist/public-api.js";
+import { BackendError } from "../dist/errors.js";
+
+type FetchFn = typeof global.fetch;
+let savedFetch: FetchFn;
+
+function captureFetch(status = 200, body: unknown = { markets: [] }) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  // @ts-expect-error global override for testing
+  global.fetch = async (url: string, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify(body), { status });
+  };
+  return calls;
+}
+
+describe("public-api — no credentials leave the process", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("browseMarkets sends no Authorization header", async () => {
+    const calls = captureFetch();
+    await browseMarkets("https://api.simmer.markets", { q: "weather" });
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    const keys = Object.keys(headers).map((k) => k.toLowerCase());
+    assert.equal(keys.includes("authorization"), false, "must not send Authorization");
+  });
+
+  it("getLeaderboard sends no Authorization header", async () => {
+    const calls = captureFetch(200, { sdk_agents: [] });
+    await getLeaderboard("https://api.simmer.markets");
+    const headers = (calls[0].init?.headers ?? {}) as Record<string, string>;
+    const keys = Object.keys(headers).map((k) => k.toLowerCase());
+    assert.equal(keys.includes("authorization"), false, "must not send Authorization");
+  });
+});
+
+describe("public-api — URL construction", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("hits the public catalogue endpoint, not the SDK one", async () => {
+    const calls = captureFetch();
+    await browseMarkets("https://api.simmer.markets", {});
+    assert.equal(calls[0].url, "https://api.simmer.markets/api/markets");
+  });
+
+  it("passes through search and filter params", async () => {
+    const calls = captureFetch();
+    await browseMarkets("https://api.simmer.markets", { q: "rain nyc", tags: "weather", status: "active" });
+    const u = new URL(calls[0].url);
+    assert.equal(u.searchParams.get("q"), "rain nyc");
+    assert.equal(u.searchParams.get("tags"), "weather");
+    assert.equal(u.searchParams.get("status"), "active");
+  });
+
+  it("caps limit at 200 for markets and 50 for the leaderboard", async () => {
+    const marketCalls = captureFetch();
+    await browseMarkets("https://api.simmer.markets", { limit: 9999 });
+    assert.equal(new URL(marketCalls[0].url).searchParams.get("limit"), "200");
+
+    const lbCalls = captureFetch(200, {});
+    await getLeaderboard("https://api.simmer.markets", { limit: 9999 });
+    assert.equal(new URL(lbCalls[0].url).searchParams.get("limit"), "50");
+  });
+
+  it("omits the query string entirely when no params are given", async () => {
+    const calls = captureFetch(200, {});
+    await getLeaderboard("https://api.simmer.markets");
+    assert.equal(calls[0].url, "https://api.simmer.markets/api/leaderboard/all");
+  });
+});
+
+describe("public-api — error surface", () => {
+  beforeEach(() => { savedFetch = global.fetch; });
+  afterEach(() => { global.fetch = savedFetch; });
+
+  it("throws BackendError carrying the server detail on 4xx", async () => {
+    captureFetch(429, { detail: "Rate limit exceeded" });
+    await assert.rejects(
+      () => browseMarkets("https://api.simmer.markets", {}),
+      (err: unknown) => {
+        assert.ok(err instanceof BackendError, `Expected BackendError, got ${err}`);
+        assert.equal(err.statusCode, 429);
+        assert.equal(err.body, "Rate limit exceeded");
+        return true;
+      },
+    );
+  });
+
+  it("falls back to the status code when the error body is not JSON", async () => {
+    // @ts-expect-error global override for testing
+    global.fetch = async () => new Response("<html>502</html>", { status: 502 });
+    await assert.rejects(
+      () => getLeaderboard("https://api.simmer.markets"),
+      (err: unknown) => {
+        assert.ok(err instanceof BackendError);
+        assert.equal(err.body, "HTTP 502");
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Why

An agent evaluating Simmer could read our docs and debug an error message. It could not see a single market, a single agent, or a single leaderboard row without first getting an API key.

Our keyless surface answered *"how do I use Simmer?"* but not *"is Simmer worth using?"* — and that second question comes first.

## What changed

**Keyless: 3 → 9. Keyed total: 21 → 23.**

### Four tools were gated for no reason

Tier-A skills have no entrypoint, so `invokeSkillTool` short-circuits and reads `SKILL.md` off disk — no network, no key. They sat inside the `if (simmer)` block as collateral damage from a loop that registered every skill uniformly.

The gate protected nothing: the same content was already reachable keyless via `get_skill_docs`. It only hid the ergonomic entry point. And two of the four (`simmer_simmer_mcp_setup`, `simmer_simmer_wallet_setup`) are **onboarding docs whose entire audience is agents that don't have a working key yet**.

The loop now splits on `skill.entrypoint` — the discriminator already used at `skill-discovery.ts:128` and `per-skill-tools.ts:97`. Tier B (`simmer_preflight`) stays gated; its entrypoint hard-requires `SIMMER_API_KEY` and exits 2 without one.

### Two new keyless tools on already-public endpoints

| Tool | Endpoint | Server-side auth |
|---|---|---|
| `simmer_browse_markets` | `GET /api/markets` | none (verified) |
| `simmer_get_leaderboard` | `GET /api/leaderboard/all` | none (verified) |

Both endpoints were already public and simply never wired to the MCP.

These live in a new `public-api.ts` rather than on `SimmerApi`, which always sends `Authorization: Bearer <key>`. Here there is no key to send, and a stray header would 401 the exact callers these serve — so a test asserts that negative directly.

### Timeouts set from measured latency

The 5s default used elsewhere **aborted a plain market browse outright** on the first end-to-end run. Measured against production:

| Call | Latency |
|---|---|
| `/api/markets?limit=2` | 4.4 – 5.4s |
| `/api/markets?limit=200` | 10.3 – 10.8s |
| `/api/leaderboard/all` | 1.7 – 6.5s |

Now 20s / 15s, with the measurements recorded in a comment so nobody tunes them back down blind. A too-tight timeout here reads to an agent as *"Simmer is down"*, not *"Simmer is slow."*

⚠️ **The underlying latency is a real problem for an agent-facing discovery surface and is NOT fixed here.** 4–11s to list markets is bad. Flagging, not addressing.

### Drive-by fix (unrelated, found while auditing)

`get_portfolio`, `get_positions`, `get_expiring_positions`, `get_fleet_summary` had no `try/catch`, while all six of their siblings wrap `BackendError` with `toMcpResponse()`. An expired-Pro user got an `upgrade_url` from `simmer_get_briefing` and a bare string from `get_portfolio` — same 403, different shape. Now consistent.

Startup tool counts were hardcoded (`3` free, `13 + skills.length` pro) and would have drifted; they now derive from skill tiers.

## Verification

End-to-end against **production** with `SIMMER_API_KEY` unset — all three newly-keyless paths return real data:

```
[simmer-mcp] v3.4.9 | tools: 9 (discovery only, 9 keyless) | skills: 5 bundled
id=2 simmer_browse_markets   isError=False len=8645
id=3 simmer_get_leaderboard  isError=False len=4384
id=4 simmer_simmer_mcp_setup isError=False len=15562
```

Keyed startup reports `23 (discovery + autoresearch + trading, 9 keyless)`.

Full suite **151/151 pass**, including the protocol tests that spawn the real server. New coverage: no-Authorization assertions, URL construction, limit caps, `BackendError` propagation, and an explicit test that no key-requiring tool leaks into the keyless list.

## Notes

- Version bumped 3.4.9 → **3.5.0** (new tools = minor). npm publish is a separate manual step.
- `server.json` is at 3.3.2 — pre-existing drift from `package.json`, untouched here.
- No backend changes. Nothing in this PR touches the `simmer` repo.

## Follow-ups (not in scope)

1. `/api/markets` latency — 4–11s on the primary discovery path.
2. `/api/sdk/markets` requires a key while the near-identical `/api/markets` is wide open. That's drift, not policy.
3. CORS is a hard allowlist (`simmer.markets`, `www`, `x402.`), so even our public endpoints are unreachable from a browser-resident agent on another origin.
4. No search-outcome instrumentation exists anywhere — we cannot currently tell what agents looked for and failed to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExG5gNuAwGmWYRe4uUY9xJ