### PR TITLE
skills: fix the install paths a cold agent actually hits, and teach dry_run

### DIFF
--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -359,20 +359,35 @@ The `sim` venue is paper money — no real funds at risk. If this returns market
 
 **Everything works except the `preflight` tool.**
 That is the one bundled tool that shells out to Python. Either `simmer-sdk` is missing, or
-it is installed in a venv the server cannot see. The server prints which interpreter it
-resolved on every start:
+it is installed in a venv the server cannot see.
+
+**Read the tool's own error first — it is the one signal every host gives you.** Calling
+`simmer_preflight` returns exit 2 with the cause:
+
+```
+ERROR: simmer-sdk not installed — run: pip install simmer-sdk>=0.17.13
+```
+
+The server also prints an interpreter line on startup, which is more useful because it
+names *which* Python got resolved:
 
 ```
 [simmer-mcp] runtime: python3: v3.x (/path) | simmer-sdk: ...
 ```
 
-Read that line — it is portable across runtimes and tells you *which* Python was used. If
-the path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b). On Hermes the server's
-stderr goes to `<HERMES_HOME>/logs/mcp-stderr.log`; other runtimes surface it differently,
-so prefer the runtime line over hunting for a log file.
+⚠️ **Whether you can actually read that line depends on the host, so don't go hunting for
+a log file.** The server always emits it; where stderr lands is the host's choice.
 
-Don't reach for this when a *different* skill tool fails — the other four bundled skills
-never run Python, so their failures have some other cause.
+| Host | Where the startup line goes |
+|---|---|
+| Hermes | `<HERMES_HOME>/logs/mcp-stderr.log` — and a profile has its own, e.g. `~/.hermes/profiles/<name>/logs/mcp-stderr.log` |
+| Grok Bot | **No file.** stderr is a Unix socket into the MCP host. Use the tool error above. |
+| Others | Varies. If there is no log, run `npx -y simmer-mcp` once in a terminal with `SIMMER_API_KEY` set and read the line directly. |
+
+If the resolved path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b).
+
+Don't reach for any of this when a *different* skill tool fails — the other four bundled
+skills never run Python, so their failures have some other cause.
 
 **Tools listed but API calls return 401.**
 - `SIMMER_API_KEY` env didn't make it into the MCP subprocess. The env block in the config has to be a direct value, not a `$VAR` reference — most MCP clients don't expand shell vars at server-launch time.

--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.1.3"
+version: "0.2.0"
 published: true
-description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
+description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex / Grok Bot), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.3"
+  version: "0.2.0"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -32,6 +32,8 @@ So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strate
 ## What you'll have at the end
 
 - `simmer-mcp` runnable via `npx -y simmer-mcp` (global install optional)
+- Optionally `simmer-sdk` on the host plus `SIMMER_MCP_PYTHON` pointing at it — needed
+  only by the `preflight` tool, the one bundled skill that runs Python. See Step 3b.
 - Your agent runtime's MCP config updated with a `simmer` entry
 - `SIMMER_API_KEY` plumbed into the MCP subprocess
 - Simmer tools visible to your agent:
@@ -101,6 +103,56 @@ This step is **optional**. The MCP config in Step 4 uses `npx -y simmer-mcp`, wh
 If you do install it and get an EACCES permission error on Linux/macOS: do NOT `sudo npm install` (creates permission tangles later). Either fix npm's global directory permissions per [npm's docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally), or just skip the global install — the `npx -y simmer-mcp` form in the config works either way.
 
 > **Why no `--version` check?** simmer-mcp's binary doesn't have CLI flags — every invocation starts the stdio MCP server. Verification happens in Step 6 when your agent calls a simmer tool and gets a real response.
