### PR TITLE
mcp: fix the warning that misled us, and document OpenClaw's CLI + secret ref

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -140,8 +140,13 @@ allowlist decision and rationale.
 ## Requirements
 
 - Node.js 18+
-- Python 3.9+ (for per-skill execution)
-- `pip install simmer-sdk>=0.13.0` (for per-skill execution)
+- Python 3.9+ — **only** for the `preflight` tool, the one bundled skill with an
+  executable entrypoint. Every other tool is pure Node.
+- `pip install 'simmer-sdk>=0.17.13'` — the floor `preflight` needs. Below it the import
+  succeeds and `preflight` then crashes on a missing API, so the server treats an
+  under-floor SDK as not installed.
+- Set `SIMMER_MCP_PYTHON` to that interpreter. The server resolves Python from
+  `SIMMER_MCP_PYTHON`, then `PATH` — it never discovers a `.venv` on its own.
 
 ## Contributing
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -100,7 +100,7 @@ By default, `simmer-mcp` resolves the Python binary in this order:
   ```
 - Your system `python` is Python 2 (RHEL 7, Ubuntu 18.04, and other legacy Linux distros ship `python` → Python 2.x). In that case the fallback to `python` silently picks up Py2, `simmer-sdk` import fails, and skills report `simmer-sdk: not installed`. Pinning to `python3` or your venv's interpreter avoids this.
 
-> **Legacy Linux warning:** On systems where `python` resolves to Python 2, all per-skill tools will fail with a silent import error unless `SIMMER_MCP_PYTHON` is set to a Python 3.8+ binary (the simmer-sdk minimum, per `pyproject.toml`).
+> **Legacy Linux warning:** On systems where `python` resolves to Python 2, the `preflight` tool (the one bundled skill that runs Python) will fail with a silent import error unless `SIMMER_MCP_PYTHON` is set to a Python 3.9+ binary. Other tools are unaffected.
 
 ### Example: Claude Desktop config with a pinned interpreter
 

--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.2.0"
+version: "0.3.0"
 published: true
 description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex / Grok Bot), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.2.0"
+  version: "0.3.0"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -111,18 +111,22 @@ observed on Grok Bot's cloud computer, 2026-09-04.
 
 ## Step 3b — Python, only if you want the `preflight` tool
 
-**Scope first, because the server's own warning overstates this.** On startup you may see:
+**Scope first.** On startup you may see:
 
 ```
