### PR TITLE
feat: import_polymarket_wallet() + OWS per-agent deprecations (0.24.4, Refs SIM-4646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.5 (2026-08-19)
+
+- **`import_polymarket_wallet()` adopts the env wallet on a sim-default client.** `SimmerClient.from_env()` without `venue=` deliberately ignores `WALLET_PRIVATE_KEY` (sim-venue safety), which made the documented import snippet fail with "private_key or ows_wallet required". An explicit import call is unambiguous intent to use the local key, so the method now picks up `OWS_WALLET` / `WALLET_PRIVATE_KEY` itself when the client has no signer. Found in the SIM-4646 acceptance run.
+
 ## 0.24.4 (2026-08-19)
 
 - **`import_polymarket_wallet()` — one call from a polymarket.com export to trading-ready.** For wallets born on Polymarket (create account, fund via their onramps, export the key into the agent env): links the wallet with ownership proof, adopts the deposit wallet Polymarket already deployed (no redeploy), tops up the extended spender approvals gaslessly, and reports the balance. Also works for a self-generated key — the deposit-wallet step then deploys fresh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.24.4 (2026-08-19)
+
+- **`import_polymarket_wallet()` — one call from a polymarket.com export to trading-ready.** For wallets born on Polymarket (create account, fund via their onramps, export the key into the agent env): links the wallet with ownership proof, adopts the deposit wallet Polymarket already deployed (no redeploy), tops up the extended spender approvals gaslessly, and reports the balance. Also works for a self-generated key — the deposit-wallet step then deploys fresh.
+- **`link_wallet()` gains `confirm_orphan_deposit_wallet` and `source`.** The former passes through the server's SIM-1611 guard so accounts with an active deposit wallet can explicitly switch signing addresses from the SDK (previously the guard's error was a dead end for SDK callers). The latter tags onboarding-path attribution server-side; leave unset — the server infers `sdk-link`.
+- **OWS per-agent deprecations (entrance closure).** `register_agent_wallet(ows_wallet_name=...)` now emits a `DeprecationWarning` and declares `wallet_source='ows'`; the server rejects new OWS per-agent registrations with 410. `update_agent_wallet_creds(ows_wallet_name=...)` warns but keeps working for existing OWS per-agent wallets. NOT deprecated: `OWS_WALLET` as a local key store for the standard external path (`link_wallet()` and trade signing).
+
 ## 0.24.3 (2026-08-18)
 
 - **Surface the server's go-live nudge on sim trades.** `TradeResult` gains `go_live` — a structured block the server attaches when a sim-only agent crosses an activity milestone (10/50/100/250 trades) and the account has never traded real. It lists the exact steps to go live, split by actor: agent steps (enable the real-trading flag, run `activate_polymarket_dw()` where needed) and owner steps (fund the wallet at the dashboard). With `include_hints=True`, the steps also land in `next_steps` so LLM agents relay them without extra parsing. Informational only; the SDK never acts on it.

--- a/mcp/bundled-skills/simmer-wallet-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-wallet-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-wallet-setup
-version: "0.3.2"
+version: "0.4.0"
 published: true
-description: Self-custody wallet setup for Simmer agents. Choose OWS (recommended), external raw key, or connect an existing dashboard-registered agent to your local runtime. Skip this skill if you use a managed wallet — managed setup is a one-time dashboard flow, not an agent task.
+description: Self-custody wallet setup for Simmer agents. Bring your own key, import a funded Polymarket wallet, or connect an existing dashboard-registered agent to your local runtime. Skip this skill if you use a managed wallet — managed setup is a one-time dashboard flow, not an agent task.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.3.2"
+  version: "0.4.0"
   displayName: Simmer Wallet Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -13,12 +13,12 @@ metadata:
     - name: SIMMER_API_KEY
       required: true
       description: "Your Simmer SDK API key (from agent registration)."
-    - name: OWS_WALLET
-      required: false
-      description: "OWS wallet name. Set only if you chose Path A (OWS)."
     - name: WALLET_PRIVATE_KEY
       required: false
-      description: "Polygon EVM private key. Set only if you chose Path B (external raw key)."
+      description: "Polygon EVM private key. The standard self-custody signer."
+    - name: OWS_WALLET
+      required: false
+      description: "OWS wallet name. Optional key store — set instead of WALLET_PRIVATE_KEY if the key lives in an OWS vault."
 ---
 
 # Simmer Wallet Setup
@@ -27,140 +27,90 @@ Self-custody wallet setup for an agent that signs its own real-money trades on P
 
 | Mode | Who signs | When to choose |
 |---|---|---|