+
+**If npm or `npx` is blocked or hangs on your host**, `bun` works as a drop-in:
+`bun add -g simmer-mcp`, and `bunx simmer-mcp` in place of `npx -y simmer-mcp` in the
+config below. Some agent runtimes gate npm behind a command review that never returns —
+observed on Grok Bot's cloud computer, 2026-09-04.
+
+## Step 3b — Python, only if you want the `preflight` tool
+
+**Scope first, because the server's own warning overstates this.** On startup you may see:
+
+```
+[simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0
+```
+
+That line is wrong in two ways. **Exactly one bundled tool needs Python** — `preflight`,
+the only bundled skill with an executable entrypoint. The other four (`simmer`,
+`simmer-wallet-setup`, `simmer-briefing`, `simmer-mcp-setup`) return their SKILL.md text
+and never start a subprocess, and every raw tool (`simmer_trade`, `simmer_get_markets`,
+`get_portfolio`, …) is pure Node. And the version floor is wrong: `preflight` requires
+**`simmer-sdk>=0.17.13`**, not `0.13.0`.
+
+So if you do not need `preflight`, skip this step. If you do:
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.17.13'
+```
+
+Use a venv — most Linux hosts mark the system Python "externally managed", so a bare
+`pip install` fails with PEP 668. If `python3 -m venv` itself fails with
+*"ensurepip is not available"*, the venv module is packaged separately on that distro:
+`sudo apt install python3-venv` (Debian/Ubuntu), or use `pipx`, or as a last resort
+`pip install --break-system-packages`.
+
+⚠️ **Creating the venv is not enough — you must point the server at it.** The server is
+launched by your runtime as `npx -y simmer-mcp` and inherits *that* environment, not your
+shell's. It resolves Python from `SIMMER_MCP_PYTHON`, then `which python`, then
+`which python3` — **it never looks for a `.venv`**. So a venv you made in a terminal is
+invisible to it, and `preflight` fails exactly as before.
+
+Add the absolute path to the `env` block of whichever config you write in Step 4:
+
+```json
+"env": {
+  "SIMMER_API_KEY": "sk_live_...",
+  "SIMMER_MCP_PYTHON": "/absolute/path/to/.venv/bin/python"
+}
+```
+
+The same key works in Hermes' YAML `env:` map. `SIMMER_MCP_PYTHON` is also the fix on
+legacy distros where `python` is Python 2.
 
 ## Step 4 — wire up the MCP config
 
@@ -186,7 +238,20 @@ Restart your OpenClaw runtime so it picks up the new server.
 
 ### Hermes
 
-Hermes uses YAML, not JSON. Edit `~/.hermes/config.yaml` and add under `mcp_servers` (snake_case — different from the other runtimes):
+**Find the live config first.** Hermes supports profiles, and each profile has its own
+`HERMES_HOME`. Editing the default config does nothing for an agent you run with `-p`:
+
+| You run Hermes as | Config to edit |
+|---|---|
+| `hermes …` (default) | `~/.hermes/config.yaml` |
+| `hermes -p <profile> …` | `~/.hermes/profiles/<profile>/config.yaml` |
+
+If you use both, add the block to both. A profile can have MCP wired and still be useless
+if that profile has no inference provider configured — **MCP and inference are separate**,
+and the profile that can think is the one that needs the entry.
+
+Hermes uses YAML, not JSON. Add under `mcp_servers` (snake_case — different from the other
+runtimes):
 ```yaml
 mcp_servers:
   simmer:
@@ -194,8 +259,15 @@ mcp_servers:
     args: ["-y", "simmer-mcp"]
     env:
       SIMMER_API_KEY: "sk_live_..."
-    enabled: true
 ```
+
+**Use the CLI rather than editing by hand where you can.** Hermes ships
+`hermes mcp add`, `hermes mcp list` and `hermes mcp test` — `hermes mcp test simmer`
+connects and counts the tools, which is a faster verification than Step 6's handshake
+(expect ~23 tools). `hermes mcp list` confirms which config Hermes actually read.
+
+Stderr from the server goes to `<HERMES_HOME>/logs/mcp-stderr.log`. Read it first when
+something is wrong.
 
 ### Codex
 
@@ -213,6 +285,27 @@ The canonical Codex MCP config path varies by install — consult [Codex's MCP d
   }
 }
 ```
+
+### Grok Bot
+
+Grok Bot has no MCP config file to edit — servers are added through its **Add MCP**
+control, with the same three fields: command `npx` (or `bunx` where npm is blocked),
+args `-y simmer-mcp`, and `SIMMER_API_KEY` in env.
+
+⚠️ **Use a separate, unclaimed agent here.** On Grok Bot the MCP server runs on the cloud
+computer that **every bot on your account shares**, and its env secrets are stored where
+any of those bots can read them. Do not rely on a convention to keep that key harmless —
+a Simmer API key is not venue-scoped, so anyone holding it can call the REST API with
+`venue="polymarket"` directly and never touch this server's `SIMMER_MCP_ALLOW_LIVE` gate.
+
+The control that actually holds is **claim status**: an unclaimed agent is $SIM-locked
+regardless of any `venue=` parameter (Step 1, Case C). So register a second agent for the
+shared VM, never send its `claim_url`, and keep your claimed agent's key off that machine.
+For real trading on Grok Bot, install the `simmer` skill and drive the SDK on your own
+machine through a granted local folder.
+
+Grok **CLI** (the coding agent, a different product) does use a config file — treat it as
+"Other / unknown runtime" below.
 
 ### Other / unknown runtime
 
@@ -260,6 +353,26 @@ The `sim` venue is paper money — no real funds at risk. If this returns market
 - Confirm the runtime fully restarted (not just reloaded the conversation).
 - Check the config file actually got written — `cat ~/.claude.json` (or equivalent) and look for the `simmer` entry under `mcpServers`.
 - For Claude Code: `claude mcp list` shows registered servers and their status.
