### PR TITLE
mcp: 3.5.1 — publish the build that npm 3.5.0 has been missing since 2026-08-23

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simmer-mcp",
-  "version": "3.4.5",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simmer-mcp",
-      "version": "3.4.5",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## What

Version bump only: `mcp/package.json` + lockfile, `3.5.0` → `3.5.1`. No code change.

## Why

Two different artifacts have shared one version string for twelve days:

| | tools | keyless |
|---|---|---|
| npm `simmer-mcp@3.5.0` (`bunx simmer-mcp`, measured 2026-09-04) | **23** | 9 |
| repo HEAD at `3.5.0` | **24** | 10 |

`eef609f` (2026-08-23) added `simmer_register_agent` without a bump. `Publish Lag Check` compares version strings, so it has been green throughout. Three dogfood runs and one code review measured different numbers and were both right. SIM-5024 step 1.

## What merging does

`publish-packages.yml` triggers on push to `main` touching `mcp/**`, compares repo vs registry, and publishes via OIDC when the repo is ahead. After merge: npm and repo agree at `3.5.1`, and `bunx simmer-mcp` reports 24 tools.

## ⚠️ `Publish Lag Check` will be RED on this PR — by design

The check runs on `pull_request` with no exemption and fails whenever the repo is ahead of npm. That is exactly the state a bump PR is in until it merges and publishes. It is **not** in the required-checks set. Do not "fix" the red by reverting the bump.

## Verification

- 156 tests pass / 0 fail at 3.5.1
- Local banner: `[simmer-mcp] v3.5.1 | tools: 24 (…, 10 keyless) | skills: 5 bundled`
- Post-merge I will confirm `registry.npmjs.org/simmer-mcp/latest` → `3.5.1` and the published banner reads 24.

The CI guard for this class of drift (step 2 of SIM-5024) stays open for the fleet.