-| **OWS per-agent** (recommended) | Local OWS vault, encrypted at rest | Per-agent isolation, multi-chain, policy-gated signing. Available for Polymarket + Kalshi. |
-| **External raw key** | Local SDK with `WALLET_PRIVATE_KEY` env | Existing setups. Fully supported; OWS is recommended for new agents. |
-| **[Connect existing agent](#connect-existing-agent)** | Local OWS vault, imported from dashboard registration | You already activated a wallet in the dashboard and want to wire your existing runtime to use it. |
+| **[External key](#path-a--external-key)** (default) | Local SDK with `WALLET_PRIVATE_KEY` env — or an OWS key store via `OWS_WALLET` | Any self-custody setup: your own wallet, your key, your machine. |
+| **[Import a Polymarket wallet](#path-b--import-a-polymarket-wallet)** | Same local signing — key exported from polymarket.com | Fund with card/exchange via Polymarket's onramps; the wallet arrives at Simmer already funded and approved. |
+| **[Connect existing agent](#connect-existing-agent)** | Same local signing, wallet already registered in the dashboard | You already activated a dedicated per-agent wallet in the dashboard and want to wire your runtime to it. |
 
 > **Already on a managed wallet?** You don't need this skill — managed setup is a dashboard flow, not an agent task. Open [simmer.markets/dashboard](https://simmer.markets/dashboard?ref=sdk-skill&utm_campaign=sdk-skill), go to your agent's **Wallet** tab, and click **Fund & activate trading**. The wizard opens a multi-chain bridge that accepts USDC, USDT, or USDC.e on Ethereum / Polygon / Base / Arbitrum / Solana — funds land as pUSD on your Polymarket Deposit Wallet, contracts auto-approve. **Do not tell the user to send funds directly to their agent wallet's EOA expecting them to sweep** — only legacy USDC.e on Polygon is recognized on the direct path; native USDC, USDT, and cross-chain tokens must go through the bridge wizard.
 
-## Path A — OWS per-agent wallet (recommended)
+## Key safety (read this first)
 
-OWS = [Open Wallet Standard](https://openwallet.sh). Local-first encrypted vault, multi-chain, policy engine, agent-scoped API keys. The private key never leaves the local machine.
+The private key goes in exactly one place: the agent host's environment, or a local key store.
 
-### One-time setup
+- Use `read -s` to set it — never paste a key into a pipe, a chat, a ticket, a shared config file, or a second browser extension "just to sign" (per SIM-2118):
+  ```bash
+  read -s -p 'WALLET_PRIVATE_KEY: ' K && export WALLET_PRIVATE_KEY=$K
+  ```
+- **Prefer a key store over a bare env var.** [OWS](https://openwallet.sh) (Open Wallet Standard) keeps the key encrypted at rest (AES-256-GCM); the SDK picks it up via `OWS_WALLET` and signs through the vault. Its policy engine can scope the agent's signing token to Polymarket orders only.
+  ```bash
+  curl -fsSL https://docs.openwallet.sh/install.sh | bash   # one-time OWS install
+  pip install 'simmer-sdk[ows]'
+  ows wallet import --name "my-agent-wallet" --private-key "$WALLET_PRIVATE_KEY"
+  unset WALLET_PRIVATE_KEY
+  export OWS_WALLET=my-agent-wallet   # SDK signs via the vault from here
+  ```
+- If a key ever touches a chat or shared surface, treat it as compromised: withdraw to a fresh wallet and start over.
 
-```bash
-# Install OWS CLI (creates ~/.ows vault, runs `ows wallet create`)
-curl -fsSL https://docs.openwallet.sh/install.sh | bash
+## Path A — External key
 
-# Install the SDK with OWS Python bindings (one command — note the [ows] extra)
-pip install 'simmer-sdk[ows]'
-
-# Create a wallet for this agent
-ows wallet create --name "my-agent-wallet"
-# Stores at ~/.ows/wallets/, derives addresses for EVM (Polygon), Solana, etc.
-
-# Fund it — show the EVM address to the human, they bridge USDC.e to Polygon
-ows wallet show my-agent-wallet
-```
-
-### Register the wallet with Simmer
-
-```python
-from simmer_sdk import SimmerClient
-client = SimmerClient(
-    api_key="sk_live_...",
-    ows_wallet="my-agent-wallet",   # name from `ows wallet create`
-)
-
-wallet = client.register_agent_wallet(ows_wallet_name="my-agent-wallet")  # one-time, Elite-tier gated, fully headless
-client.activate_polymarket_dw(agent_id=wallet["agent_id"])   # sets on-chain CLOB approvals on the agent's deposit wallet — signs via OWS, gasless relay, headless
-client.update_agent_wallet_creds(ows_wallet_name="my-agent-wallet")  # caches CLOB API creds server-side
-```
-
-> All three calls are fully headless — they authenticate with your SDK API key, no dashboard session or browser required. `register_agent_wallet()` requires Elite tier. `activate_polymarket_dw(agent_id=...)` sets the deposit-wallet approvals; `update_agent_wallet_creds()` then caches CLOB creds. Both are required before trading — caching creds alone does not set on-chain allowances. (Don't use `set_approvals()` here — that's the user-primary EOA path and a no-op for per-agent deposit wallets.) After all three run once, all trading is API-only.
->
-> Elite users can alternatively register a per-agent wallet through the dashboard's agent-creation wizard (My Agents → Create agent → optional "Link dedicated wallet" step) or retrofit an existing agent via its Wallet tab. The SDK path and the dashboard path produce the same `user_agent_wallets` row — pick whichever fits your workflow.
-
-(Alternative: set `OWS_WALLET=my-agent-wallet` in the environment and pass only `api_key` — the SDK auto-detects.)
-
-### Trade — same API, OWS routes the signing
-
-```python
-result = client.trade(
-    market_id, "yes", 10.0,
-    venue="polymarket",
-    reasoning="..."
-)
-# SDK builds the order, OWS signs locally, broadcast goes through Simmer
-```
-
-### For Kalshi (Solana)
-
-OWS is multi-chain. The same wallet has a Solana account derived automatically.
-
-```bash
-ows wallet show my-agent-wallet  # shows Solana address too
-# Fund with SOL + USDC, complete KYC at dflow.net/proof
-```
-
-```python
-client = SimmerClient(
-    api_key="sk_live_...",
-    ows_wallet="my-agent-wallet",
-    venue="kalshi",
-)
-client.trade(market_id, "yes", 5.0, reasoning="...")
-```
-
-No `SOLANA_PRIVATE_KEY` env var needed — OWS handles signing through the same vault.
-
-### What OWS gives over raw keys
-
-- **Encrypted at rest** (AES-256-GCM, scrypt KDF). Private key only decrypted in-process for signing, then wiped.
-- **Policy engine** — chain allowlists, daily caps, contract allowlists. Optional.
-- **Multi-chain** — same vault, every chain Simmer supports.
-- **Per-agent isolation** — separate wallets per agent for clean P&L attribution.
-- **Agent API keys** with bounded access (revocable, expiring).
-
-## Path B — External raw key
-
-> Fully supported path for self-custody with an existing wallet. New agents should consider OWS first — same self-custody guarantee, encrypted at rest, multi-chain, and easier to layer policy controls. Raw-key flow stays supported for users who already have it set up.
-
-Set the key in the environment, then construct the client:
-
-```bash
-export WALLET_PRIVATE_KEY="0x..."  # Polymarket Polygon wallet
-```
+Set the key (see key safety above), then construct the client:
 
 ```python
 client = SimmerClient(api_key="sk_live_...")
-# private_key is auto-detected from WALLET_PRIVATE_KEY env var
+# signer auto-detected: WALLET_PRIVATE_KEY or OWS_WALLET env var
 client.link_wallet()    # signs a challenge message locally — fully headless
 client.set_approvals()  # signs approval txs locally — fully headless, key never leaves agent
 
-# If your account uses a Polymarket Deposit Wallet (Elite / upgraded accounts):
+# If your account uses a Polymarket Deposit Wallet (upgraded accounts):
 client.activate_polymarket_dw()  # one-time — signs EIP-712 batch locally, no browser needed
 
 # If you have stranded USDC.e on your Deposit Wallet, wrap it to pUSD:
 result = client.wrap_on_dw()  # idempotent — no-op when nothing stranded
 ```
 
-Both calls work without a browser session. `link_wallet()` signs a challenge with your local key. `set_approvals()` builds, signs, and broadcasts each approval transaction via Simmer's RPC proxy — your `WALLET_PRIVATE_KEY` never leaves the agent process.
+All calls work without a browser session. `link_wallet()` signs a challenge with your local key. `set_approvals()` builds, signs, and broadcasts each approval transaction via Simmer's RPC proxy — your key never leaves the agent process.
 
 > **Using a Deposit Wallet?** If your account has been upgraded to a Polymarket Deposit Wallet (DW), run `client.activate_polymarket_dw()` after `set_approvals()` — it signs the EIP-712 activation batch headlessly with your local key. Alternatively, use the dashboard browser flow at [simmer.markets/dashboard](https://simmer.markets/dashboard?ref=sdk-skill&utm_campaign=sdk-skill) → Wallets → Activate Trading.
 
-> **Browser-backed per-agent wallet?** If the dashboard created a dedicated wallet for an agent and your bot has that wallet's `WALLET_PRIVATE_KEY`, run `client.activate_polymarket_dw(agent_id="<agent_id>")` first, then `client.update_agent_wallet_creds(agent_id="<agent_id>")`. The second call derives CLOB API creds locally from the EOA signer and caches them on the existing per-agent wallet row.
+> **Stranded USDC.e on your DW?** Run `client.wrap_on_dw()` to convert it to pUSD headlessly. Idempotent — safe to call on every startup; returns immediately if nothing is stranded. Returns `{"wrapped": bool, "amount_units": int, "calls_count": int, "success": bool}`. Requires the same signer as `activate_polymarket_dw()`. Added in SDK 0.17.7.
 
-> **Stranded USDC.e on your DW?** Run `client.wrap_on_dw()` to convert it to pUSD headlessly. Idempotent — safe to call on every startup; returns immediately if nothing is stranded. Returns `{"wrapped": bool, "amount_units": int, "calls_count": int, "success": bool}`. Requires the same key as `activate_polymarket_dw()` (WALLET_PRIVATE_KEY or OWS wallet). Added in SDK 0.17.7.
+### For Kalshi (Solana)
 
-### Migrating to OWS when ready
-
-No rush. When ready, import the existing key into OWS and switch over:
-
-```bash
-ows wallet import --name "my-agent-wallet" --private-key "$WALLET_PRIVATE_KEY"
-unset WALLET_PRIVATE_KEY  # OWS handles signing from here
-```
-
-Then in the agent code:
+Set `SOLANA_PRIVATE_KEY` (base58) in the env, fund with SOL + USDC, complete KYC at dflow.net/proof. If the key lives in an OWS vault, the same wallet's derived Solana account signs — no `SOLANA_PRIVATE_KEY` needed:
 
 ```python
-client = SimmerClient(api_key="sk_live_...", ows_wallet="my-agent-wallet")
-# Same trade() / set_approvals() / redeem() API — OWS routes the signing
+client = SimmerClient.from_env(venue="kalshi")
+client.trade(market_id, "yes", 5.0, reasoning="...")
 ```
 
-The same wallet address is preserved, so existing positions and approvals carry over.
+## Path B — Import a Polymarket wallet
+
+For a wallet born on polymarket.com: create the account there, fund it with their onramps (card, exchange transfer), export the private key (polymarket.com → Settings → Export Private Key), and set it as `WALLET_PRIVATE_KEY` on the agent host (key safety above applies in full — this is a raw key).
+
+```python
+client = SimmerClient.from_env()
+result = client.import_polymarket_wallet()   # SDK 0.24.4+
+# links with ownership proof, adopts the Polymarket-deployed deposit wallet
+# (no redeploy), tops up approvals gaslessly, derives creds, reports balance
+```
+
+The wallet arrives already funded and approved — Polymarket deployed the deposit wallet and pre-set the core exchange allowance. Note the shared surface: manual trades on polymarket.com use the same wallet as the agent and can collide with its positions.
+
+Docs: [docs.simmer.markets/polymarket-import](https://docs.simmer.markets/polymarket-import).
+
+## Dedicated per-agent wallets (Elite)
+
+Elite accounts can give each agent its own wallet (own EOA + own deposit wallet, clean per-agent P&L). **Register the wallet from the dashboard** (My Agents → your agent → Add wallet), then activate on the host where the key lives:
+
+```python
+# WALLET_PRIVATE_KEY must be set to the agent EOA private key.
+client.activate_polymarket_dw(agent_id="<agent_id>")     # sets on-chain approvals — OWS/raw-key signed, gasless relay
+client.update_agent_wallet_creds(agent_id="<agent_id>")  # derives + caches CLOB creds
+```
+
+Both calls are required (approvals first) and idempotent. Don't use `set_approvals()` here — that's the user-primary EOA path and a no-op for per-agent deposit wallets. Get `<agent_id>` from `client.get_agent_wallets()`.
+
+> **Existing OWS per-agent wallets:** new OWS per-agent registrations are closed (`register_agent_wallet()` is deprecated and the server rejects it), but wallets already registered on that path keep working unchanged — `client.update_agent_wallet_creds(ows_wallet_name="<wallet>")` remains supported for them. OWS as a key store for the standard path (everything above) is unaffected.
 
 ## Polymarket token note
 
@@ -174,7 +124,7 @@ Either way, after setup `client.set_approvals()` should report `all_set=True`. I
 
 ## Connect existing agent
 
-You already created an agent in the dashboard and have its API key. Now wire it to your locally-running agent runtime.
+You already created an agent in the dashboard, registered its dedicated wallet, and have its API key. Now wire it to your locally-running agent runtime.
 
 ### Prerequisites
 - API key (from dashboard → agent settings → API key, or wizard success modal)
@@ -185,34 +135,27 @@ You already created an agent in the dashboard and have its API key. Now wire it 
 
 1. **Install packages**
    ```bash
-   pip install 'simmer-sdk[ows]'
+   pip install simmer-sdk          # add [ows] extra if using the OWS key store
    ```
 
-2. **Import wallet key into OWS**
-   ```bash
-   ows wallet add <name> --private-key <your-eoa-private-key>
-   ```
-   Choose a memorable `<name>` (e.g. `my-agent-trading`). This becomes your `OWS_WALLET` env var.
-
-3. **Set env vars in your agent runtime**
+2. **Set env vars in your agent runtime**
    Use `read -s` to avoid clipboard contamination (per SIM-2118):
    ```bash
    read -s -p 'SIMMER_API_KEY: ' KEY && export SIMMER_API_KEY=$KEY
-   export OWS_WALLET=<name>
+   read -s -p 'WALLET_PRIVATE_KEY: ' K && export WALLET_PRIVATE_KEY=$K
    ```
+   (Optionally import the key into OWS instead — see key safety above — and set `OWS_WALLET`.)
 
-4. **Activate trading: on-chain approvals + CLOB credentials (one-time)**
+3. **Activate trading: on-chain approvals + CLOB credentials (one-time)**
    ```bash
    python -c "from simmer_sdk import SimmerClient; \
      c = SimmerClient.from_env(venue='polymarket'); \
      c.activate_polymarket_dw(agent_id='<agent_id>'); \
-     c.update_agent_wallet_creds(ows_wallet_name='<name>')"
+     c.update_agent_wallet_creds(agent_id='<agent_id>')"
    ```
-   First sets the deposit wallet's on-chain CLOB approvals (OWS-signed EIP-712 batch, relayed gasless), then derives + caches CLOB creds server-side. **Both** are required before any Polymarket trades — approvals alone or creds alone is not enough. Get `<agent_id>` from `client.get_agent_wallets()`.
+   First sets the deposit wallet's on-chain CLOB approvals (locally-signed EIP-712 batch, relayed gasless), then derives + caches CLOB creds server-side. **Both** are required before any Polymarket trades — approvals alone or creds alone is not enough. Get `<agent_id>` from `client.get_agent_wallets()`. (Existing OWS-registered wallets replace the final call with `c.update_agent_wallet_creds(ows_wallet_name='<name>')`.)
 
-   For browser-backed raw-key per-agent wallets, keep the same approvals call and replace the final line with `c.update_agent_wallet_creds(agent_id='<agent_id>')`.
-
-5. **Verify**
+4. **Verify**
    ```bash
    python -c "from simmer_sdk import SimmerClient; \
      c = SimmerClient.from_env(); \
@@ -229,13 +172,14 @@ The auto risk monitor (stop-loss, take-profit) is configured at simmer.markets/d
 
 ## Troubleshooting
 
-- **"External wallet requires a pre-signed order"** → key not configured. For OWS: `ows wallet list` to verify the wallet exists. For external: confirm `WALLET_PRIVATE_KEY` is set.
-- **"insufficient allowance"** → set approvals once per wallet: `client.activate_polymarket_dw(agent_id=...)` for a per-agent OWS/deposit-wallet, or `client.set_approvals()` for a raw-key/user-primary EOA wallet.
+- **"External wallet requires a pre-signed order"** → key not configured. Confirm `WALLET_PRIVATE_KEY` is set — or, for an OWS key store, `ows wallet list` to verify the wallet exists and `OWS_WALLET` is set.
+- **"insufficient allowance"** → set approvals once per wallet: `client.activate_polymarket_dw(agent_id=...)` for a per-agent deposit wallet, `client.activate_polymarket_dw()` for a user-primary deposit wallet, or `client.set_approvals()` for a legacy raw-key EOA wallet.
 - **Balance shows $0 but funds visible elsewhere** → check chain (Polygon vs Solana) and token (pUSD vs USDC.e). See dashboard migration tool for V2 conversion.
 - **API key format wrong / 401 with a key that "looks set"** → inspect the raw value: `printenv SIMMER_API_KEY | cut -c1-20`. Must start with `sk_live_`. A common silent failure: install commands that use `pbpaste` or similar clipboard-read primitives write the *install command text itself* as the key value when the user copies the command after copying the key. Fix: get a fresh key from simmer.markets/dashboard, then `export SIMMER_API_KEY="sk_live_..."` (type/paste the key directly, never pipe from clipboard into the variable assignment).
 
 ## Links
 
+- Polymarket wallet import: [docs.simmer.markets/polymarket-import](https://docs.simmer.markets/polymarket-import)
 - OWS docs: [openwallet.sh](https://openwallet.sh)
 - Simmer wallet docs: [docs.simmer.markets/wallets](https://docs.simmer.markets/wallets)
 - V2 migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)

--- a/mcp/bundled-skills/simmer-wallet-setup/clawhub.json
+++ b/mcp/bundled-skills/simmer-wallet-setup/clawhub.json
@@ -16,14 +16,14 @@
       "description": "Your Simmer SDK API key (from agent registration)."
     },
     {
-      "name": "OWS_WALLET",
-      "required": false,
-      "description": "OWS wallet name. Set only if you chose Path A (OWS)."
-    },
-    {
       "name": "WALLET_PRIVATE_KEY",
       "required": false,
-      "description": "Polygon EVM private key. Set only if you chose Path B (external raw key)."
+      "description": "Polygon EVM private key. The standard self-custody signer."
+    },
+    {
+      "name": "OWS_WALLET",
+      "required": false,
+      "description": "OWS wallet name. Optional key store — set instead of WALLET_PRIVATE_KEY if the key lives in an OWS vault."
     }
   ],
   "cron": null,

--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.9"
+  version: "1.24.10"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -91,7 +91,7 @@ Documentation references — open when the situation matches.
 
 | When | Where |
 |---|---|
-| Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers OWS (recommended), external raw key, and managed paths |
+| Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers external self-custody (your own key, with OWS as an optional key store), importing a funded Polymarket wallet, and managed paths |
 | Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. |
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
@@ -104,7 +104,7 @@ Documentation references — open when the situation matches.
 - **Order behavior**: `client.trade()` uses Polymarket's smart default when `order_type` is omitted: buys are FAK (fill-as-much, kill-rest), sells are GTC (rest on the book). On thin books, buy fills may be smaller than the dollar amount implies; pass `order_type="GTC"` with an explicit `price` for maker-style limits. Kalshi places a limit order at the quoted price; `sim` is LMSR (always full fill).
 - **Auto-redeem** (managed wallets only): ON by default. Winning Polymarket positions are claimed automatically. Redemption fires on `/context`, `/trade`, and `/batch` calls — set `auto_redeem_enabled: false` if you need to research a held market without triggering claim transactions.
 - **Edge vs costs**: real venues have 1-5% spreads plus venue fees. Don't trade unless your edge clears ~5% net of costs. Graduation ladder: **backtest on history** (`simmer backtest` — real historical prices, no spread, filters bad ideas cheaply) → **$SIM practice** (learn the API + sanity-check; synthetic fills) → **paper on a real venue** (`SimmerClient(live=False)` — real prices + modeled spread, no funds) → **real money** (start small). Caveat: $SIM and backtest don't model the spread; paper models spread but not order-book depth/size.
-- **Tiers**: Free / Pro (3× rate limits) / Elite (10× + per-agent OWS wallets). Pricing at [simmer.markets/pricing](https://simmer.markets/pricing?ref=sdk-skill&utm_campaign=sdk-skill).
+- **Tiers**: Free / Pro (3× rate limits) / Elite (10× + dedicated per-agent wallets). Pricing at [simmer.markets/pricing](https://simmer.markets/pricing?ref=sdk-skill&utm_campaign=sdk-skill).
 
 ## API surface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.3"
+version = "0.24.4"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.4"
+version = "0.24.5"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -5479,6 +5479,8 @@ class SimmerClient:
         self,
         signature_type: int = 0,
         confirm_replace_managed: bool = True,
+        confirm_orphan_deposit_wallet: bool = False,
+        source: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Link an external wallet to your Simmer account.
@@ -5502,6 +5504,18 @@ class SimmerClient:
                 migration cannot silently displace the managed wallet — the
                 relink fails loud with an actionable 4xx instead. Server-side
                 guard: SIM-1580.
+            confirm_orphan_deposit_wallet: Required (`True`) when this account
+                already has an ACTIVE Polymarket deposit wallet and you are
+                linking a DIFFERENT signing address. The DW is bound on-chain
+                to the current EOA (CREATE2), so the server refuses the relink
+                by default — the current setup's funds and positions stay on
+                its deposit wallet in the legacy slot, and you can toggle back
+                anytime. Default `False` so the switch is always explicit.
+                Server-side guard: SIM-1611.
+            source: Optional onboarding-path tag stored server-side for funnel
+                attribution ('browser' | 'sdk-link' | 'polymarket-import').
+                Leave unset — the server infers 'sdk-link' for SDK calls.
+                `import_polymarket_wallet()` sets 'polymarket-import'.
 
         Returns:
             Dict with success status and wallet info. When `success` is True,
@@ -5577,6 +5591,8 @@ class SimmerClient:
                 "nonce": nonce,
                 "signature_type": signature_type,
                 "confirm_replace_managed": confirm_replace_managed,
+                "confirm_orphan_deposit_wallet": confirm_orphan_deposit_wallet,
+                "source": source,
             }
         )
 
@@ -5613,6 +5629,119 @@ class SimmerClient:
                 )
 
         return result
+
+    def import_polymarket_wallet(
+        self,
+        confirm_replace_managed: bool = True,
+        confirm_orphan_deposit_wallet: bool = False,
+    ) -> Dict[str, Any]:
+        """Import a wallet exported from polymarket.com — one call to trading-ready.
+
+        For wallets born on Polymarket (create account there, fund via their
+        onramps, export the private key, put it in this agent's env as
+        `WALLET_PRIVATE_KEY`). Polymarket has already deployed the deposit
+        wallet and pre-set the core exchange allowance, so this composes the
+        existing steps end-to-end:
+
+        1. `link_wallet(source='polymarket-import')` — proves ownership by
+           signing a server challenge with the local key, and derives CLOB
+           credentials.
+        2. Adopts the Polymarket-deployed deposit wallet at its derived
+           address (no redeploy — the server recognizes it on-chain).
+        3. `activate_polymarket_dw()` — gasless top-up of any extended
+           spender approvals beyond what Polymarket pre-sets.
+        4. Reports the deposit-wallet balance.
+
+        Also works for a wallet you generated yourself — step 2 then deploys
+        a fresh deposit wallet instead of adopting one.
+
+        Key safety: the private key belongs in the agent host env (or a key
+        store like OWS — the SDK picks it up via `OWS_WALLET`). Never paste it
+        into chat, shared configs, or a browser extension. Note manual trades
+        on polymarket.com share this wallet with your agent — positions show
+        on both surfaces and can collide.
+
+        Args:
+            confirm_replace_managed: See `link_wallet()`. Default True — an
+                explicit import call means "I want self-custody".
+            confirm_orphan_deposit_wallet: See `link_wallet()`. Required True
+                when the account already has an active deposit wallet on a
+                different address (e.g. switching a managed-DW account to the
+                imported wallet). Default False so that switch is explicit.
+
+        Returns:
+            Dict with: success, wallet_address, deposit_wallet_address,
+            dw_already_existed, approvals (dict from activate_polymarket_dw),
+            clob_credentials_registered, balance_usd (best-effort, may be
+            None), and error when a step failed.
+        """
+        # Step 1 — prove ownership + link, tagged for funnel attribution.
+        result = self.link_wallet(
+            confirm_replace_managed=confirm_replace_managed,
+            confirm_orphan_deposit_wallet=confirm_orphan_deposit_wallet,
+            source="polymarket-import",
+        )
+        if not result.get("success"):
+            return {
+                "success": False,
+                "step": "link",
+                "error": result.get("error") or "Wallet link failed",
+                **{k: v for k, v in result.items() if k not in ("success", "error")},
+            }
+
+        summary: Dict[str, Any] = {
+            "success": True,
+            "wallet_address": result.get("wallet_address") or self._wallet_address,
+            "clob_credentials_registered": result.get("clob_credentials_registered"),
+        }
+
+        # Step 2 — adopt (or deploy) the deposit wallet. Idempotent server-side:
+        # a Polymarket-born wallet's DW already exists on-chain at the CREATE2
+        # address, so this registers it without a redeploy.
+        print("[PM-Import] Adopting deposit wallet…")
+        try:
+            upgrade = self._request(
+                "POST", "/api/user/wallet/external-upgrade-to-deposit-wallet"
+            )
+        except Exception as e:
+            summary.update({
+                "success": False,
+                "step": "deposit_wallet",
+                "error": f"Deposit-wallet adoption failed: {e}",
+            })
+            return summary
+        summary["deposit_wallet_address"] = upgrade.get("deposit_wallet_address")
+        summary["dw_already_existed"] = bool(upgrade.get("already_existed"))
+
+        # Step 3 — gasless allowance top-up for the extended spender set.
+        try:
+            summary["approvals"] = self.activate_polymarket_dw()
+        except Exception as e:
+            summary.update({
+                "success": False,
+                "step": "approvals",
+                "error": f"Approval activation failed: {e}",
+            })
+            return summary
+
+        # Step 4 — best-effort balance for the closing summary.
+        balance_usd: Optional[float] = None
+        try:
+            briefing = self._request("GET", "/api/sdk/briefing")
+            _pm = (briefing.get("venues") or {}).get("polymarket") or {}
+            if _pm.get("balance") is not None:
+                balance_usd = float(_pm["balance"])
+        except Exception:
+            pass
+        summary["balance_usd"] = balance_usd
+
+        _bal = f"${balance_usd:,.2f}" if balance_usd is not None else "unknown"
+        print(
+            f"[PM-Import] You're live — wallet {summary['wallet_address'][:10]}… "
+            f"linked, deposit wallet {str(summary['deposit_wallet_address'])[:10]}… "
+            f"active, balance {_bal}."
+        )
+        return summary
 
     def check_approvals(self, address: Optional[str] = None, no_cache: bool = False, include_tx_params: bool = False) -> Dict[str, Any]:
         """
@@ -6554,11 +6683,14 @@ class SimmerClient:
     def register_agent_wallet(self, ows_wallet_name: str) -> dict:
         """Register an OWS wallet for this agent. Elite-only (beta).
 
-        Creates a per-agent wallet record on the server. After registration,
-        set on-chain approvals via activate_polymarket_dw(agent_id=...), then
-        call update_agent_wallet_creds(ows_wallet_name=...) to cache CLOB
-        credentials server-side. Both are required before trading. (set_approvals()
-        is the user-primary EOA path and is a no-op for per-agent deposit wallets.)
+        .. deprecated::
+            New OWS per-agent registrations are closed server-side (the server
+            returns 410). Use the raw-key per-agent path instead: register the
+            agent's EOA via the dashboard wizard, then cache CLOB credentials
+            with ``update_agent_wallet_creds(agent_id=..., private_key=...)``.
+            Existing OWS per-agent wallets keep working. OWS as a local key
+            store for the STANDARD external path (``OWS_WALLET`` +
+            ``link_wallet()``) is NOT deprecated.
 
         Args:
             ows_wallet_name: Name of the OWS wallet (e.g. "agent-mybot")
@@ -6566,13 +6698,26 @@ class SimmerClient:
         Returns:
             dict with wallet record (id, agent_id, wallet_address, approvals_set)
         """
+        import warnings
+        warnings.warn(
+            "register_agent_wallet(ows_wallet_name=...) is deprecated — the "
+            "server no longer accepts new OWS per-agent registrations. Use the "
+            "raw-key per-agent path (update_agent_wallet_creds(agent_id=..., "
+            "private_key=...)) instead. OWS_WALLET as a signer for the "
+            "standard external path (link_wallet()) is unaffected.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from simmer_sdk.ows_utils import get_ows_wallet_address
         wallet_address = get_ows_wallet_address(ows_wallet_name)
 
         # agent_id is derived server-side from the API key — no need to pass it.
+        # wallet_source is declared truthfully: this address came from an OWS
+        # vault, and the server's SIM-4646 entrance-closure guard keys on it.
         resp = self._request("POST", "/api/sdk/agent-wallet/register", json={
             "ows_wallet_name": ows_wallet_name,
             "wallet_address": wallet_address,
+            "wallet_source": "ows",
         })
         return resp
 
@@ -6651,6 +6796,14 @@ class SimmerClient:
         Args:
             ows_wallet_name: Name of the OWS wallet. Positional usage remains
                 supported for existing callers.
+
+                .. deprecated::
+                    The OWS per-agent branch is deprecated (new OWS per-agent
+                    registrations are closed; existing OWS per-agent wallets
+                    keep working through this call). Prefer the raw-key form
+                    ``update_agent_wallet_creds(agent_id=..., private_key=...)``.
+                    OWS as a key store for the STANDARD external path
+                    (``OWS_WALLET`` + ``link_wallet()``) is NOT deprecated.
             agent_id: SDK agent ID from the dashboard. Required for raw-key
                 calls so callers make the per-agent target explicit.
             private_key: Optional raw EOA private key. Defaults to this
@@ -6663,6 +6816,17 @@ class SimmerClient:
             raise ValueError("Pass either ows_wallet_name or private_key, not both")
 
         if ows_wallet_name:
+            import warnings
+            warnings.warn(
+                "update_agent_wallet_creds(ows_wallet_name=...) is deprecated "
+                "for per-agent wallets — existing OWS per-agent wallets keep "
+                "working, but new registrations are closed. Prefer "
+                "update_agent_wallet_creds(agent_id=..., private_key=...). "
+                "OWS_WALLET as a signer for the standard external path "
+                "(link_wallet()) is unaffected.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             from simmer_sdk.ows_utils import get_ows_wallet_address, ows_derive_clob_creds
             wallet_address = get_ows_wallet_address(ows_wallet_name)
             creds = ows_derive_clob_creds(ows_wallet_name)

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -5675,6 +5675,26 @@ class SimmerClient:
             clob_credentials_registered, balance_usd (best-effort, may be
             None), and error when a step failed.
         """
+        # Calling this method IS explicit intent to use the local key, so adopt
+        # the env wallet even when the client was built with the sim-venue
+        # default (`from_env()` sets _ignore_env_wallets=True there, which
+        # otherwise makes the copy-paste import snippet fail with "private_key
+        # required"). OWS first, mirroring constructor precedence.
+        if not (self._private_key or self._ows_wallet):
+            _env_ows = os.environ.get("OWS_WALLET")
+            if _env_ows:
+                from simmer_sdk.ows_utils import get_ows_wallet_address
+                self._ows_wallet = _env_ows
+                self._wallet_address = get_ows_wallet_address(_env_ows)
+            else:
+                _env_key = (
+                    os.environ.get(self.PRIVATE_KEY_ENV_VAR)
+                    or os.environ.get(self.PRIVATE_KEY_ENV_VAR_LEGACY)
+                )
+                if _env_key:
+                    self._validate_and_set_wallet(_env_key)
+                    self._private_key = _env_key
+
         # Step 1 — prove ownership + link, tagged for funnel attribution.
         result = self.link_wallet(
             confirm_replace_managed=confirm_replace_managed,

--- a/skills/simmer-wallet-setup/SKILL.md
+++ b/skills/simmer-wallet-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-wallet-setup
-version: "0.3.2"
+version: "0.4.0"
 published: true
-description: Self-custody wallet setup for Simmer agents. Choose OWS (recommended), external raw key, or connect an existing dashboard-registered agent to your local runtime. Skip this skill if you use a managed wallet — managed setup is a one-time dashboard flow, not an agent task.
+description: Self-custody wallet setup for Simmer agents. Bring your own key, import a funded Polymarket wallet, or connect an existing dashboard-registered agent to your local runtime. Skip this skill if you use a managed wallet — managed setup is a one-time dashboard flow, not an agent task.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.3.2"
+  version: "0.4.0"
   displayName: Simmer Wallet Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -13,12 +13,12 @@ metadata:
     - name: SIMMER_API_KEY
       required: true
       description: "Your Simmer SDK API key (from agent registration)."
-    - name: OWS_WALLET
-      required: false
-      description: "OWS wallet name. Set only if you chose Path A (OWS)."
     - name: WALLET_PRIVATE_KEY
       required: false
-      description: "Polygon EVM private key. Set only if you chose Path B (external raw key)."
+      description: "Polygon EVM private key. The standard self-custody signer."
+    - name: OWS_WALLET
+      required: false
+      description: "OWS wallet name. Optional key store — set instead of WALLET_PRIVATE_KEY if the key lives in an OWS vault."
 ---
 
 # Simmer Wallet Setup
@@ -27,140 +27,90 @@ Self-custody wallet setup for an agent that signs its own real-money trades on P
 
 | Mode | Who signs | When to choose |
 |---|---|---|
-| **OWS per-agent** (recommended) | Local OWS vault, encrypted at rest | Per-agent isolation, multi-chain, policy-gated signing. Available for Polymarket + Kalshi. |
-| **External raw key** | Local SDK with `WALLET_PRIVATE_KEY` env | Existing setups. Fully supported; OWS is recommended for new agents. |
-| **[Connect existing agent](#connect-existing-agent)** | Local OWS vault, imported from dashboard registration | You already activated a wallet in the dashboard and want to wire your existing runtime to use it. |
+| **[External key](#path-a--external-key)** (default) | Local SDK with `WALLET_PRIVATE_KEY` env — or an OWS key store via `OWS_WALLET` | Any self-custody setup: your own wallet, your key, your machine. |
+| **[Import a Polymarket wallet](#path-b--import-a-polymarket-wallet)** | Same local signing — key exported from polymarket.com | Fund with card/exchange via Polymarket's onramps; the wallet arrives at Simmer already funded and approved. |
+| **[Connect existing agent](#connect-existing-agent)** | Same local signing, wallet already registered in the dashboard | You already activated a dedicated per-agent wallet in the dashboard and want to wire your runtime to it. |
 
 > **Already on a managed wallet?** You don't need this skill — managed setup is a dashboard flow, not an agent task. Open [simmer.markets/dashboard](https://simmer.markets/dashboard?ref=sdk-skill&utm_campaign=sdk-skill), go to your agent's **Wallet** tab, and click **Fund & activate trading**. The wizard opens a multi-chain bridge that accepts USDC, USDT, or USDC.e on Ethereum / Polygon / Base / Arbitrum / Solana — funds land as pUSD on your Polymarket Deposit Wallet, contracts auto-approve. **Do not tell the user to send funds directly to their agent wallet's EOA expecting them to sweep** — only legacy USDC.e on Polygon is recognized on the direct path; native USDC, USDT, and cross-chain tokens must go through the bridge wizard.
 
-## Path A — OWS per-agent wallet (recommended)
+## Key safety (read this first)
 
-OWS = [Open Wallet Standard](https://openwallet.sh). Local-first encrypted vault, multi-chain, policy engine, agent-scoped API keys. The private key never leaves the local machine.
+The private key goes in exactly one place: the agent host's environment, or a local key store.
 
-### One-time setup
+- Use `read -s` to set it — never paste a key into a pipe, a chat, a ticket, a shared config file, or a second browser extension "just to sign" (per SIM-2118):
+  ```bash
+  read -s -p 'WALLET_PRIVATE_KEY: ' K && export WALLET_PRIVATE_KEY=$K
+  ```
+- **Prefer a key store over a bare env var.** [OWS](https://openwallet.sh) (Open Wallet Standard) keeps the key encrypted at rest (AES-256-GCM); the SDK picks it up via `OWS_WALLET` and signs through the vault. Its policy engine can scope the agent's signing token to Polymarket orders only.
+  ```bash
+  curl -fsSL https://docs.openwallet.sh/install.sh | bash   # one-time OWS install
+  pip install 'simmer-sdk[ows]'
+  ows wallet import --name "my-agent-wallet" --private-key "$WALLET_PRIVATE_KEY"
+  unset WALLET_PRIVATE_KEY
+  export OWS_WALLET=my-agent-wallet   # SDK signs via the vault from here
+  ```
+- If a key ever touches a chat or shared surface, treat it as compromised: withdraw to a fresh wallet and start over.
 
-```bash
-# Install OWS CLI (creates ~/.ows vault, runs `ows wallet create`)
-curl -fsSL https://docs.openwallet.sh/install.sh | bash
+## Path A — External key
 
-# Install the SDK with OWS Python bindings (one command — note the [ows] extra)
-pip install 'simmer-sdk[ows]'
-
-# Create a wallet for this agent
-ows wallet create --name "my-agent-wallet"
-# Stores at ~/.ows/wallets/, derives addresses for EVM (Polygon), Solana, etc.
-
-# Fund it — show the EVM address to the human, they bridge USDC.e to Polygon
-ows wallet show my-agent-wallet
-```
-
-### Register the wallet with Simmer
-
-```python
-from simmer_sdk import SimmerClient
-client = SimmerClient(
-    api_key="sk_live_...",
-    ows_wallet="my-agent-wallet",   # name from `ows wallet create`
-)
-
-wallet = client.register_agent_wallet(ows_wallet_name="my-agent-wallet")  # one-time, Elite-tier gated, fully headless
-client.activate_polymarket_dw(agent_id=wallet["agent_id"])   # sets on-chain CLOB approvals on the agent's deposit wallet — signs via OWS, gasless relay, headless
-client.update_agent_wallet_creds(ows_wallet_name="my-agent-wallet")  # caches CLOB API creds server-side
-```
-
-> All three calls are fully headless — they authenticate with your SDK API key, no dashboard session or browser required. `register_agent_wallet()` requires Elite tier. `activate_polymarket_dw(agent_id=...)` sets the deposit-wallet approvals; `update_agent_wallet_creds()` then caches CLOB creds. Both are required before trading — caching creds alone does not set on-chain allowances. (Don't use `set_approvals()` here — that's the user-primary EOA path and a no-op for per-agent deposit wallets.) After all three run once, all trading is API-only.
->
-> Elite users can alternatively register a per-agent wallet through the dashboard's agent-creation wizard (My Agents → Create agent → optional "Link dedicated wallet" step) or retrofit an existing agent via its Wallet tab. The SDK path and the dashboard path produce the same `user_agent_wallets` row — pick whichever fits your workflow.
-
-(Alternative: set `OWS_WALLET=my-agent-wallet` in the environment and pass only `api_key` — the SDK auto-detects.)
-
-### Trade — same API, OWS routes the signing
-
-```python
-result = client.trade(
-    market_id, "yes", 10.0,
-    venue="polymarket",
-    reasoning="..."
-)
-# SDK builds the order, OWS signs locally, broadcast goes through Simmer
-```
-
-### For Kalshi (Solana)
-
-OWS is multi-chain. The same wallet has a Solana account derived automatically.
-
-```bash
-ows wallet show my-agent-wallet  # shows Solana address too
-# Fund with SOL + USDC, complete KYC at dflow.net/proof
-```
-
-```python
-client = SimmerClient(
-    api_key="sk_live_...",
-    ows_wallet="my-agent-wallet",
-    venue="kalshi",
-)
-client.trade(market_id, "yes", 5.0, reasoning="...")
-```
-
-No `SOLANA_PRIVATE_KEY` env var needed — OWS handles signing through the same vault.
-
-### What OWS gives over raw keys
-
-- **Encrypted at rest** (AES-256-GCM, scrypt KDF). Private key only decrypted in-process for signing, then wiped.
-- **Policy engine** — chain allowlists, daily caps, contract allowlists. Optional.
-- **Multi-chain** — same vault, every chain Simmer supports.
-- **Per-agent isolation** — separate wallets per agent for clean P&L attribution.
-- **Agent API keys** with bounded access (revocable, expiring).
-
-## Path B — External raw key
-
-> Fully supported path for self-custody with an existing wallet. New agents should consider OWS first — same self-custody guarantee, encrypted at rest, multi-chain, and easier to layer policy controls. Raw-key flow stays supported for users who already have it set up.
-
-Set the key in the environment, then construct the client:
-
-```bash
-export WALLET_PRIVATE_KEY="0x..."  # Polymarket Polygon wallet
-```
+Set the key (see key safety above), then construct the client:
 
 ```python
 client = SimmerClient(api_key="sk_live_...")
-# private_key is auto-detected from WALLET_PRIVATE_KEY env var
+# signer auto-detected: WALLET_PRIVATE_KEY or OWS_WALLET env var
 client.link_wallet()    # signs a challenge message locally — fully headless
 client.set_approvals()  # signs approval txs locally — fully headless, key never leaves agent
 
-# If your account uses a Polymarket Deposit Wallet (Elite / upgraded accounts):
+# If your account uses a Polymarket Deposit Wallet (upgraded accounts):
 client.activate_polymarket_dw()  # one-time — signs EIP-712 batch locally, no browser needed
 
 # If you have stranded USDC.e on your Deposit Wallet, wrap it to pUSD:
 result = client.wrap_on_dw()  # idempotent — no-op when nothing stranded
 ```
 
-Both calls work without a browser session. `link_wallet()` signs a challenge with your local key. `set_approvals()` builds, signs, and broadcasts each approval transaction via Simmer's RPC proxy — your `WALLET_PRIVATE_KEY` never leaves the agent process.
+All calls work without a browser session. `link_wallet()` signs a challenge with your local key. `set_approvals()` builds, signs, and broadcasts each approval transaction via Simmer's RPC proxy — your key never leaves the agent process.
 
 > **Using a Deposit Wallet?** If your account has been upgraded to a Polymarket Deposit Wallet (DW), run `client.activate_polymarket_dw()` after `set_approvals()` — it signs the EIP-712 activation batch headlessly with your local key. Alternatively, use the dashboard browser flow at [simmer.markets/dashboard](https://simmer.markets/dashboard?ref=sdk-skill&utm_campaign=sdk-skill) → Wallets → Activate Trading.
 
-> **Browser-backed per-agent wallet?** If the dashboard created a dedicated wallet for an agent and your bot has that wallet's `WALLET_PRIVATE_KEY`, run `client.activate_polymarket_dw(agent_id="<agent_id>")` first, then `client.update_agent_wallet_creds(agent_id="<agent_id>")`. The second call derives CLOB API creds locally from the EOA signer and caches them on the existing per-agent wallet row.
+> **Stranded USDC.e on your DW?** Run `client.wrap_on_dw()` to convert it to pUSD headlessly. Idempotent — safe to call on every startup; returns immediately if nothing is stranded. Returns `{"wrapped": bool, "amount_units": int, "calls_count": int, "success": bool}`. Requires the same signer as `activate_polymarket_dw()`. Added in SDK 0.17.7.
 
-> **Stranded USDC.e on your DW?** Run `client.wrap_on_dw()` to convert it to pUSD headlessly. Idempotent — safe to call on every startup; returns immediately if nothing is stranded. Returns `{"wrapped": bool, "amount_units": int, "calls_count": int, "success": bool}`. Requires the same key as `activate_polymarket_dw()` (WALLET_PRIVATE_KEY or OWS wallet). Added in SDK 0.17.7.
+### For Kalshi (Solana)
 
-### Migrating to OWS when ready
-
-No rush. When ready, import the existing key into OWS and switch over:
-
-```bash
-ows wallet import --name "my-agent-wallet" --private-key "$WALLET_PRIVATE_KEY"
-unset WALLET_PRIVATE_KEY  # OWS handles signing from here
-```
-
-Then in the agent code:
+Set `SOLANA_PRIVATE_KEY` (base58) in the env, fund with SOL + USDC, complete KYC at dflow.net/proof. If the key lives in an OWS vault, the same wallet's derived Solana account signs — no `SOLANA_PRIVATE_KEY` needed:
 
 ```python
-client = SimmerClient(api_key="sk_live_...", ows_wallet="my-agent-wallet")
-# Same trade() / set_approvals() / redeem() API — OWS routes the signing
+client = SimmerClient.from_env(venue="kalshi")
+client.trade(market_id, "yes", 5.0, reasoning="...")
 ```
 
-The same wallet address is preserved, so existing positions and approvals carry over.
+## Path B — Import a Polymarket wallet
+
+For a wallet born on polymarket.com: create the account there, fund it with their onramps (card, exchange transfer), export the private key (polymarket.com → Settings → Export Private Key), and set it as `WALLET_PRIVATE_KEY` on the agent host (key safety above applies in full — this is a raw key).
+
+```python
+client = SimmerClient.from_env()
+result = client.import_polymarket_wallet()   # SDK 0.24.4+
+# links with ownership proof, adopts the Polymarket-deployed deposit wallet
+# (no redeploy), tops up approvals gaslessly, derives creds, reports balance
+```
+
+The wallet arrives already funded and approved — Polymarket deployed the deposit wallet and pre-set the core exchange allowance. Note the shared surface: manual trades on polymarket.com use the same wallet as the agent and can collide with its positions.
+
+Docs: [docs.simmer.markets/polymarket-import](https://docs.simmer.markets/polymarket-import).
+
+## Dedicated per-agent wallets (Elite)
+
+Elite accounts can give each agent its own wallet (own EOA + own deposit wallet, clean per-agent P&L). **Register the wallet from the dashboard** (My Agents → your agent → Add wallet), then activate on the host where the key lives:
+
+```python
+# WALLET_PRIVATE_KEY must be set to the agent EOA private key.
+client.activate_polymarket_dw(agent_id="<agent_id>")     # sets on-chain approvals — OWS/raw-key signed, gasless relay
+client.update_agent_wallet_creds(agent_id="<agent_id>")  # derives + caches CLOB creds
+```
+
+Both calls are required (approvals first) and idempotent. Don't use `set_approvals()` here — that's the user-primary EOA path and a no-op for per-agent deposit wallets. Get `<agent_id>` from `client.get_agent_wallets()`.
+
+> **Existing OWS per-agent wallets:** new OWS per-agent registrations are closed (`register_agent_wallet()` is deprecated and the server rejects it), but wallets already registered on that path keep working unchanged — `client.update_agent_wallet_creds(ows_wallet_name="<wallet>")` remains supported for them. OWS as a key store for the standard path (everything above) is unaffected.
 
 ## Polymarket token note
 
@@ -174,7 +124,7 @@ Either way, after setup `client.set_approvals()` should report `all_set=True`. I
 
 ## Connect existing agent
 
-You already created an agent in the dashboard and have its API key. Now wire it to your locally-running agent runtime.
+You already created an agent in the dashboard, registered its dedicated wallet, and have its API key. Now wire it to your locally-running agent runtime.
 
 ### Prerequisites
 - API key (from dashboard → agent settings → API key, or wizard success modal)
@@ -185,34 +135,27 @@ You already created an agent in the dashboard and have its API key. Now wire it 
 
 1. **Install packages**
    ```bash
-   pip install 'simmer-sdk[ows]'
+   pip install simmer-sdk          # add [ows] extra if using the OWS key store
    ```
 
-2. **Import wallet key into OWS**
-   ```bash
-   ows wallet add <name> --private-key <your-eoa-private-key>
-   ```
-   Choose a memorable `<name>` (e.g. `my-agent-trading`). This becomes your `OWS_WALLET` env var.
-
-3. **Set env vars in your agent runtime**
+2. **Set env vars in your agent runtime**
    Use `read -s` to avoid clipboard contamination (per SIM-2118):
    ```bash
    read -s -p 'SIMMER_API_KEY: ' KEY && export SIMMER_API_KEY=$KEY
-   export OWS_WALLET=<name>
+   read -s -p 'WALLET_PRIVATE_KEY: ' K && export WALLET_PRIVATE_KEY=$K
    ```
+   (Optionally import the key into OWS instead — see key safety above — and set `OWS_WALLET`.)
 
-4. **Activate trading: on-chain approvals + CLOB credentials (one-time)**
+3. **Activate trading: on-chain approvals + CLOB credentials (one-time)**
    ```bash
    python -c "from simmer_sdk import SimmerClient; \
      c = SimmerClient.from_env(venue='polymarket'); \
      c.activate_polymarket_dw(agent_id='<agent_id>'); \
-     c.update_agent_wallet_creds(ows_wallet_name='<name>')"
+     c.update_agent_wallet_creds(agent_id='<agent_id>')"
    ```
-   First sets the deposit wallet's on-chain CLOB approvals (OWS-signed EIP-712 batch, relayed gasless), then derives + caches CLOB creds server-side. **Both** are required before any Polymarket trades — approvals alone or creds alone is not enough. Get `<agent_id>` from `client.get_agent_wallets()`.
+   First sets the deposit wallet's on-chain CLOB approvals (locally-signed EIP-712 batch, relayed gasless), then derives + caches CLOB creds server-side. **Both** are required before any Polymarket trades — approvals alone or creds alone is not enough. Get `<agent_id>` from `client.get_agent_wallets()`. (Existing OWS-registered wallets replace the final call with `c.update_agent_wallet_creds(ows_wallet_name='<name>')`.)
 
-   For browser-backed raw-key per-agent wallets, keep the same approvals call and replace the final line with `c.update_agent_wallet_creds(agent_id='<agent_id>')`.
-
-5. **Verify**
+4. **Verify**
    ```bash
    python -c "from simmer_sdk import SimmerClient; \
      c = SimmerClient.from_env(); \
@@ -229,13 +172,14 @@ The auto risk monitor (stop-loss, take-profit) is configured at simmer.markets/d
 
 ## Troubleshooting
 
-- **"External wallet requires a pre-signed order"** → key not configured. For OWS: `ows wallet list` to verify the wallet exists. For external: confirm `WALLET_PRIVATE_KEY` is set.
-- **"insufficient allowance"** → set approvals once per wallet: `client.activate_polymarket_dw(agent_id=...)` for a per-agent OWS/deposit-wallet, or `client.set_approvals()` for a raw-key/user-primary EOA wallet.
+- **"External wallet requires a pre-signed order"** → key not configured. Confirm `WALLET_PRIVATE_KEY` is set — or, for an OWS key store, `ows wallet list` to verify the wallet exists and `OWS_WALLET` is set.
+- **"insufficient allowance"** → set approvals once per wallet: `client.activate_polymarket_dw(agent_id=...)` for a per-agent deposit wallet, `client.activate_polymarket_dw()` for a user-primary deposit wallet, or `client.set_approvals()` for a legacy raw-key EOA wallet.
 - **Balance shows $0 but funds visible elsewhere** → check chain (Polygon vs Solana) and token (pUSD vs USDC.e). See dashboard migration tool for V2 conversion.
 - **API key format wrong / 401 with a key that "looks set"** → inspect the raw value: `printenv SIMMER_API_KEY | cut -c1-20`. Must start with `sk_live_`. A common silent failure: install commands that use `pbpaste` or similar clipboard-read primitives write the *install command text itself* as the key value when the user copies the command after copying the key. Fix: get a fresh key from simmer.markets/dashboard, then `export SIMMER_API_KEY="sk_live_..."` (type/paste the key directly, never pipe from clipboard into the variable assignment).
 
 ## Links
 
+- Polymarket wallet import: [docs.simmer.markets/polymarket-import](https://docs.simmer.markets/polymarket-import)
 - OWS docs: [openwallet.sh](https://openwallet.sh)
 - Simmer wallet docs: [docs.simmer.markets/wallets](https://docs.simmer.markets/wallets)
 - V2 migration guide: [docs.simmer.markets/v2-migration](https://docs.simmer.markets/v2-migration)

--- a/skills/simmer-wallet-setup/clawhub.json
+++ b/skills/simmer-wallet-setup/clawhub.json
@@ -16,14 +16,14 @@
       "description": "Your Simmer SDK API key (from agent registration)."
     },
     {
-      "name": "OWS_WALLET",
-      "required": false,
-      "description": "OWS wallet name. Set only if you chose Path A (OWS)."
-    },
-    {
       "name": "WALLET_PRIVATE_KEY",
       "required": false,
-      "description": "Polygon EVM private key. Set only if you chose Path B (external raw key)."
+      "description": "Polygon EVM private key. The standard self-custody signer."
+    },
+    {
+      "name": "OWS_WALLET",
+      "required": false,
+      "description": "OWS wallet name. Optional key store — set instead of WALLET_PRIVATE_KEY if the key lives in an OWS vault."
     }
   ],
   "cron": null,

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.9"
+  version: "1.24.10"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -91,7 +91,7 @@ Documentation references — open when the situation matches.
 
 | When | Where |
 |---|---|
-| Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers OWS (recommended), external raw key, and managed paths |
+| Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers external self-custody (your own key, with OWS as an optional key store), importing a funded Polymarket wallet, and managed paths |
 | Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. |
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
@@ -104,7 +104,7 @@ Documentation references — open when the situation matches.
 - **Order behavior**: `client.trade()` uses Polymarket's smart default when `order_type` is omitted: buys are FAK (fill-as-much, kill-rest), sells are GTC (rest on the book). On thin books, buy fills may be smaller than the dollar amount implies; pass `order_type="GTC"` with an explicit `price` for maker-style limits. Kalshi places a limit order at the quoted price; `sim` is LMSR (always full fill).
 - **Auto-redeem** (managed wallets only): ON by default. Winning Polymarket positions are claimed automatically. Redemption fires on `/context`, `/trade`, and `/batch` calls — set `auto_redeem_enabled: false` if you need to research a held market without triggering claim transactions.
 - **Edge vs costs**: real venues have 1-5% spreads plus venue fees. Don't trade unless your edge clears ~5% net of costs. Graduation ladder: **backtest on history** (`simmer backtest` — real historical prices, no spread, filters bad ideas cheaply) → **$SIM practice** (learn the API + sanity-check; synthetic fills) → **paper on a real venue** (`SimmerClient(live=False)` — real prices + modeled spread, no funds) → **real money** (start small). Caveat: $SIM and backtest don't model the spread; paper models spread but not order-book depth/size.
-- **Tiers**: Free / Pro (3× rate limits) / Elite (10× + per-agent OWS wallets). Pricing at [simmer.markets/pricing](https://simmer.markets/pricing?ref=sdk-skill&utm_campaign=sdk-skill).
+- **Tiers**: Free / Pro (3× rate limits) / Elite (10× + dedicated per-agent wallets). Pricing at [simmer.markets/pricing](https://simmer.markets/pricing?ref=sdk-skill&utm_campaign=sdk-skill).
 
 ## API surface
 

--- a/tests/test_agent_wallets_sdk.py
+++ b/tests/test_agent_wallets_sdk.py
@@ -38,16 +38,22 @@ class TestRegisterAgentWallet:
             "is_active": True,
         }
 
-        result = client.register_agent_wallet("agent-test")
+        # SIM-4646 (0.24.4): OWS per-agent registration is a closed entrance —
+        # the method warns, and declares wallet_source='ows' truthfully so the
+        # server's closure guard can 410 it.
+        with pytest.warns(DeprecationWarning, match="register_agent_wallet"):
+            result = client.register_agent_wallet("agent-test")
 
         mock_addr.assert_called_once_with("agent-test")
         # PR #73 (0.17.5): agent_id is now derived server-side from the API
-        # key; the SDK only sends ows_wallet_name + wallet_address.
+        # key; the SDK only sends ows_wallet_name + wallet_address (+ the
+        # SIM-4646 wallet_source declaration).
         client._request.assert_called_once_with(
             "POST", "/api/sdk/agent-wallet/register",
             json={
                 "ows_wallet_name": "agent-test",
                 "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "wallet_source": "ows",
             }
         )
         assert result["ows_wallet_name"] == "agent-test"

--- a/tests/test_import_env_wallet_adoption.py
+++ b/tests/test_import_env_wallet_adoption.py
@@ -1,0 +1,65 @@
+"""import_polymarket_wallet() adopts the env wallet on a sim-default client.
+
+`from_env()` without venue sets _ignore_env_wallets=True, so the client has no
+signer even when WALLET_PRIVATE_KEY is set. An explicit import call is
+unambiguous intent to use that key — found by Adrian in the SIM-4646
+acceptance run when the documented copy-paste snippet failed with
+"private_key or ows_wallet required".
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from simmer_sdk.client import SimmerClient
+
+_KEY = "0x" + "11" * 32
+
+
+def _bare_client():
+    """Client shaped like from_env() with the sim default: no signer configured."""
+    client = SimmerClient.__new__(SimmerClient)
+    client._agent_id = "test-agent-uuid"
+    client._ows_wallet = None
+    client._wallet_address = None
+    client._private_key = None
+    client.base_url = "https://api.simmer.markets"
+    client.live = True
+    client.venue = "sim"
+    client._request = MagicMock()
+    return client
+
+
+def test_import_adopts_env_private_key():
+    client = _bare_client()
+    with patch.dict(os.environ, {"WALLET_PRIVATE_KEY": _KEY}, clear=False), \
+         patch.object(client, "link_wallet",
+                      return_value={"success": False, "error": "stop here"}) as mock_link:
+        client.import_polymarket_wallet()
+    assert client._private_key == _KEY
+    assert client._wallet_address is not None
+    mock_link.assert_called_once()
+
+
+def test_import_prefers_env_ows_over_raw_key():
+    client = _bare_client()
+    with patch.dict(os.environ,
+                    {"OWS_WALLET": "my-vault", "WALLET_PRIVATE_KEY": _KEY},
+                    clear=False), \
+         patch("simmer_sdk.ows_utils.get_ows_wallet_address",
+               return_value="0x1234567890abcdef1234567890abcdef12345678"), \
+         patch.object(client, "link_wallet",
+                      return_value={"success": False, "error": "stop here"}):
+        client.import_polymarket_wallet()
+    assert client._ows_wallet == "my-vault"
+    assert client._private_key is None
+
+
+def test_import_does_not_override_explicit_signer():
+    client = _bare_client()
+    client._private_key = _KEY
+    client._wallet_address = "0x3c7fa6cb352c6df150b14e16c635029a0b56aa0b"
+    with patch.dict(os.environ, {"WALLET_PRIVATE_KEY": "0x" + "22" * 32}, clear=False), \
+         patch.object(client, "link_wallet",
+                      return_value={"success": False, "error": "stop here"}):
+        client.import_polymarket_wallet()
+    assert client._private_key == _KEY

--- a/tests/test_import_polymarket_wallet.py
+++ b/tests/test_import_polymarket_wallet.py
@@ -1,0 +1,174 @@
+"""Tests for import_polymarket_wallet() + link-source tagging (SIM-4646, 0.24.4).
+
+Phase A of the Polymarket-link onboarding: a wallet born on polymarket.com
+(funded there, key exported into the agent env) becomes trading-ready in one
+call — link with ownership proof, adopt the already-deployed deposit wallet,
+gasless approval top-up, balance summary.
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+
+
+def _make_client(**overrides):
+    client = SimmerClient.__new__(SimmerClient)
+    client._agent_id = overrides.get("agent_id", "test-agent-uuid")
+    client._ows_wallet = overrides.get("ows_wallet", None)
+    client._wallet_address = overrides.get(
+        "wallet_address", "0x3c7fa6cb352c6df150b14e16c635029a0b56aa0b"
+    )
+    client._private_key = overrides.get("private_key", "0x" + "11" * 32)
+    client.base_url = "https://api.simmer.markets"
+    client.live = True
+    client.venue = "polymarket"
+    client._request = MagicMock()
+    return client
+
+
+# =============================================================================
+# link_wallet signature additions
+# =============================================================================
+
+
+def test_link_wallet_accepts_source_defaulting_none():
+    sig = inspect.signature(SimmerClient.link_wallet)
+    assert "source" in sig.parameters
+    assert sig.parameters["source"].default is None, (
+        "source must default to None so the server infers 'sdk-link' for "
+        "plain SDK calls — a hardcoded default would fragment the funnel data."
+    )
+
+
+def test_link_wallet_accepts_confirm_orphan_deposit_wallet_defaulting_false():
+    sig = inspect.signature(SimmerClient.link_wallet)
+    assert "confirm_orphan_deposit_wallet" in sig.parameters
+    assert sig.parameters["confirm_orphan_deposit_wallet"].default is False, (
+        "Default must be False — orphaning an active deposit wallet has to be "
+        "an explicit choice (server guard SIM-1611)."
+    )
+
+
+# =============================================================================
+# import_polymarket_wallet composition
+# =============================================================================
+
+
+def test_import_declares_polymarket_import_source_and_composes_steps():
+    client = _make_client()
+    with patch.object(
+        client, "link_wallet",
+        return_value={"success": True, "wallet_address": client._wallet_address,
+                      "clob_credentials_registered": True},
+    ) as mock_link, patch.object(
+        client, "activate_polymarket_dw",
+        return_value={"already_set": True, "calls_count": 0, "success": True},
+    ) as mock_activate:
+        client._request.side_effect = [
+            # external-upgrade-to-deposit-wallet — adopt, no redeploy
+            {"deposit_wallet_address": "0x6471A609E9B87447cd1552FfDe4AF3625fA2F180",
+             "already_existed": True},
+            # briefing — balance summary
+            {"venues": {"polymarket": {"balance": 5.0}}},
+        ]
+        result = client.import_polymarket_wallet()
+
+    mock_link.assert_called_once_with(
+        confirm_replace_managed=True,
+        confirm_orphan_deposit_wallet=False,
+        source="polymarket-import",
+    )
+    upgrade_call = client._request.call_args_list[0]
+    assert upgrade_call.args == (
+        "POST", "/api/user/wallet/external-upgrade-to-deposit-wallet"
+    )
+    mock_activate.assert_called_once_with()
+
+    assert result["success"] is True
+    assert result["deposit_wallet_address"] == (
+        "0x6471A609E9B87447cd1552FfDe4AF3625fA2F180"
+    )
+    assert result["dw_already_existed"] is True
+    assert result["balance_usd"] == 5.0
+
+
+def test_import_link_failure_short_circuits():
+    """A failed link must stop the flow — adopting a DW for an unlinked
+    wallet would act on whatever wallet was previously active."""
+    client = _make_client()
+    with patch.object(
+        client, "link_wallet",
+        return_value={"success": False, "error": "Challenge has expired."},
+    ):
+        result = client.import_polymarket_wallet()
+
+    assert result["success"] is False
+    assert result["step"] == "link"
+    assert "expired" in result["error"]
+    client._request.assert_not_called()
+
+
+def test_import_balance_fetch_failure_is_nonfatal():
+    client = _make_client()
+    with patch.object(
+        client, "link_wallet",
+        return_value={"success": True, "wallet_address": client._wallet_address,
+                      "clob_credentials_registered": True},
+    ), patch.object(
+        client, "activate_polymarket_dw",
+        return_value={"already_set": False, "calls_count": 3, "success": True},
+    ):
+        client._request.side_effect = [
+            {"deposit_wallet_address": "0x6471A609E9B87447cd1552FfDe4AF3625fA2F180",
+             "already_existed": True},
+            RuntimeError("briefing down"),
+        ]
+        result = client.import_polymarket_wallet()
+
+    assert result["success"] is True
+    assert result["balance_usd"] is None
+
+
+# =============================================================================
+# OWS deprecation warnings (entrance closure)
+# =============================================================================
+
+
+def test_update_agent_wallet_creds_ows_branch_warns():
+    client = _make_client()
+    creds = MagicMock(api_key="k", api_secret="s", api_passphrase="p")
+    with patch("simmer_sdk.ows_utils.get_ows_wallet_address",
+               return_value="0x1234567890abcdef1234567890abcdef12345678"), \
+         patch("simmer_sdk.ows_utils.ows_derive_clob_creds",
+               return_value=creds):
+        client._request.return_value = {"id": "w", "approvals_set": True}
+        with pytest.warns(DeprecationWarning, match="update_agent_wallet_creds"):
+            client.update_agent_wallet_creds("agent-test")
+
+
+def test_raw_key_creds_path_does_not_warn(recwarn):
+    """The raw-key per-agent path is the recommended replacement — it must
+    stay warning-free or the deprecation nudge points at itself."""
+    client = _make_client()
+    client._request.return_value = {"id": "w", "approvals_set": True}
+    with patch("simmer_sdk.signing.get_wallet_address",
+               return_value="0x1234567890abcdef1234567890abcdef12345678"), \
+         patch("simmer_sdk.client.SimmerClient._derive_clob_creds_with_key",
+               create=True,
+               return_value={"apiKey": "k", "secret": "s", "passphrase": "p"}):
+        try:
+            client.update_agent_wallet_creds(
+                agent_id="test-agent-uuid", private_key="0x" + "11" * 32
+            )
+        except Exception:
+            # The raw-key derive path may need more mocking than this test
+            # cares about — we only assert on warnings emitted before any
+            # failure, which is where the deprecation branch sits.
+            pass
+    deprecations = [w for w in recwarn.list
+                    if issubclass(w.category, DeprecationWarning)
+                    and "update_agent_wallet_creds" in str(w.message)]
+    assert not deprecations


### PR DESCRIPTION
## Summary

SDK half of **Polymarket-link onboarding Phase A** (spec: simmer `_dev/active/_polymarket-link-onboarding/spec.md`, ticket SIM-4646). Companion: SupaFund/simmer#1927.

### import_polymarket_wallet()
One call from a polymarket.com key export to trading-ready: `link_wallet(source='polymarket-import')` → adopt the Polymarket-deployed deposit wallet via `/api/user/wallet/external-upgrade-to-deposit-wallet` (idempotent, no redeploy) → `activate_polymarket_dw()` gasless top-up → best-effort balance summary from `/api/sdk/briefing`. Non-raising composition (mirrors `link_wallet`'s creds handling): failures return `{success: False, step, error}`.

### link_wallet() additions
- `confirm_orphan_deposit_wallet` passthrough — the server's SIM-1611 guard error was previously a dead end for SDK callers (the flag existed server-side but the SDK never sent it). Default False, so nothing changes for existing callers.
- `source` (default None) — server infers `sdk-link` when unset.

### OWS entrance closure (deprecations only)
- `register_agent_wallet(ows_wallet_name=...)`: DeprecationWarning + now declares `wallet_source='ows'` truthfully, which the server (post-#1927) rejects with 410.
- `update_agent_wallet_creds(ows_wallet_name=...)`: DeprecationWarning; keeps working for the 3 existing OWS per-agent wallets.
- NOT deprecated: `OWS_WALLET` as key store for the standard path (link + trade signing).

### Skills sweep (reposition, don't erase)
- `simmer-wallet-setup` 0.3.2 → **0.4.0**: external-key path is primary with a consolidated key-safety section (OWS presented as optional key store + policy-engine scoping), new 'Import a Polymarket wallet' path, per-agent section keeps an 'existing OWS wallets keep working' note. ClawHub republish AFTER server closure deploys (Adrian-gated, as always).
- `simmer` overview 1.24.9 → **1.24.10**: two-line repositioning (wallet-setup row + Elite tier line). Same republish gate; website skill.md auto-follows.

## Tests
Full suite: **703 passed, 9 skipped** (incl. new `tests/test_import_polymarket_wallet.py`, updated register wire-format pin).

## Release order
Merge simmer#1927 first (server accepts `source` + rejects `wallet_source='ows'`), then release 0.24.4 to PyPI, then republish the two skills.