+- For Hermes: `hermes mcp list` shows which config it actually read, and
+  `hermes mcp test simmer` connects and counts tools. If you run Hermes with `-p`, check
+  you edited that profile's config and not the default one.
+
+**Everything works except the `preflight` tool.**
+That is the one bundled tool that shells out to Python. Either `simmer-sdk` is missing, or
+it is installed in a venv the server cannot see. The server prints which interpreter it
+resolved on every start:
+
+```
+[simmer-mcp] runtime: python3: v3.x (/path) | simmer-sdk: ...
+```
+
+Read that line — it is portable across runtimes and tells you *which* Python was used. If
+the path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b). On Hermes the server's
+stderr goes to `<HERMES_HOME>/logs/mcp-stderr.log`; other runtimes surface it differently,
+so prefer the runtime line over hunting for a log file.
+
+Don't reach for this when a *different* skill tool fails — the other four bundled skills
+never run Python, so their failures have some other cause.
 
 **Tools listed but API calls return 401.**
 - `SIMMER_API_KEY` env didn't make it into the MCP subprocess. The env block in the config has to be a direct value, not a `$VAR` reference — most MCP clients don't expand shell vars at server-launch time.

--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.11"
+  version: "1.25.0"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -51,10 +51,19 @@ Response includes `api_key`, `claim_url`, and 10,000 $SIM starting balance for p
 
 ```bash
 export SIMMER_API_KEY="sk_live_..."   # paste your actual key here
-pip install simmer-sdk
+
+# Use a venv. Most Linux agent hosts (Debian/Ubuntu, and the cloud VMs most
+# agent runtimes give you) mark the system Python "externally managed", so a
+# bare `pip install` fails with PEP 668 rather than installing.
+python3 -m venv .venv && .venv/bin/pip install simmer-sdk
+# Then run with .venv/bin/python, or `source .venv/bin/activate` first.
+
 # Verify the key loaded correctly (catches clipboard contamination):
 [[ "$SIMMER_API_KEY" == sk_live_* ]] || echo "WARNING: SIMMER_API_KEY should start with sk_live_ — re-set the key"
 ```
