### PR TITLE
fix(skill): MCP install line points at the deprecated PyPI stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Skills in this repo (`skills/`) are the official Simmer-maintained strategies. S
 | **Onboarding Guide** | [simmer.markets/skill.md](https://simmer.markets/skill.md) |
 | **Skills Registry** | [docs.simmer.markets/skills](https://docs.simmer.markets/skills/overview) |
 | **ClawHub** | [clawhub.ai](https://clawhub.ai) |
-| **MCP Server** | `pip install simmer-mcp` — docs + error troubleshooting as MCP resources ([PyPI](https://pypi.org/project/simmer-mcp/)) |
+| **MCP Server** | `npm install -g simmer-mcp` — docs + error troubleshooting as MCP resources ([npm](https://www.npmjs.com/package/simmer-mcp)) |
 | **Telegram** | [t.me/+m7sN0OLM_780M2Fl](https://t.me/+m7sN0OLM_780M2Fl) |
 
 ## Contributing

--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.10"
+  version: "1.24.11"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -117,7 +117,7 @@ client.trade(id, side, usd, ...)   # execute (always with reasoning=)
 client.cancel_order(order_id)      # or cancel_market_orders / cancel_all_orders
 ```
 
-REST equivalents documented at [docs.simmer.markets](https://docs.simmer.markets). MCP server: `pip install simmer-mcp`.
+REST equivalents documented at [docs.simmer.markets](https://docs.simmer.markets). MCP server: `npm install -g simmer-mcp`.
 
 ## What you bring vs what Simmer brings
 

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.10"
+  version: "1.24.11"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -117,7 +117,7 @@ client.trade(id, side, usd, ...)   # execute (always with reasoning=)
 client.cancel_order(order_id)      # or cancel_market_orders / cancel_all_orders
 ```
 
-REST equivalents documented at [docs.simmer.markets](https://docs.simmer.markets). MCP server: `pip install simmer-mcp`.
+REST equivalents documented at [docs.simmer.markets](https://docs.simmer.markets). MCP server: `npm install -g simmer-mcp`.
 
 ## What you bring vs what Simmer brings
 


### PR DESCRIPTION
## The bug

The canonical skill told agents `MCP server: pip install simmer-mcp`. That package is the **deprecated PyPI stub** — installing it yields a 0.99.0 deprecation shim that exits 1. The live server is the **npm** package `simmer-mcp` (3.5.0, source `simmer-sdk/mcp/`).

Our own documentation already says this: `simmer-docs/open-source.mdx` tells people to `pip uninstall simmer-mcp` and switch to npm. The SDK surfaces just never followed.

## Three published surfaces carried it

| File | Where it's visible |
|---|---|
| `skills/simmer/SKILL.md` | the canonical — published to ClawHub, generated into `simmer.markets/skill.md` |
| `mcp/bundled-skills/simmer/SKILL.md` | bundled **into the npm MCP package** |
| `README.md` | GitHub and PyPI, and it linked to the PyPI page |

The second one is the sharp edge: the npm MCP server shipped a bundled skill instructing users to install its own deprecated Python predecessor.

All three now read `npm install -g simmer-mcp`, matching `open-source.mdx`. `metadata.version` bumped 1.24.10 → 1.24.11 on both skill copies.

## How it surfaced

Found while wiring install-path tabs into the `/home` Skills prototype (SupaFund/simmer#1952). Those tabs render a real install command per distribution path, which is what exposed the line as wrong — the claim "works on any agent runtime" was being asserted without any surface that actually showed the commands.

## Not done here

**Not republished to ClawHub.** That's an external publish and Adrian's call. Once it lands: `npx clawhub skill publish`, and the website copy auto-follows on the next build via the prebuild sync.