-[simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0
+[simmer-mcp] ⚠ simmer-sdk not installed — the preflight tool will fail (other tools are
+unaffected). Run: pip install 'simmer-sdk>=0.17.13', then set SIMMER_MCP_PYTHON to that
+interpreter.
 ```
 
-That line is wrong in two ways. **Exactly one bundled tool needs Python** — `preflight`,
-the only bundled skill with an executable entrypoint. The other four (`simmer`,
-`simmer-wallet-setup`, `simmer-briefing`, `simmer-mcp-setup`) return their SKILL.md text
-and never start a subprocess, and every raw tool (`simmer_trade`, `simmer_get_markets`,
-`get_portfolio`, …) is pure Node. And the version floor is wrong: `preflight` requires
-**`simmer-sdk>=0.17.13`**, not `0.13.0`.
+**Exactly one bundled tool needs Python** — `preflight`, the only bundled skill with an
+executable entrypoint. The other four (`simmer`, `simmer-wallet-setup`, `simmer-briefing`,
+`simmer-mcp-setup`) return their SKILL.md text and never start a subprocess, and every raw
+tool (`simmer_trade`, `simmer_get_markets`, `get_portfolio`, …) is pure Node.
+
+⚠️ **On an older server the same warning reads `per-skill execution will fail` and
+`>=0.13.0`. Both were wrong** — it is one tool, not all of them, and `preflight` requires
+`>=0.17.13`. If you see that older wording, trust this page over the log line.
 
 So if you do not need `preflight`, skip this step. If you do:
 
@@ -151,8 +155,15 @@ Add the absolute path to the `env` block of whichever config you write in Step 4
 }
 ```
 
-The same key works in Hermes' YAML `env:` map. `SIMMER_MCP_PYTHON` is also the fix on
-legacy distros where `python` is Python 2.
+The same key works in Hermes' YAML `env:` map and OpenClaw's `env` object.
+`SIMMER_MCP_PYTHON` is also the fix on legacy distros where `python` is Python 2.
+
+**Verified 2026-09-04**, both directions: pointed at a venv *without* the SDK the server
+reports `simmer-sdk: not installed`; pointed at one *with* it, `simmer-sdk: v0.24.6`. The
+startup line names the interpreter it resolved, so it tells you whether the variable took
+effect. With the variable unset it resolves from `PATH` — so it can appear to work by
+accident if the launching process happens to have a venv activated, and break when the
+same config runs under a runtime with a different `PATH`.
 
 ## Step 4 — wire up the MCP config
 
@@ -217,7 +228,25 @@ Project-scoped: use `.cursor/mcp.json` in the project root.
 
 ### OpenClaw
 
-Edit `~/.openclaw/openclaw.json` and add `simmer` under `mcp.servers`:
+**Prefer the CLI.** OpenClaw ships `openclaw mcp add`, and `openclaw mcp doctor simmer --probe`
+verifies the handshake and counts tools (expect ~23) — faster and less error-prone than
+editing JSON by hand.
+
+⚠️ **Do not paste the key in literally if you can avoid it.** OpenClaw supports env
+references — `"SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"` — and its own doctor warns when
+it finds a literal key in the config. `~/.openclaw/openclaw.json` is a file other processes
+on that machine can read; a reference keeps the secret in the environment.
+
+⚠️ **`mcp doctor` reports green even when the install is half-broken.** It probes the
+handshake, and the handshake succeeds without Python. Confirmed on OpenClaw 2026.9.1,
+2026-09-04: doctor showed 23 tools while the server's stderr said `simmer-sdk not
+installed`. A green doctor does not mean `preflight` works — see Step 3b.
+
+Headless hosts (agent seats, CI) cannot run the interactive onboarding at all; it exits
+with `Onboarding needs an interactive TTY`. Use
+`openclaw onboard --non-interactive --accept-risk`.
+
+If you edit the file by hand instead, add `simmer` under `mcp.servers`:
 ```json
 {
   "mcp": {
@@ -382,6 +411,7 @@ a log file.** The server always emits it; where stderr lands is the host's choic
 |---|---|
 | Hermes | `<HERMES_HOME>/logs/mcp-stderr.log` — and a profile has its own, e.g. `~/.hermes/profiles/<name>/logs/mcp-stderr.log` |
 | Grok Bot | **No file.** stderr is a Unix socket into the MCP host. Use the tool error above. |
+| OpenClaw | `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (and `bundle-mcp::` entries under the gateway) |
 | Others | Varies. If there is no log, run `npx -y simmer-mcp` once in a terminal with `SIMMER_API_KEY` set and read the line directly. |
 
 If the resolved path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b).

--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -255,15 +255,23 @@ it wherever the gateway is launched from, or keep it in a file the gateway sourc
 ⚠️ **Don't check the tool count against a number in this document — check it against the
 server's own banner.** The server prints `[simmer-mcp] v<x> | tools: N (…, K keyless)` on
 startup; that N is the truth for the build you are running, and it changes between
-releases. Measured 2026-09-04: published `simmer-mcp@3.5.0` from npm reports **23 tools,
-9 keyless**.
+releases. As of 2026-09-04 the published npm build reports **23 tools, 9 keyless** —
+quoted only as a rough scale, not a target to match, since a build from source can differ
+from the published package at the same version number.
 
 ⚠️ **A low count usually means the key did not resolve, not that tools are missing.**
-Without a usable `SIMMER_API_KEY` the server starts cleanly in **keyless mode** with only
-the keyless subset — no error, no warning, because the malformed-key guard only fires on a
-non-empty bad key. An empty one is silent. So if the banner shows roughly a third of the
-tools you expected, check the key reached the server process before debugging anything
-else.
+Without a usable `SIMMER_API_KEY` the server starts in **keyless mode** with only the
+keyless subset. It does say so — look for this line, which is the fastest diagnosis
+available:
+
+```
+[simmer-mcp] No SIMMER_API_KEY set — discovery tools only (skills, docs, market browse,
+leaderboard, troubleshooting). Trading and portfolio tools need a key
+```
+
+A key that is present but malformed gets a different line naming `sk_live_`. So if the
+banner shows roughly a third of the tools you expected, read the two lines above it before
+debugging anything else.
 
 ⚠️ **`mcp doctor` reports green even when the install is half-broken.** It probes the
 handshake, and the handshake succeeds without Python. Confirmed on OpenClaw 2026.9.1,
@@ -283,7 +291,7 @@ If you edit the file by hand instead, add `simmer` under `mcp.servers`:
         "command": "npx",
         "args": ["-y", "simmer-mcp"],
         "env": {
-          "SIMMER_API_KEY": "sk_live_..."
+          "SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"
         }
       }
     }
@@ -320,7 +328,7 @@ mcp_servers:
 
 **Use the CLI rather than editing by hand where you can.** Hermes ships
 `hermes mcp add`, `hermes mcp list` and `hermes mcp test` — `hermes mcp test simmer`
-connects and counts the tools, which is a faster verification than Step 6's handshake
+connects and counts the tools, which is a faster verification than Step 6's handshake.
 `hermes mcp list` confirms which config Hermes actually read.
 
 Stderr from the server goes to `<HERMES_HOME>/logs/mcp-stderr.log`. Read it first when
@@ -392,10 +400,8 @@ Don't trust "looks installed" — verify with a real tool call.
 Ask your agent:
 > What simmer tools can you see? List them.
 
-The agent should respond with the 3 utility tools, raw market/trade tools, and the core bundled skill tools:
-- `list_skills`
-- `get_skill_docs`
-- `troubleshoot_error`
+The agent should respond with the keyless utility tools, raw market/trade tools, and the core bundled skill tools:
+- Keyless utilities, available with or without a key — `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, `simmer_register_agent`
 - Core bundled skill tools (`simmer_simmer`, `simmer_simmer_wallet_setup`, `simmer_simmer_mcp_setup`, `simmer_simmer_briefing`, `simmer_preflight`)
 - Raw market/trade tools (`simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, and portfolio/position tools)
 

--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -37,7 +37,7 @@ So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strate
 - Your agent runtime's MCP config updated with a `simmer` entry
 - `SIMMER_API_KEY` plumbed into the MCP subprocess
 - Simmer tools visible to your agent:
-  - **3 free utility tools** (always available): `list_skills`, `get_skill_docs`, `troubleshoot_error`
+  - **Keyless utility tools** (always available, no key needed): `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, and on newer builds `simmer_register_agent`. The startup banner prints the exact keyless count for your build.
   - **Core Simmer skill tools** — the npm package bundles only foundational, pinned skills (`simmer`, `simmer-wallet-setup`, `simmer-mcp-setup`, `simmer-briefing`, and `preflight`). Situational strategies such as combo, shock-ladder, copytrading, weather, and DCA install on demand from ClawHub so they stay current.
   - **Raw market/trade tools** — `simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, portfolio/position tools, and guarded order cancellation.
   - **4 Pro-gated autoresearch tools** (`init_experiment`, `run_experiment`, `log_experiment`, `backtest_experiment`) — only registered if you're on the Pro plan.
@@ -234,23 +234,39 @@ hand.
 
 ```bash
 export SIMMER_API_KEY=sk_live_...   # the gateway must see this too — see below
-openclaw mcp add simmer --command npx --args '-y,simmer-mcp' \
-  --env 'SIMMER_API_KEY=ref(env:SIMMER_API_KEY)'
+openclaw mcp add simmer --command npx --arg -y --arg simmer-mcp \
+  --env 'SIMMER_API_KEY=${SIMMER_API_KEY}'
 openclaw mcp doctor simmer --probe
 ```
 
-Flag names vary by OpenClaw version — run `openclaw mcp add --help` first and match the
-shape above to what it accepts.
+`--arg` is repeatable (one per argv element) and `--env` takes `KEY=VALUE` — both per
+OpenClaw's own `mcp` CLI docs. Quote the `${…}` so your shell does not expand it before
+OpenClaw sees it.
+
+⚠️ Known upstream issue at the time of writing: entries added via `openclaw mcp add` can
+pass `doctor` yet never reach a `claude-cli`-backed agent session
+(`openclaw/openclaw#122712`). If the tools show in `doctor` but not in the agent, that is
+the first thing to check, and the hand-edit path below is the workaround.
 
 ⚠️ **Do not paste the key in literally if you can avoid it.** OpenClaw supports env
-references — `"SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"` — and its own doctor warns when
+references — `"SIMMER_API_KEY": "${SIMMER_API_KEY}"` (also `"$SIMMER_API_KEY"`, or the
+object form `{ source: "env", id: "SIMMER_API_KEY" }`) — and its own doctor warns when
 it finds a literal key in the config. `~/.openclaw/openclaw.json` is a file other processes
 on that machine can read; a reference keeps the secret in the environment.
 
-But **the OpenClaw gateway process itself must carry that variable**, not just your
-interactive shell. If it does not, the reference resolves to an empty string and the
-server starts in keyless mode with no error at all — see the tool-count note above. Export
-it wherever the gateway is launched from, or keep it in a file the gateway sources.
+**The OpenClaw gateway process itself must carry that variable**, not just your
+interactive shell. Per OpenClaw's secrets docs, a missing or empty env value **fails
+resolution** — the reference does not silently become an empty string, and it does not
+fall through to any other credential. So the symptom of a variable the gateway cannot see
+is a resolution error from OpenClaw, not a quietly keyless server. Export it wherever the
+gateway is launched from, or keep it in a file the gateway sources.
+
+Do not write `ref(env:NAME)` as the value. That is only how OpenClaw *labels* a resolved
+reference in its own output; as an input it is treated as a literal string, which is
+truthy — so the server registers every tool against a garbage key and prints only the
+`sk_live_` warning. That looks like a healthy install with a bad key, which sends you
+debugging the wrong thing. Doctor's literal-secret check is simply "value does not start
+with `$`", so the `${…}` form is the one it accepts.
 
 ⚠️ **Don't check the tool count against a number in this document — check it against the
 server's own banner.** The server prints `[simmer-mcp] v<x> | tools: N (…, K keyless)` on
@@ -291,7 +307,7 @@ If you edit the file by hand instead, add `simmer` under `mcp.servers`:
         "command": "npx",
         "args": ["-y", "simmer-mcp"],
         "env": {
-          "SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"
+          "SIMMER_API_KEY": "${SIMMER_API_KEY}"
         }
       }
     }
@@ -401,7 +417,7 @@ Ask your agent:
 > What simmer tools can you see? List them.
 
 The agent should respond with the keyless utility tools, raw market/trade tools, and the core bundled skill tools:
-- Keyless utilities, available with or without a key — `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, `simmer_register_agent`
+- Keyless utilities, available with or without a key — `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, and on newer builds `simmer_register_agent`. The exact set depends on the build you installed; the startup banner's keyless count is authoritative, not this list.
 - Core bundled skill tools (`simmer_simmer`, `simmer_simmer_wallet_setup`, `simmer_simmer_mcp_setup`, `simmer_simmer_briefing`, `simmer_preflight`)
 - Raw market/trade tools (`simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, and portfolio/position tools)
 

--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -229,13 +229,41 @@ Project-scoped: use `.cursor/mcp.json` in the project root.
 ### OpenClaw
 
 **Prefer the CLI.** OpenClaw ships `openclaw mcp add`, and `openclaw mcp doctor simmer --probe`
-verifies the handshake and counts tools (expect ~23) — faster and less error-prone than
-editing JSON by hand.
+verifies the handshake and counts tools — faster and less error-prone than editing JSON by
+hand.
+
+```bash
+export SIMMER_API_KEY=sk_live_...   # the gateway must see this too — see below
+openclaw mcp add simmer --command npx --args '-y,simmer-mcp' \
+  --env 'SIMMER_API_KEY=ref(env:SIMMER_API_KEY)'
+openclaw mcp doctor simmer --probe
+```
+
+Flag names vary by OpenClaw version — run `openclaw mcp add --help` first and match the
+shape above to what it accepts.
 
 ⚠️ **Do not paste the key in literally if you can avoid it.** OpenClaw supports env
 references — `"SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"` — and its own doctor warns when
 it finds a literal key in the config. `~/.openclaw/openclaw.json` is a file other processes
 on that machine can read; a reference keeps the secret in the environment.
+
+But **the OpenClaw gateway process itself must carry that variable**, not just your
+interactive shell. If it does not, the reference resolves to an empty string and the
+server starts in keyless mode with no error at all — see the tool-count note above. Export
+it wherever the gateway is launched from, or keep it in a file the gateway sources.
+
+⚠️ **Don't check the tool count against a number in this document — check it against the
+server's own banner.** The server prints `[simmer-mcp] v<x> | tools: N (…, K keyless)` on
+startup; that N is the truth for the build you are running, and it changes between
+releases. Measured 2026-09-04: published `simmer-mcp@3.5.0` from npm reports **23 tools,
+9 keyless**.
+
+⚠️ **A low count usually means the key did not resolve, not that tools are missing.**
+Without a usable `SIMMER_API_KEY` the server starts cleanly in **keyless mode** with only
+the keyless subset — no error, no warning, because the malformed-key guard only fires on a
+non-empty bad key. An empty one is silent. So if the banner shows roughly a third of the
+tools you expected, check the key reached the server process before debugging anything
+else.
 
 ⚠️ **`mcp doctor` reports green even when the install is half-broken.** It probes the
 handshake, and the handshake succeeds without Python. Confirmed on OpenClaw 2026.9.1,
@@ -293,7 +321,7 @@ mcp_servers:
 **Use the CLI rather than editing by hand where you can.** Hermes ships
 `hermes mcp add`, `hermes mcp list` and `hermes mcp test` — `hermes mcp test simmer`
 connects and counts the tools, which is a faster verification than Step 6's handshake
-(expect ~23 tools). `hermes mcp list` confirms which config Hermes actually read.
+`hermes mcp list` confirms which config Hermes actually read.
 
 Stderr from the server goes to `<HERMES_HOME>/logs/mcp-stderr.log`. Read it first when
 something is wrong.

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -1108,7 +1108,7 @@ async function main() {
   console.error(`[simmer-mcp] runtime: ${probeLines}`);
 
   if (!probe.python3.detected) {
-    console.error("[simmer-mcp] ⚠ python3 not found — per-skill execution will fail. Install python3 to use trading skills.");
+    console.error("[simmer-mcp] ⚠ python3 not found — the preflight tool will fail (other tools are unaffected). Install python3 to use it.");
   }
   if (!probe.simmerSdk.detected && simmer) {
     console.error("[simmer-mcp] ⚠ simmer-sdk not installed — the preflight tool will fail (other tools are unaffected). Run: pip install 'simmer-sdk>=0.17.13', then set SIMMER_MCP_PYTHON to that interpreter.");

--- a/mcp/src/mcp-server.ts
+++ b/mcp/src/mcp-server.ts
@@ -1111,7 +1111,7 @@ async function main() {
     console.error("[simmer-mcp] ⚠ python3 not found — per-skill execution will fail. Install python3 to use trading skills.");
   }
   if (!probe.simmerSdk.detected && simmer) {
-    console.error("[simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0");
+    console.error("[simmer-mcp] ⚠ simmer-sdk not installed — the preflight tool will fail (other tools are unaffected). Run: pip install 'simmer-sdk>=0.17.13', then set SIMMER_MCP_PYTHON to that interpreter.");
   }
 
   const transport = new StdioServerTransport();

--- a/mcp/src/runtime-probe.ts
+++ b/mcp/src/runtime-probe.ts
@@ -1,5 +1,34 @@
 import { spawn } from "node:child_process";
 
+/**
+ * Minimum simmer-sdk the bundled `preflight` skill needs — it calls APIs that do not
+ * exist below this. Keep in sync with `bundled-skills/preflight/clawhub.json`.
+ */
+export const SDK_MIN_VERSION = "0.17.13";
+const SDK_INSTALL_HINT = `Install: pip install 'simmer-sdk>=${SDK_MIN_VERSION}'`;
+
+/**
+ * True when `version` is >= SDK_MIN_VERSION.
+ *
+ * Fails OPEN on anything unparseable (empty, a dev build, a git describe string): an
+ * SDK that is actually present should not be reported missing just because we could not
+ * read its version. Only a version we can read AND that is genuinely below the floor
+ * gets rejected.
+ */
+export function meetsSdkFloor(version: string, floor = SDK_MIN_VERSION): boolean {
+  const numeric = (v: string) => v.trim().match(/^\d+(?:\.\d+)*/)?.[0] ?? "";
+  const got = numeric(version);
+  if (got === "") return true;
+  const a = got.split(".").map(Number);
+  const b = numeric(floor).split(".").map(Number);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x > y;
+  }
+  return true;
+}
+
 export interface ProbeResult {
   detected: boolean;
   version?: string;
@@ -65,11 +94,16 @@ export async function probeRuntime(): Promise<RuntimeProbeResult> {
     ? { detected: true, version: py.stdout.replace(/^Python /, ""), path: pythonBin }
     : { detected: false, path: pythonBin, installHint: "Install: brew install python@3.11 (macOS) or apt install python3 (Debian/Ubuntu)" };
 
-  let simmerSdk: ProbeResult = { detected: false, installHint: "Install: pip install 'simmer-sdk>=0.17.13'" };
+  let simmerSdk: ProbeResult = { detected: false, installHint: SDK_INSTALL_HINT };
   if (python3.detected) {
     const sdk = await runQuick(pythonBin, ["-c", "import simmer_sdk; print(simmer_sdk.__version__)"]);
     if (sdk.exitCode === 0) {
-      simmerSdk = { detected: true, version: sdk.stdout };
+      // Import success is not enough: `preflight` calls APIs added in SDK_MIN_VERSION and
+      // only catches ImportError, so an older-but-importable SDK crashes with a traceback
+      // instead of reporting the install hint. Treat below-floor as not usable.
+      simmerSdk = meetsSdkFloor(sdk.stdout)
+        ? { detected: true, version: sdk.stdout }
+        : { detected: false, version: sdk.stdout, installHint: SDK_INSTALL_HINT };
     }
   }
 

--- a/mcp/src/runtime-probe.ts
+++ b/mcp/src/runtime-probe.ts
@@ -65,7 +65,7 @@ export async function probeRuntime(): Promise<RuntimeProbeResult> {
     ? { detected: true, version: py.stdout.replace(/^Python /, ""), path: pythonBin }
     : { detected: false, path: pythonBin, installHint: "Install: brew install python@3.11 (macOS) or apt install python3 (Debian/Ubuntu)" };
 
-  let simmerSdk: ProbeResult = { detected: false, installHint: "Install: pip install simmer-sdk>=0.13.0" };
+  let simmerSdk: ProbeResult = { detected: false, installHint: "Install: pip install 'simmer-sdk>=0.17.13'" };
   if (python3.detected) {
     const sdk = await runQuick(pythonBin, ["-c", "import simmer_sdk; print(simmer_sdk.__version__)"]);
     if (sdk.exitCode === 0) {

--- a/mcp/src/runtime-probe.ts
+++ b/mcp/src/runtime-probe.ts
@@ -7,28 +7,6 @@ import { spawn } from "node:child_process";
 export const SDK_MIN_VERSION = "0.17.13";
 const SDK_INSTALL_HINT = `Install: pip install 'simmer-sdk>=${SDK_MIN_VERSION}'`;
 
-/**
- * True when `version` is >= SDK_MIN_VERSION.
- *
- * Fails OPEN on anything unparseable (empty, a dev build, a git describe string): an
- * SDK that is actually present should not be reported missing just because we could not
- * read its version. Only a version we can read AND that is genuinely below the floor
- * gets rejected.
- */
-export function meetsSdkFloor(version: string, floor = SDK_MIN_VERSION): boolean {
-  const numeric = (v: string) => v.trim().match(/^\d+(?:\.\d+)*/)?.[0] ?? "";
-  const got = numeric(version);
-  if (got === "") return true;
-  const a = got.split(".").map(Number);
-  const b = numeric(floor).split(".").map(Number);
-  for (let i = 0; i < Math.max(a.length, b.length); i++) {
-    const x = a[i] ?? 0;
-    const y = b[i] ?? 0;
-    if (x !== y) return x > y;
-  }
-  return true;
-}
-
 export interface ProbeResult {
   detected: boolean;
   version?: string;
@@ -98,12 +76,12 @@ export async function probeRuntime(): Promise<RuntimeProbeResult> {
   if (python3.detected) {
     const sdk = await runQuick(pythonBin, ["-c", "import simmer_sdk; print(simmer_sdk.__version__)"]);
     if (sdk.exitCode === 0) {
-      // Import success is not enough: `preflight` calls APIs added in SDK_MIN_VERSION and
-      // only catches ImportError, so an older-but-importable SDK crashes with a traceback
-      // instead of reporting the install hint. Treat below-floor as not usable.
-      simmerSdk = meetsSdkFloor(sdk.stdout)
-        ? { detected: true, version: sdk.stdout }
-        : { detected: false, version: sdk.stdout, installHint: SDK_INSTALL_HINT };
+      // NOTE: presence only. An SDK below SDK_MIN_VERSION imports fine here and then
+      // crashes inside `preflight.py`, which catches only ImportError. Reporting that
+      // as "not installed" from this probe does NOT prevent the crash — the execution
+      // path (per-skill-tools.ts) never consults this probe. The fix belongs in
+      // preflight.py, tracked separately.
+      simmerSdk = { detected: true, version: sdk.stdout };
     }
   }
 

--- a/mcp/src/runtime-probe.ts
+++ b/mcp/src/runtime-probe.ts
@@ -80,7 +80,7 @@ export async function probeRuntime(): Promise<RuntimeProbeResult> {
       // crashes inside `preflight.py`, which catches only ImportError. Reporting that
       // as "not installed" from this probe does NOT prevent the crash — the execution
       // path (per-skill-tools.ts) never consults this probe. The fix belongs in
-      // preflight.py, tracked separately.
+      // preflight.py — SIM-5023.
       simmerSdk = { detected: true, version: sdk.stdout };
     }
   }

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.2.0"
+version: "0.3.0"
 published: true
 description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex / Grok Bot), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.2.0"
+  version: "0.3.0"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY
@@ -111,18 +111,22 @@ observed on Grok Bot's cloud computer, 2026-09-04.
 
 ## Step 3b — Python, only if you want the `preflight` tool
 
-**Scope first, because the server's own warning overstates this.** On startup you may see:
+**Scope first.** On startup you may see:
 
 ```
-[simmer-mcp] ⚠ simmer-sdk not installed — per-skill execution will fail. Run: pip install simmer-sdk>=0.13.0
+[simmer-mcp] ⚠ simmer-sdk not installed — the preflight tool will fail (other tools are
+unaffected). Run: pip install 'simmer-sdk>=0.17.13', then set SIMMER_MCP_PYTHON to that
+interpreter.
 ```
 
-That line is wrong in two ways. **Exactly one bundled tool needs Python** — `preflight`,
-the only bundled skill with an executable entrypoint. The other four (`simmer`,
-`simmer-wallet-setup`, `simmer-briefing`, `simmer-mcp-setup`) return their SKILL.md text
-and never start a subprocess, and every raw tool (`simmer_trade`, `simmer_get_markets`,
-`get_portfolio`, …) is pure Node. And the version floor is wrong: `preflight` requires
-**`simmer-sdk>=0.17.13`**, not `0.13.0`.
+**Exactly one bundled tool needs Python** — `preflight`, the only bundled skill with an
+executable entrypoint. The other four (`simmer`, `simmer-wallet-setup`, `simmer-briefing`,
+`simmer-mcp-setup`) return their SKILL.md text and never start a subprocess, and every raw
+tool (`simmer_trade`, `simmer_get_markets`, `get_portfolio`, …) is pure Node.
+
+⚠️ **On an older server the same warning reads `per-skill execution will fail` and
+`>=0.13.0`. Both were wrong** — it is one tool, not all of them, and `preflight` requires
+`>=0.17.13`. If you see that older wording, trust this page over the log line.
 
 So if you do not need `preflight`, skip this step. If you do:
 
@@ -151,8 +155,15 @@ Add the absolute path to the `env` block of whichever config you write in Step 4
 }
 ```
 
-The same key works in Hermes' YAML `env:` map. `SIMMER_MCP_PYTHON` is also the fix on
-legacy distros where `python` is Python 2.
+The same key works in Hermes' YAML `env:` map and OpenClaw's `env` object.
+`SIMMER_MCP_PYTHON` is also the fix on legacy distros where `python` is Python 2.
+
+**Verified 2026-09-04**, both directions: pointed at a venv *without* the SDK the server
+reports `simmer-sdk: not installed`; pointed at one *with* it, `simmer-sdk: v0.24.6`. The
+startup line names the interpreter it resolved, so it tells you whether the variable took
+effect. With the variable unset it resolves from `PATH` — so it can appear to work by
+accident if the launching process happens to have a venv activated, and break when the
+same config runs under a runtime with a different `PATH`.
 
 ## Step 4 — wire up the MCP config
 
@@ -217,7 +228,25 @@ Project-scoped: use `.cursor/mcp.json` in the project root.
 
 ### OpenClaw
 
-Edit `~/.openclaw/openclaw.json` and add `simmer` under `mcp.servers`:
+**Prefer the CLI.** OpenClaw ships `openclaw mcp add`, and `openclaw mcp doctor simmer --probe`
+verifies the handshake and counts tools (expect ~23) — faster and less error-prone than
+editing JSON by hand.
+
+⚠️ **Do not paste the key in literally if you can avoid it.** OpenClaw supports env
+references — `"SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"` — and its own doctor warns when
+it finds a literal key in the config. `~/.openclaw/openclaw.json` is a file other processes
+on that machine can read; a reference keeps the secret in the environment.
+
+⚠️ **`mcp doctor` reports green even when the install is half-broken.** It probes the
+handshake, and the handshake succeeds without Python. Confirmed on OpenClaw 2026.9.1,
+2026-09-04: doctor showed 23 tools while the server's stderr said `simmer-sdk not
+installed`. A green doctor does not mean `preflight` works — see Step 3b.
+
+Headless hosts (agent seats, CI) cannot run the interactive onboarding at all; it exits
+with `Onboarding needs an interactive TTY`. Use
+`openclaw onboard --non-interactive --accept-risk`.
+
+If you edit the file by hand instead, add `simmer` under `mcp.servers`:
 ```json
 {
   "mcp": {
@@ -382,6 +411,7 @@ a log file.** The server always emits it; where stderr lands is the host's choic
 |---|---|
 | Hermes | `<HERMES_HOME>/logs/mcp-stderr.log` — and a profile has its own, e.g. `~/.hermes/profiles/<name>/logs/mcp-stderr.log` |
 | Grok Bot | **No file.** stderr is a Unix socket into the MCP host. Use the tool error above. |
+| OpenClaw | `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (and `bundle-mcp::` entries under the gateway) |
 | Others | Varies. If there is no log, run `npx -y simmer-mcp` once in a terminal with `SIMMER_API_KEY` set and read the line directly. |
 
 If the resolved path is not your venv, set `SIMMER_MCP_PYTHON` (Step 3b).

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -255,15 +255,23 @@ it wherever the gateway is launched from, or keep it in a file the gateway sourc
 ⚠️ **Don't check the tool count against a number in this document — check it against the
 server's own banner.** The server prints `[simmer-mcp] v<x> | tools: N (…, K keyless)` on
 startup; that N is the truth for the build you are running, and it changes between
-releases. Measured 2026-09-04: published `simmer-mcp@3.5.0` from npm reports **23 tools,
-9 keyless**.
+releases. As of 2026-09-04 the published npm build reports **23 tools, 9 keyless** —
+quoted only as a rough scale, not a target to match, since a build from source can differ
+from the published package at the same version number.
 
 ⚠️ **A low count usually means the key did not resolve, not that tools are missing.**
-Without a usable `SIMMER_API_KEY` the server starts cleanly in **keyless mode** with only
-the keyless subset — no error, no warning, because the malformed-key guard only fires on a
-non-empty bad key. An empty one is silent. So if the banner shows roughly a third of the
-tools you expected, check the key reached the server process before debugging anything
-else.
+Without a usable `SIMMER_API_KEY` the server starts in **keyless mode** with only the
+keyless subset. It does say so — look for this line, which is the fastest diagnosis
+available:
+
+```
+[simmer-mcp] No SIMMER_API_KEY set — discovery tools only (skills, docs, market browse,
+leaderboard, troubleshooting). Trading and portfolio tools need a key
+```
+
+A key that is present but malformed gets a different line naming `sk_live_`. So if the
+banner shows roughly a third of the tools you expected, read the two lines above it before
+debugging anything else.
 
 ⚠️ **`mcp doctor` reports green even when the install is half-broken.** It probes the
 handshake, and the handshake succeeds without Python. Confirmed on OpenClaw 2026.9.1,
@@ -283,7 +291,7 @@ If you edit the file by hand instead, add `simmer` under `mcp.servers`:
         "command": "npx",
         "args": ["-y", "simmer-mcp"],
         "env": {
-          "SIMMER_API_KEY": "sk_live_..."
+          "SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"
         }
       }
     }
@@ -320,7 +328,7 @@ mcp_servers:
 
 **Use the CLI rather than editing by hand where you can.** Hermes ships
 `hermes mcp add`, `hermes mcp list` and `hermes mcp test` — `hermes mcp test simmer`
-connects and counts the tools, which is a faster verification than Step 6's handshake
+connects and counts the tools, which is a faster verification than Step 6's handshake.
 `hermes mcp list` confirms which config Hermes actually read.
 
 Stderr from the server goes to `<HERMES_HOME>/logs/mcp-stderr.log`. Read it first when
@@ -392,10 +400,8 @@ Don't trust "looks installed" — verify with a real tool call.
 Ask your agent:
 > What simmer tools can you see? List them.
 
-The agent should respond with the 3 utility tools, raw market/trade tools, and the core bundled skill tools:
-- `list_skills`
-- `get_skill_docs`
-- `troubleshoot_error`
+The agent should respond with the keyless utility tools, raw market/trade tools, and the core bundled skill tools:
+- Keyless utilities, available with or without a key — `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, `simmer_register_agent`
 - Core bundled skill tools (`simmer_simmer`, `simmer_simmer_wallet_setup`, `simmer_simmer_mcp_setup`, `simmer_simmer_briefing`, `simmer_preflight`)
 - Raw market/trade tools (`simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, and portfolio/position tools)
 

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -37,7 +37,7 @@ So: MCP and SDK are different shapes, both legitimate. MCP runs pre-built strate
 - Your agent runtime's MCP config updated with a `simmer` entry
 - `SIMMER_API_KEY` plumbed into the MCP subprocess
 - Simmer tools visible to your agent:
-  - **3 free utility tools** (always available): `list_skills`, `get_skill_docs`, `troubleshoot_error`
+  - **Keyless utility tools** (always available, no key needed): `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, and on newer builds `simmer_register_agent`. The startup banner prints the exact keyless count for your build.
   - **Core Simmer skill tools** — the npm package bundles only foundational, pinned skills (`simmer`, `simmer-wallet-setup`, `simmer-mcp-setup`, `simmer-briefing`, and `preflight`). Situational strategies such as combo, shock-ladder, copytrading, weather, and DCA install on demand from ClawHub so they stay current.
   - **Raw market/trade tools** — `simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, portfolio/position tools, and guarded order cancellation.
   - **4 Pro-gated autoresearch tools** (`init_experiment`, `run_experiment`, `log_experiment`, `backtest_experiment`) — only registered if you're on the Pro plan.
@@ -234,23 +234,39 @@ hand.
 
 ```bash
 export SIMMER_API_KEY=sk_live_...   # the gateway must see this too — see below
-openclaw mcp add simmer --command npx --args '-y,simmer-mcp' \
-  --env 'SIMMER_API_KEY=ref(env:SIMMER_API_KEY)'
+openclaw mcp add simmer --command npx --arg -y --arg simmer-mcp \
+  --env 'SIMMER_API_KEY=${SIMMER_API_KEY}'
 openclaw mcp doctor simmer --probe
 ```
 
-Flag names vary by OpenClaw version — run `openclaw mcp add --help` first and match the
-shape above to what it accepts.
+`--arg` is repeatable (one per argv element) and `--env` takes `KEY=VALUE` — both per
+OpenClaw's own `mcp` CLI docs. Quote the `${…}` so your shell does not expand it before
+OpenClaw sees it.
+
+⚠️ Known upstream issue at the time of writing: entries added via `openclaw mcp add` can
+pass `doctor` yet never reach a `claude-cli`-backed agent session
+(`openclaw/openclaw#122712`). If the tools show in `doctor` but not in the agent, that is
+the first thing to check, and the hand-edit path below is the workaround.
 
 ⚠️ **Do not paste the key in literally if you can avoid it.** OpenClaw supports env
-references — `"SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"` — and its own doctor warns when
+references — `"SIMMER_API_KEY": "${SIMMER_API_KEY}"` (also `"$SIMMER_API_KEY"`, or the
+object form `{ source: "env", id: "SIMMER_API_KEY" }`) — and its own doctor warns when
 it finds a literal key in the config. `~/.openclaw/openclaw.json` is a file other processes
 on that machine can read; a reference keeps the secret in the environment.
 
-But **the OpenClaw gateway process itself must carry that variable**, not just your
-interactive shell. If it does not, the reference resolves to an empty string and the
-server starts in keyless mode with no error at all — see the tool-count note above. Export
-it wherever the gateway is launched from, or keep it in a file the gateway sources.
+**The OpenClaw gateway process itself must carry that variable**, not just your
+interactive shell. Per OpenClaw's secrets docs, a missing or empty env value **fails
+resolution** — the reference does not silently become an empty string, and it does not
+fall through to any other credential. So the symptom of a variable the gateway cannot see
+is a resolution error from OpenClaw, not a quietly keyless server. Export it wherever the
+gateway is launched from, or keep it in a file the gateway sources.
+
+Do not write `ref(env:NAME)` as the value. That is only how OpenClaw *labels* a resolved
+reference in its own output; as an input it is treated as a literal string, which is
+truthy — so the server registers every tool against a garbage key and prints only the
+`sk_live_` warning. That looks like a healthy install with a bad key, which sends you
+debugging the wrong thing. Doctor's literal-secret check is simply "value does not start
+with `$`", so the `${…}` form is the one it accepts.
 
 ⚠️ **Don't check the tool count against a number in this document — check it against the
 server's own banner.** The server prints `[simmer-mcp] v<x> | tools: N (…, K keyless)` on
@@ -291,7 +307,7 @@ If you edit the file by hand instead, add `simmer` under `mcp.servers`:
         "command": "npx",
         "args": ["-y", "simmer-mcp"],
         "env": {
-          "SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"
+          "SIMMER_API_KEY": "${SIMMER_API_KEY}"
         }
       }
     }
@@ -401,7 +417,7 @@ Ask your agent:
 > What simmer tools can you see? List them.
 
 The agent should respond with the keyless utility tools, raw market/trade tools, and the core bundled skill tools:
-- Keyless utilities, available with or without a key — `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, `simmer_register_agent`
+- Keyless utilities, available with or without a key — `list_skills`, `get_skill_docs`, `troubleshoot_error`, `simmer_browse_markets`, `simmer_get_leaderboard`, and on newer builds `simmer_register_agent`. The exact set depends on the build you installed; the startup banner's keyless count is authoritative, not this list.
 - Core bundled skill tools (`simmer_simmer`, `simmer_simmer_wallet_setup`, `simmer_simmer_mcp_setup`, `simmer_simmer_briefing`, `simmer_preflight`)
 - Raw market/trade tools (`simmer_get_markets`, `simmer_get_market_context`, `simmer_get_briefing`, `simmer_trade`, and portfolio/position tools)
 

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -229,13 +229,41 @@ Project-scoped: use `.cursor/mcp.json` in the project root.
 ### OpenClaw
 
 **Prefer the CLI.** OpenClaw ships `openclaw mcp add`, and `openclaw mcp doctor simmer --probe`
-verifies the handshake and counts tools (expect ~23) — faster and less error-prone than
-editing JSON by hand.
+verifies the handshake and counts tools — faster and less error-prone than editing JSON by
+hand.
+
+```bash
+export SIMMER_API_KEY=sk_live_...   # the gateway must see this too — see below
+openclaw mcp add simmer --command npx --args '-y,simmer-mcp' \
+  --env 'SIMMER_API_KEY=ref(env:SIMMER_API_KEY)'
+openclaw mcp doctor simmer --probe
+```
+
+Flag names vary by OpenClaw version — run `openclaw mcp add --help` first and match the
+shape above to what it accepts.
 
 ⚠️ **Do not paste the key in literally if you can avoid it.** OpenClaw supports env
 references — `"SIMMER_API_KEY": "ref(env:SIMMER_API_KEY)"` — and its own doctor warns when
 it finds a literal key in the config. `~/.openclaw/openclaw.json` is a file other processes
 on that machine can read; a reference keeps the secret in the environment.
+
+But **the OpenClaw gateway process itself must carry that variable**, not just your
+interactive shell. If it does not, the reference resolves to an empty string and the
+server starts in keyless mode with no error at all — see the tool-count note above. Export
+it wherever the gateway is launched from, or keep it in a file the gateway sources.
+
+⚠️ **Don't check the tool count against a number in this document — check it against the
+server's own banner.** The server prints `[simmer-mcp] v<x> | tools: N (…, K keyless)` on
+startup; that N is the truth for the build you are running, and it changes between
+releases. Measured 2026-09-04: published `simmer-mcp@3.5.0` from npm reports **23 tools,
+9 keyless**.
+
+⚠️ **A low count usually means the key did not resolve, not that tools are missing.**
+Without a usable `SIMMER_API_KEY` the server starts cleanly in **keyless mode** with only
+the keyless subset — no error, no warning, because the malformed-key guard only fires on a
+non-empty bad key. An empty one is silent. So if the banner shows roughly a third of the
+tools you expected, check the key reached the server process before debugging anything
+else.
 
 ⚠️ **`mcp doctor` reports green even when the install is half-broken.** It probes the
 handshake, and the handshake succeeds without Python. Confirmed on OpenClaw 2026.9.1,
@@ -293,7 +321,7 @@ mcp_servers:
 **Use the CLI rather than editing by hand where you can.** Hermes ships
 `hermes mcp add`, `hermes mcp list` and `hermes mcp test` — `hermes mcp test simmer`
 connects and counts the tools, which is a faster verification than Step 6's handshake
-(expect ~23 tools). `hermes mcp list` confirms which config Hermes actually read.
+`hermes mcp list` confirms which config Hermes actually read.
 
 Stderr from the server goes to `<HERMES_HOME>/logs/mcp-stderr.log`. Read it first when
 something is wrong.


### PR DESCRIPTION
## Context

Third cold dogfood pass — OpenClaw 2026.9.1, installed fresh on the Grok Bot box. Install, ClawHub, and the MCP handshake all passed. Everything below is what it found broken on our side.

## The worst variant of a known bug

`openclaw mcp doctor simmer --probe` reports **green, 23 tools**, while the server's stderr says `simmer-sdk not installed`. The handshake succeeds without Python, so a purpose-built diagnostic certifies a half-broken install. That's the third independent reproduction (Hermes, Grok Bot, now OpenClaw) and the first where a health check actively says "fine".

## Fixing the source of two numbers I got wrong

The startup warning is where I picked up both errors the review caught on #325:

| Was | Is |
|---|---|
| `per-skill execution will fail` | only `preflight` runs Python; the other four bundled skills return SKILL.md text |
| `pip install simmer-sdk>=0.13.0` | `preflight` requires `>=0.17.13` |

Corrected in `mcp/src/mcp-server.ts` and `mcp/src/runtime-probe.ts`. The new text also names `SIMMER_MCP_PYTHON`, without which installing the SDK still doesn't help.

## OpenClaw section

It prescribed a hand JSON edit while `openclaw mcp add` and `openclaw mcp doctor --probe` exist — the same gap Hermes had. Step 4 already states the rule (*"use the native CLI if the runtime has one"*); it was stated and unapplied on two of two runtimes tested, so Cursor and Codex are worth checking too (SIM-5018).

Also added: `ref(env:SIMMER_API_KEY)` instead of a literal key in a world-readable config — OpenClaw's own doctor warns about this and we were telling people to paste it in; the `--non-interactive` onboarding flag, since headless seats fail with `Onboarding needs an interactive TTY`; and the log path `/tmp/openclaw/openclaw-YYYY-MM-DD.log` for the per-host stderr table.

## `SIMMER_MCP_PYTHON` is now verified, not reasoned

#325 shipped this guidance derived from source and never executed — the same way the *first*, wrong version of that fix was produced. Run both directions:

- venv **without** the SDK → `runtime: python3: v3.11.8 (/…/nosdk/bin/python) | simmer-sdk: not installed`
- venv **with** it → `… (/…/withsdk/bin/python) | simmer-sdk: v0.24.6`

The variable is honoured and the startup line names the interpreter, so it is self-diagnosing. Unset, it resolves from `PATH` — so it can appear to work by accident under one launcher and break under another with the same config. That's now in the skill.

## Verification

- `check:bundle-skills` → `bundle fresh`
- Pre-existing `TS2589` errors at `mcp-server.ts` 235/264 are **not** from this diff — identical on the baseline with these changes stashed, and `mcp-build` passed on #325 with them present.

`simmer-mcp-setup` 0.2.0 → 0.3.0. ClawHub republish held for approval; merging does not publish.