+
+No Python on the host? Every step in this skill is also reachable over plain
+REST — register, find markets, trade. See [docs.simmer.markets](https://docs.simmer.markets).
 
 ### 2. Send your human the claim link
 
@@ -85,6 +94,36 @@ if not result.success:
 
 `reasoning=` is optional in the API but expected by convention — it's displayed publicly on the trade page.
 
+### Sizing check before you place: `dry_run`
+
+`client.trade(..., dry_run=True)` validates and prices the order without placing it. Use
+it for **one job**: confirming the share count your `amount` buys, so a tick round-down
+doesn't leave you one share short.
+
+```python
+preview = client.trade(markets[0].id, "yes", 10.0, dry_run=True)
+print(preview)          # share count and estimated price — nothing placed
+result = client.trade(markets[0].id, "yes", 10.0)   # then place for real
+```
+
+⚠️ **Two things it is not**, both of which will bite you if you treat it as a safety gate:
+
+- **Not a permission check.** The server skips account trading-limit enforcement on a dry
+  run, so a clean preview can still be rejected live for a daily cap, a spend cap, or a
+  cooldown. Read `client.get_settings()` for those.
+- **Not an accurate price on Polymarket.** It prices from the market's external price
+  rather than the executable book, so on neg-risk markets (YES and NO as independent CLOB
+  tokens) the estimate can differ from the fill. When the entry price is the thing you
+  need right, call `/api/sdk/markets/{id}/executable-price`.
+
+**To rehearse a strategy rather than check a size, use `SimmerClient(live=False)`** — real
+venue prices with the bid-ask spread modeled and no funds at risk. That is the preview
+that behaves like the real venue; `dry_run` is a sizing tool.
+
+⚠️ **The defaults differ by method, so read them rather than assuming.**
+`trade()` is `dry_run=False` — it places for real unless you ask otherwise.
+`place_combo()` is `dry_run=True` — it previews unless you pass `dry_run=False`.
+
 ## Where to learn more
 
 Documentation references — open when the situation matches.
@@ -92,7 +131,8 @@ Documentation references — open when the situation matches.
 | When | Where |
 |---|---|
 | Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers external self-custody (your own key, with OWS as an optional key store), importing a funded Polymarket wallet, and managed paths |
-| Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. |
+| Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. **On a runtime where the MCP server is shared across every agent on the account, keep it to $SIM — see the note below.** |
+| Running on Grok Bot | Install this skill with `clawhub install simmer --workdir <your agent-data dir> --dir workflows` — Grok Bot loads skills from `workflows/`, not the default `./skills`. If `npx clawhub` stalls, `bun add -g clawhub` works. **Register a separate agent for it and leave that agent unclaimed:** Grok Bot's cloud computer is shared by every bot on your account, so any key stored there is readable by all of them, and an unclaimed agent is $SIM-locked no matter what `venue=` anything passes. Keep your claimed, wallet-linked agent's key off that machine. |
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -32,6 +32,9 @@ So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strate
 ## What you'll have at the end
 
 - `simmer-mcp` runnable via `npx -y simmer-mcp` (global install optional)
+- `simmer-sdk` installed on the host — **required for the bundled skill tools**, which
+  shell out to Python. Skip it and the server still starts and the raw tools still work,
+  so the failure is silent. See Step 3b.
 - Your agent runtime's MCP config updated with a `simmer` entry
 - `SIMMER_API_KEY` plumbed into the MCP subprocess
 - Simmer tools visible to your agent:
@@ -106,6 +109,27 @@ If you do install it and get an EACCES permission error on Linux/macOS: do NOT `
 `bun add -g simmer-mcp`, and `bunx simmer-mcp` in place of `npx -y simmer-mcp` in the
 config below. Some agent runtimes gate npm behind a command review that never returns —
 observed on Grok Bot's cloud computer, 2026-09-04.
+
+## Step 3b — install the Python SDK, or half the tools will fail
+
+**Do not skip this one.** The MCP server runs on Node, but the **bundled skill runners
+shell out to Python**. Without `simmer-sdk` on the host, the server still starts, the
+handshake still succeeds, and the raw tools (`simmer_trade`, `simmer_get_markets`,
+`get_portfolio`) still work — but every per-skill execution fails. The only signal is one
+line in the server's stderr log:
+
+```
+[simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0
+```
+
+That log is easy to never see, so install it up front:
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.13.0'
+```
+
+Use a venv. Most Linux hosts mark the system Python "externally managed", so a bare
+`pip install` fails with PEP 668 instead of installing.
 
 ## Step 4 — wire up the MCP config
 
@@ -191,7 +215,20 @@ Restart your OpenClaw runtime so it picks up the new server.
 
 ### Hermes
 
-Hermes uses YAML, not JSON. Edit `~/.hermes/config.yaml` and add under `mcp_servers` (snake_case — different from the other runtimes):
+**Find the live config first.** Hermes supports profiles, and each profile has its own
+`HERMES_HOME`. Editing the default config does nothing for an agent you run with `-p`:
+
+| You run Hermes as | Config to edit |
+|---|---|
+| `hermes …` (default) | `~/.hermes/config.yaml` |
+| `hermes -p <profile> …` | `~/.hermes/profiles/<profile>/config.yaml` |
+
+If you use both, add the block to both. A profile can have MCP wired and still be useless
+if that profile has no inference provider configured — **MCP and inference are separate**,
+and the profile that can think is the one that needs the entry.
+
+Hermes uses YAML, not JSON. Add under `mcp_servers` (snake_case — different from the other
+runtimes):
 ```yaml
 mcp_servers:
   simmer:
@@ -199,8 +236,15 @@ mcp_servers:
     args: ["-y", "simmer-mcp"]
     env:
       SIMMER_API_KEY: "sk_live_..."
-    enabled: true
 ```
+
+**Use the CLI rather than editing by hand where you can.** Hermes ships
+`hermes mcp add`, `hermes mcp list` and `hermes mcp test` — `hermes mcp test simmer`
+connects and counts the tools, which is a faster verification than Step 6's handshake
+(expect ~23 tools). `hermes mcp list` confirms which config Hermes actually read.
+
+Stderr from the server goes to `mcp-stderr.log` under that same `HERMES_HOME`. Read it
+first when something is wrong.
 
 ### Codex
 
@@ -280,6 +324,15 @@ The `sim` venue is paper money — no real funds at risk. If this returns market
 - Confirm the runtime fully restarted (not just reloaded the conversation).
 - Check the config file actually got written — `cat ~/.claude.json` (or equivalent) and look for the `simmer` entry under `mcpServers`.
 - For Claude Code: `claude mcp list` shows registered servers and their status.
+- For Hermes: `hermes mcp list` shows which config it actually read, and
+  `hermes mcp test simmer` connects and counts tools. If you run Hermes with `-p`, check
+  you edited that profile's config and not the default one.
+
+**Tools appear and raw trades work, but every bundled skill fails.**
+`simmer-sdk` is missing on the host — the skill runners are Python. Read the server's
+stderr log (`mcp-stderr.log` under the runtime's home) for the
+`simmer-sdk not installed` line, then do Step 3b. Nothing else looks wrong when this
+happens, which is why it is worth checking early.
 
 **Tools listed but API calls return 401.**
 - `SIMMER_API_KEY` env didn't make it into the MCP subprocess. The env block in the config has to be a direct value, not a `$VAR` reference — most MCP clients don't expand shell vars at server-launch time.

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.1.3"
+version: "0.2.0"
 published: true
-description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
+description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex / Grok Bot), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.1.3"
+  version: "0.2.0"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -101,6 +101,11 @@ This step is **optional**. The MCP config in Step 4 uses `npx -y simmer-mcp`, wh
 If you do install it and get an EACCES permission error on Linux/macOS: do NOT `sudo npm install` (creates permission tangles later). Either fix npm's global directory permissions per [npm's docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally), or just skip the global install — the `npx -y simmer-mcp` form in the config works either way.
 
 > **Why no `--version` check?** simmer-mcp's binary doesn't have CLI flags — every invocation starts the stdio MCP server. Verification happens in Step 6 when your agent calls a simmer tool and gets a real response.
+
+**If npm or `npx` is blocked or hangs on your host**, `bun` works as a drop-in:
+`bun add -g simmer-mcp`, and `bunx simmer-mcp` in place of `npx -y simmer-mcp` in the
+config below. Some agent runtimes gate npm behind a command review that never returns —
+observed on Grok Bot's cloud computer, 2026-09-04.
 
 ## Step 4 — wire up the MCP config
 
@@ -213,6 +218,21 @@ The canonical Codex MCP config path varies by install — consult [Codex's MCP d
   }
 }
 ```
+
+### Grok Bot
+
+Grok Bot has no MCP config file to edit — servers are added through its **Add MCP**
+control, with the same three fields: command `npx` (or `bunx` where npm is blocked),
+args `-y simmer-mcp`, and `SIMMER_API_KEY` in env.
+
+⚠️ **Keep this to $SIM.** On Grok Bot the MCP server runs on the cloud computer that
+**every bot on your account shares**, and its env secrets are stored where any of those
+bots can read them. That is fine for a practice key and wrong for a real-money one. For
+real trading on Grok Bot, install the `simmer` skill instead and drive the SDK on your
+own machine through a granted local folder, which keeps the key off the shared VM.
+
+Grok **CLI** (the coding agent, a different product) does use a config file — treat it as
+"Other / unknown runtime" below.
 
 ### Other / unknown runtime
 

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -32,9 +32,8 @@ So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strate
 ## What you'll have at the end
 
 - `simmer-mcp` runnable via `npx -y simmer-mcp` (global install optional)
-- `simmer-sdk` installed on the host — **required for the bundled skill tools**, which
-  shell out to Python. Skip it and the server still starts and the raw tools still work,
-  so the failure is silent. See Step 3b.
+- Optionally `simmer-sdk` on the host plus `SIMMER_MCP_PYTHON` pointing at it — needed
+  only by the `preflight` tool, the one bundled skill that runs Python. See Step 3b.
 - Your agent runtime's MCP config updated with a `simmer` entry
 - `SIMMER_API_KEY` plumbed into the MCP subprocess
 - Simmer tools visible to your agent:
@@ -110,26 +109,50 @@ If you do install it and get an EACCES permission error on Linux/macOS: do NOT `
 config below. Some agent runtimes gate npm behind a command review that never returns —
 observed on Grok Bot's cloud computer, 2026-09-04.
 
