### PR TITLE
docs: introduce the repo as the harness, not just the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 [![PyPI version](https://badge.fury.io/py/simmer-sdk.svg)](https://pypi.org/project/simmer-sdk/)
 
-Simmer is the leading prediction market interface for AI agents. Autonomous trading agents place trades on venues like Polymarket and Kalshi through a unified API and SDK — with self-custody wallets, safety rails, and smart context.
+Simmer is the leading prediction market harness for AI agents. Autonomous agents place trades on venues like Polymarket, Kalshi and Hyperliquid through a unified API — with self-custody wallets, safety rails, and smart context.
 
 - **AI-native trading platform** — designed for autonomous agents, with full support for manual trading too. Users install trading skills and let their agents trade autonomously.
 - **$SIM simulated trading** — paper-trade with virtual currency before risking real funds.
-- **Multi-venue** — trade Polymarket and Kalshi through one unified API.
+- **Multi-venue** — trade Polymarket, Kalshi and Hyperliquid through one unified API.
+
+## What's in this repo
+
+| | |
+|--|--|
+| [`skills/`](skills/) | 28 skills an agent installs and runs. `skills/simmer/SKILL.md` is the canonical source for [simmer.markets/skill.md](https://simmer.markets/skill.md). |
+| [`mcp/`](mcp/) | MCP server, published to npm as [`simmer-mcp`](https://www.npmjs.com/package/simmer-mcp). |
+| [`simmer_sdk/`](simmer_sdk/) | Python SDK, published to PyPI as [`simmer-sdk`](https://pypi.org/project/simmer-sdk/). |
 
 ## Installation
 


### PR DESCRIPTION
`simmer.markets/start` now calls Simmer a **"prediction market harness for AI agents"** and links here (SupaFund/simmer#1888). A reader following that link met a page that called itself a Python SDK and opened with `pip install`, with `## Skills` at line 290 of 326.

The contents were already harness-shaped. The introduction wasn't.

## Changes — all above line 20

| | |
|--|--|
| `interface` → `harness` | matches the front door |
| Venue list gains Hyperliquid | `simmer_sdk/` has carried `hyperliquid_venue.py` + `hyperliquid_signing.py` for a while, and `/start` already lists Hyperliquid publicly. The README was the stale one. |
| New "What's in this repo" table | names `skills/` (28), `mcp/`, `simmer_sdk/` so the first two are visible without scrolling past the SDK quickstart |

## Deliberately not changed

- **"leading"** stays. It's an existing marketing claim, not mine to quietly delete.
- **Nothing below `## Installation`.** The body still leads with pip. Reordering so skills come first is a bigger edit and a separate decision.

## Note

`# Simmer SDK` stays as the H1 — the repo is named `simmer-sdk` and publishes that PyPI package, so renaming it would fight the package identity. The table carries the "more than an SDK" point instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVFALbrW963hTt6uG3o18S
