### PR TITLE
feat: surface the server's go-live nudge on sim trades (0.24.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.3 (2026-08-18)
+
+- **Surface the server's go-live nudge on sim trades.** `TradeResult` gains `go_live` — a structured block the server attaches when a sim-only agent crosses an activity milestone (10/50/100/250 trades) and the account has never traded real. It lists the exact steps to go live, split by actor: agent steps (enable the real-trading flag, run `activate_polymarket_dw()` where needed) and owner steps (fund the wallet at the dashboard). With `include_hints=True`, the steps also land in `next_steps` so LLM agents relay them without extra parsing. Informational only; the SDK never acts on it.
+
 ## 0.24.2 (2026-08-07)
 
 - **Approvals warning now checks the deposit wallet, and stops handing DW users a no-op fix (SIM-4344).** `_warn_approvals_once()` called `check_approvals()` with no address, so it always checked the signer EOA. For deposit-wallet users approvals live on the DW, so the EOA is correctly empty and the warning fired every session on healthy accounts. It also told everyone to run `set_approvals()`, which signs from the EOA and does nothing for a DW user. Two customers chased this as a real fault while debugging unrelated rejections (SIM-4351, SIM-4377). Now checks the DW when `_uses_deposit_wallet`, and recommends `activate_polymarket_dw()` for that cohort. The remediation string matters more after this fix, not less: the warning no longer cries wolf, so users will act on it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.2"
+version = "0.24.3"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -140,6 +140,7 @@ class TradeResult:
     error_code: Optional[str] = None  # Machine-readable failure bucket.
     error_hint: Optional[str] = None  # Actionable next step for agents.
     next_steps: Optional[List[str]] = None  # Optional contextual follow-up hints.
+    go_live: Optional[dict] = None  # Server milestone nudge: steps to enable real trading (sim-only accounts).
 
     @property
     def shares_filled(self) -> float:
@@ -1980,6 +1981,13 @@ class SimmerClient:
             steps = ["Call get_positions(response_mode='summary') to verify exposure."]
             if result.order_id:
                 steps.append(f"Call cancel_order('{result.order_id}') if you need to cancel the open order.")
+            if result.go_live:
+                steps.append(result.go_live.get("reason", "Ready to go live."))
+                for s in result.go_live.get("steps", []):
+                    actor = s.get("actor", "owner")
+                    action = s.get("action", "")
+                    detail = s.get("method") or s.get("url") or ""
+                    steps.append(f"Go-live {actor} step: {action} ({detail})".rstrip(" ()"))
             return steps
         if result.error_hint:
             return [result.error_hint]
@@ -2654,6 +2662,7 @@ class SimmerClient:
                 fee_rate_bps=d.get("fee_rate_bps"),
                 error_code=d.get("error_code") or _structured.get("code"),
                 error_hint=d.get("error_hint") or d.get("hint") or _structured.get("hint"),
+                go_live=d.get("go_live"),
             )
             if include_hints:
                 result.next_steps = self._trade_next_steps(result)

--- a/tests/test_go_live_passthrough.py
+++ b/tests/test_go_live_passthrough.py
@@ -1,0 +1,89 @@
+"""go_live passthrough: the server's sim-milestone nudge must survive parsing.
+
+The server attaches a structured `go_live` block to successful sim-trade
+responses when a sim-only agent crosses an activity milestone. `_build_result`
+maps fields explicitly, so without a mapping the block is silently dropped —
+these tests pin the mapping and the include_hints surfacing in next_steps.
+"""
+
+from __future__ import annotations
+
+from simmer_sdk.client import SimmerClient, TradeResult
+
+GO_LIVE_BLOCK = {
+    "reason": "This agent has placed 10 simulated trades but real trading is not set up for this account.",
+    "sim_trades": 10,
+    "steps": [
+        {
+            "actor": "agent",
+            "action": "enable_real_trading",
+            "method": "PATCH /api/sdk/settings",
+            "body": {"sdk_real_trading_enabled": True},
+        },
+        {
+            "actor": "owner",
+            "action": "fund_wallet",
+            "url": "https://simmer.markets/dashboard",
+        },
+    ],
+}
+
+
+def _make_client(venue: str = "sim") -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client.live = True
+    client.venue = venue
+    client._private_key = None
+    client._ows_wallet = None
+    client._solana_private_key = None
+    client._held_markets_cache = None
+    client._approvals_warned = False
+    client.ORDER_TYPES = {"FAK", "FOK", "GTC", "GTD"}
+    client.VENUES = {"sim", "polymarket", "kalshi", "simmer"}
+    return client
+
+
+def _sim_response(**extra):
+    resp = {
+        "success": True,
+        "trade_id": "t1",
+        "market_id": "m1",
+        "side": "yes",
+        "shares_bought": 20.0,
+        "shares_requested": 20.0,
+        "cost": 10.0,
+        "new_price": 0.55,
+        "position": {"sim_balance": 9980.0},
+        "fill_status": "filled",
+    }
+    resp.update(extra)
+    return resp
+
+
+def test_trade_result_defaults_go_live_none():
+    assert TradeResult(success=True).go_live is None
+
+
+def test_go_live_block_survives_parsing():
+    client = _make_client()
+    client._request = lambda method, path, **kw: _sim_response(go_live=GO_LIVE_BLOCK)
+    result = client.trade(market_id="m1", side="yes", amount=10.0)
+    assert result.success
+    assert result.go_live == GO_LIVE_BLOCK
+
+
+def test_absent_go_live_stays_none():
+    client = _make_client()
+    client._request = lambda method, path, **kw: _sim_response()
+    result = client.trade(market_id="m1", side="yes", amount=10.0)
+    assert result.go_live is None
+
+
+def test_include_hints_surfaces_go_live_in_next_steps():
+    client = _make_client()
+    client._request = lambda method, path, **kw: _sim_response(go_live=GO_LIVE_BLOCK)
+    result = client.trade(market_id="m1", side="yes", amount=10.0, include_hints=True)
+    joined = " ".join(result.next_steps)
+    assert "10 simulated trades" in joined
+    assert "enable_real_trading" in joined
+    assert "fund_wallet" in joined


### PR DESCRIPTION
Companion to SupaFund/simmer#1910 (server attaches a structured `go_live` block to successful sim-trade responses at activity milestones when the account has never traded real).

- `TradeResult.go_live` + explicit `_build_result` mapping (without it the field is silently dropped).
- `include_hints=True` surfaces the steps in `next_steps` so LLM agents relay them without extra parsing.
- Informational only — the SDK never acts on the block.
- Tests: `tests/test_go_live_passthrough.py` (4 new); SIM-2238 TradeResult regressions still green (9 passed total).
- CHANGELOG + version 0.24.3.