-## Step 3b — install the Python SDK, or half the tools will fail
+## Step 3b — Python, only if you want the `preflight` tool
 
-**Do not skip this one.** The MCP server runs on Node, but the **bundled skill runners
-shell out to Python**. Without `simmer-sdk` on the host, the server still starts, the
-handshake still succeeds, and the raw tools (`simmer_trade`, `simmer_get_markets`,
-`get_portfolio`) still work — but every per-skill execution fails. The only signal is one
-line in the server's stderr log:
+**Scope first, because the server's own warning overstates this.** On startup you may see:
 
 ```
 [simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0
 ```
 
-That log is easy to never see, so install it up front:
+That line is wrong in two ways. **Exactly one bundled tool needs Python** — `preflight`,
+the only bundled skill with an executable entrypoint. The other four (`simmer`,
+`simmer-wallet-setup`, `simmer-briefing`, `simmer-mcp-setup`) return their SKILL.md text
+and never start a subprocess, and every raw tool (`simmer_trade`, `simmer_get_markets`,
+`get_portfolio`, …) is pure Node. And the version floor is wrong: `preflight` requires
+**`simmer-sdk>=0.17.13`**, not `0.13.0`.
+
+So if you do not need `preflight`, skip this step. If you do:
 
 ```bash
-python3 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.13.0'
+python3 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.17.13'
 ```
 
-Use a venv. Most Linux hosts mark the system Python "externally managed", so a bare
-`pip install` fails with PEP 668 instead of installing.
+Use a venv — most Linux hosts mark the system Python "externally managed", so a bare
+`pip install` fails with PEP 668. If `python3 -m venv` itself fails with
+*"ensurepip is not available"*, the venv module is packaged separately on that distro:
+`sudo apt install python3-venv` (Debian/Ubuntu), or use `pipx`, or as a last resort
+`pip install --break-system-packages`.
+
+⚠️ **Creating the venv is not enough — you must point the server at it.** The server is
+launched by your runtime as `npx -y simmer-mcp` and inherits *that* environment, not your
+shell's. It resolves Python from `SIMMER_MCP_PYTHON`, then `which python`, then
+`which python3` — **it never looks for a `.venv`**. So a venv you made in a terminal is
+invisible to it, and `preflight` fails exactly as before.
+
+Add the absolute path to the `env` block of whichever config you write in Step 4:
+
+```json
+"env": {
+  "SIMMER_API_KEY": "sk_live_...",
+  "SIMMER_MCP_PYTHON": "/absolute/path/to/.venv/bin/python"
+}
+```
+
+The same key works in Hermes' YAML `env:` map. `SIMMER_MCP_PYTHON` is also the fix on
+legacy distros where `python` is Python 2.
 
 ## Step 4 — wire up the MCP config
 
@@ -243,8 +266,8 @@ mcp_servers:
 connects and counts the tools, which is a faster verification than Step 6's handshake
 (expect ~23 tools). `hermes mcp list` confirms which config Hermes actually read.
 
-Stderr from the server goes to `mcp-stderr.log` under that same `HERMES_HOME`. Read it
-first when something is wrong.
+Stderr from the server goes to `<HERMES_HOME>/logs/mcp-stderr.log`. Read it first when
+something is wrong.
 
 ### Codex
 
@@ -269,11 +292,17 @@ Grok Bot has no MCP config file to edit — servers are added through its **Add 
 control, with the same three fields: command `npx` (or `bunx` where npm is blocked),
 args `-y simmer-mcp`, and `SIMMER_API_KEY` in env.
 
-⚠️ **Keep this to $SIM.** On Grok Bot the MCP server runs on the cloud computer that
-**every bot on your account shares**, and its env secrets are stored where any of those
-bots can read them. That is fine for a practice key and wrong for a real-money one. For
-real trading on Grok Bot, install the `simmer` skill instead and drive the SDK on your
-own machine through a granted local folder, which keeps the key off the shared VM.
+⚠️ **Use a separate, unclaimed agent here.** On Grok Bot the MCP server runs on the cloud
+computer that **every bot on your account shares**, and its env secrets are stored where
+any of those bots can read them. Do not rely on a convention to keep that key harmless —
+a Simmer API key is not venue-scoped, so anyone holding it can call the REST API with
+`venue="polymarket"` directly and never touch this server's `SIMMER_MCP_ALLOW_LIVE` gate.
+
+The control that actually holds is **claim status**: an unclaimed agent is $SIM-locked
+regardless of any `venue=` parameter (Step 1, Case C). So register a second agent for the
+shared VM, never send its `claim_url`, and keep your claimed agent's key off that machine.
+For real trading on Grok Bot, install the `simmer` skill and drive the SDK on your own
+machine through a granted local folder.
 
 Grok **CLI** (the coding agent, a different product) does use a config file — treat it as
 "Other / unknown runtime" below.
@@ -328,11 +357,22 @@ The `sim` venue is paper money — no real funds at risk. If this returns market
   `hermes mcp test simmer` connects and counts tools. If you run Hermes with `-p`, check
   you edited that profile's config and not the default one.
 
-**Tools appear and raw trades work, but every bundled skill fails.**
-`simmer-sdk` is missing on the host — the skill runners are Python. Read the server's
-stderr log (`mcp-stderr.log` under the runtime's home) for the
-`simmer-sdk not installed` line, then do Step 3b. Nothing else looks wrong when this
-happens, which is why it is worth checking early.
+**Everything works except the `preflight` tool.**
+That is the one bundled tool that shells out to Python. Either `simmer-sdk` is missing, or
+it is installed in a venv the server cannot see. The server prints which interpreter it
+resolved on every start:
+
+```
+[simmer-mcp] runtime: python3: v3.x (/path) | simmer-sdk: ...
+```
+
+Read that line — it is portable across runtimes and tells you *which* Python was used. If
+the path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b). On Hermes the server's
+stderr goes to `<HERMES_HOME>/logs/mcp-stderr.log`; other runtimes surface it differently,
+so prefer the runtime line over hunting for a log file.
+
+Don't reach for this when a *different* skill tool fails — the other four bundled skills
+never run Python, so their failures have some other cause.
 
 **Tools listed but API calls return 401.**
 - `SIMMER_API_KEY` env didn't make it into the MCP subprocess. The env block in the config has to be a direct value, not a `$VAR` reference — most MCP clients don't expand shell vars at server-launch time.

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -359,20 +359,35 @@ The `sim` venue is paper money — no real funds at risk. If this returns market
 
 **Everything works except the `preflight` tool.**
 That is the one bundled tool that shells out to Python. Either `simmer-sdk` is missing, or
-it is installed in a venv the server cannot see. The server prints which interpreter it
-resolved on every start:
+it is installed in a venv the server cannot see.
+
+**Read the tool's own error first — it is the one signal every host gives you.** Calling
+`simmer_preflight` returns exit 2 with the cause:
+
+```
+ERROR: simmer-sdk not installed — run: pip install simmer-sdk>=0.17.13
+```
+
+The server also prints an interpreter line on startup, which is more useful because it
+names *which* Python got resolved:
 
 ```
 [simmer-mcp] runtime: python3: v3.x (/path) | simmer-sdk: ...
 ```
 
-Read that line — it is portable across runtimes and tells you *which* Python was used. If
-the path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b). On Hermes the server's
-stderr goes to `<HERMES_HOME>/logs/mcp-stderr.log`; other runtimes surface it differently,
-so prefer the runtime line over hunting for a log file.
+⚠️ **Whether you can actually read that line depends on the host, so don't go hunting for
+a log file.** The server always emits it; where stderr lands is the host's choice.
 
-Don't reach for this when a *different* skill tool fails — the other four bundled skills
-never run Python, so their failures have some other cause.
+| Host | Where the startup line goes |
+|---|---|
+| Hermes | `<HERMES_HOME>/logs/mcp-stderr.log` — and a profile has its own, e.g. `~/.hermes/profiles/<name>/logs/mcp-stderr.log` |
+| Grok Bot | **No file.** stderr is a Unix socket into the MCP host. Use the tool error above. |
+| Others | Varies. If there is no log, run `npx -y simmer-mcp` once in a terminal with `SIMMER_API_KEY` set and read the line directly. |
+
+If the resolved path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b).
+
+Don't reach for any of this when a *different* skill tool fails — the other four bundled
+skills never run Python, so their failures have some other cause.
 
 **Tools listed but API calls return 401.**
 - `SIMMER_API_KEY` env didn't make it into the MCP subprocess. The env block in the config has to be a direct value, not a `$VAR` reference — most MCP clients don't expand shell vars at server-launch time.

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -94,17 +94,31 @@ if not result.success:
 
 `reasoning=` is optional in the API but expected by convention — it's displayed publicly on the trade page.
 
-### Check before you place: `dry_run`
+### Sizing check before you place: `dry_run`
 
-`client.trade(..., dry_run=True)` validates and prices the order without placing
-it — no money moves. Use it to see the exact fill you would get before committing,
-especially on a first run against a new market or a new venue.
+`client.trade(..., dry_run=True)` validates and prices the order without placing it. Use
+it for **one job**: confirming the share count your `amount` buys, so a tick round-down
+doesn't leave you one share short.
 
 ```python
 preview = client.trade(markets[0].id, "yes", 10.0, dry_run=True)
-print(preview)          # exact shares, price, fees — nothing placed
+print(preview)          # share count and estimated price — nothing placed
 result = client.trade(markets[0].id, "yes", 10.0)   # then place for real
 ```
+
+⚠️ **Two things it is not**, both of which will bite you if you treat it as a safety gate:
+
+- **Not a permission check.** The server skips account trading-limit enforcement on a dry
+  run, so a clean preview can still be rejected live for a daily cap, a spend cap, or a
+  cooldown. Read `client.get_settings()` for those.
+- **Not an accurate price on Polymarket.** It prices from the market's external price
+  rather than the executable book, so on neg-risk markets (YES and NO as independent CLOB
+  tokens) the estimate can differ from the fill. When the entry price is the thing you
+  need right, call `/api/sdk/markets/{id}/executable-price`.
+
+**To rehearse a strategy rather than check a size, use `SimmerClient(live=False)`** — real
+venue prices with the bid-ask spread modeled and no funds at risk. That is the preview
+that behaves like the real venue; `dry_run` is a sizing tool.
 
 ⚠️ **The defaults differ by method, so read them rather than assuming.**
 `trade()` is `dry_run=False` — it places for real unless you ask otherwise.
@@ -118,7 +132,7 @@ Documentation references — open when the situation matches.
 |---|---|
 | Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers external self-custody (your own key, with OWS as an optional key store), importing a funded Polymarket wallet, and managed paths |
 | Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. **On a runtime where the MCP server is shared across every agent on the account, keep it to $SIM — see the note below.** |
-| Running on Grok Bot | Install this skill with `clawhub install simmer --workdir <your agent-data dir> --dir workflows` — Grok Bot loads skills from `workflows/`, not the default `./skills`. If `npx clawhub` stalls, `bun add -g clawhub` works. Prefer this skill over adding the MCP server: an `AddMcpServer` entry runs on the shared cloud computer and is visible to **every bot on your account**, so treat any key you put there as $SIM-only. |
+| Running on Grok Bot | Install this skill with `clawhub install simmer --workdir <your agent-data dir> --dir workflows` — Grok Bot loads skills from `workflows/`, not the default `./skills`. If `npx clawhub` stalls, `bun add -g clawhub` works. **Register a separate agent for it and leave that agent unclaimed:** Grok Bot's cloud computer is shared by every bot on your account, so any key stored there is readable by all of them, and an unclaimed agent is $SIM-locked no matter what `venue=` anything passes. Keep your claimed, wallet-linked agent's key off that machine. |
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.24.11"
+  version: "1.25.0"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -51,10 +51,19 @@ Response includes `api_key`, `claim_url`, and 10,000 $SIM starting balance for p
 
 ```bash
 export SIMMER_API_KEY="sk_live_..."   # paste your actual key here
-pip install simmer-sdk
+
+# Use a venv. Most Linux agent hosts (Debian/Ubuntu, and the cloud VMs most
+# agent runtimes give you) mark the system Python "externally managed", so a
+# bare `pip install` fails with PEP 668 rather than installing.
+python3 -m venv .venv && .venv/bin/pip install simmer-sdk
+# Then run with .venv/bin/python, or `source .venv/bin/activate` first.
+
 # Verify the key loaded correctly (catches clipboard contamination):
 [[ "$SIMMER_API_KEY" == sk_live_* ]] || echo "WARNING: SIMMER_API_KEY should start with sk_live_ — re-set the key"
 ```
+
+No Python on the host? Every step in this skill is also reachable over plain
+REST — register, find markets, trade. See [docs.simmer.markets](https://docs.simmer.markets).
 
 ### 2. Send your human the claim link
 
@@ -85,6 +94,22 @@ if not result.success:
 
 `reasoning=` is optional in the API but expected by convention — it's displayed publicly on the trade page.
 
+### Check before you place: `dry_run`
+
+`client.trade(..., dry_run=True)` validates and prices the order without placing
+it — no money moves. Use it to see the exact fill you would get before committing,
+especially on a first run against a new market or a new venue.
+
+```python
+preview = client.trade(markets[0].id, "yes", 10.0, dry_run=True)
+print(preview)          # exact shares, price, fees — nothing placed
+result = client.trade(markets[0].id, "yes", 10.0)   # then place for real
+```
+
+⚠️ **The defaults differ by method, so read them rather than assuming.**
+`trade()` is `dry_run=False` — it places for real unless you ask otherwise.
+`place_combo()` is `dry_run=True` — it previews unless you pass `dry_run=False`.
+
 ## Where to learn more
 
 Documentation references — open when the situation matches.
@@ -92,7 +117,8 @@ Documentation references — open when the situation matches.
 | When | Where |
 |---|---|
 | Setting up a real-money wallet (Polymarket or Kalshi) | Install [`simmer-wallet-setup`](https://clawhub.ai/skills/simmer-wallet-setup) — covers external self-custody (your own key, with OWS as an optional key store), importing a funded Polymarket wallet, and managed paths |
-| Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. |
+| Wiring Simmer into an MCP-aware agent (Claude Code, Cursor, OpenClaw, Hermes, Codex) | Install [`simmer-mcp-setup`](https://clawhub.ai/skills/simmer-mcp-setup) — one-shot bootstrap for the Simmer MCP server. Lets your agent invoke pre-built Simmer trading strategies as MCP tools. **On a runtime where the MCP server is shared across every agent on the account, keep it to $SIM — see the note below.** |
+| Running on Grok Bot | Install this skill with `clawhub install simmer --workdir <your agent-data dir> --dir workflows` — Grok Bot loads skills from `workflows/`, not the default `./skills`. If `npx clawhub` stalls, `bun add -g clawhub` works. Prefer this skill over adding the MCP server: an `AddMcpServer` entry runs on the shared cloud computer and is visible to **every bot on your account**, so treat any key you put there as $SIM-only. |
 | Periodic portfolio check-in (heartbeat / cron loop) | [docs.simmer.markets](https://docs.simmer.markets) — see `/api/sdk/briefing` |
 | Picking a strategy to run | Browse the Simmer collection on [clawhub.ai/skills?q=simmer](https://clawhub.ai/skills?q=simmer) |
 | Building your own strategy skill | [docs.simmer.markets/skills/building](https://docs.simmer.markets/skills/building) |


### PR DESCRIPTION
## What

A dogfood run on a Grok Bot seat (2026-09-04) registered and traded \$SIM from `skill.md` alone — the core path works cold, on a runtime we have never tested. Then it failed on **every install path we document**. This fixes what was ours.

## Findings and fixes

| Finding | Ours? | Fix |
|---|---|---|
| `pip install simmer-sdk` dies on PEP 668 (externally-managed env) | **yes, general** | venv form; REST noted for Python-less hosts |
| `dry_run` documented nowhere an agent reads | **yes, general** | taught in the skill body |
| `trade()` defaults `dry_run=False`, `place_combo()` defaults `True` | **yes** | stated explicitly; **defaults NOT changed** |
| `clawhub install` lands in `./skills`, Grok Bot loads `workflows/` | Grok-specific | documented `--workdir/--dir` |
| npm/npx gated on that seat; `bun` works | Grok-specific | documented as fallback |
| `simmer-mcp-setup` lists no Grok runtime | yes | Grok Bot section added |

## The one recommendation from the report I declined

The report asked for Grok Bot to be documented as an MCP door and for a Simmer connector. Verified on that same seat: a Grok Bot MCP server runs on a cloud computer **shared by every bot on the account**, with env secrets under `/home/box/agent-data/connector-secrets/` readable across them. So the MCP section is scoped to \$SIM on purpose and points real-money users at the skill + local-SDK path. Detail: `simmer-labs/shared-knowledge/intel/grokbot-runtime.md`.

## Not changed, deliberately

- **`trade()`'s `dry_run` default stays `False`.** Flipping it would silently stop every live agent from placing real trades.
- **`client.py` untouched.** The `dry_run` docstring is already thorough — it documents that dry-run is not a permission check and carries the neg-risk pricing caveat. The gap was the skill, not the code.

## Verification

- `/start` returns `<body><div id="root"></div></body>` — confirmed against prod, filed separately, not in this PR.
- `skills/simmer/SKILL.md:54` bare pip confirmed before edit.
- `simmer-mcp-setup` runtime list confirmed to name only Claude Code / Codex / Cursor / Hermes / OpenClaw.

Versions bumped (`simmer` 1.24.11 → 1.25.0, `simmer-mcp-setup` 0.1.3 → 0.2.0). **ClawHub republish held pending approval** — merging this does not publish.