### PR TITLE
fix(sdk): dry_run=True on venue=kalshi no longer places a real order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.2 (2026-09-07)
+
+- **`trade(dry_run=True, venue="kalshi")` no longer places a real order.** The Kalshi BYOW path never had a `dry_run` parameter, so a call documented as a no-op fetched a quote, signed a Solana transaction with `SOLANA_PRIVATE_KEY`, and submitted it for real — money moved on a call that promised none would. There is no Kalshi preview pricing yet, so `dry_run=True` on `venue="kalshi"` now returns `success=False` with an error naming the gap, before any quote, signing, or submit call. `dry_run` on `sim` and `polymarket` is unaffected. See SIM-5041.
+
 ## 0.25.1 (2026-09-06)
 
 - **Paper `trade(dry_run=True)` no longer books paper inventory.** On a `live=False` client the dry run applied the fill to the in-memory portfolio before checking the flag, so a preview followed by the real paper trade on the same market double-booked shares and cost_basis, and paper expectancy drifted from what the strategy actually did. The dry run still settles any resolved paper positions first (as `get_positions()` does) and returns the same `TradeResult`; it just leaves the book alone. Live-venue dry_run already worked this way.

--- a/mcp/bundled-skills/simmer/SKILL.md
+++ b/mcp/bundled-skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.25.1"
+  version: "1.25.2"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"
@@ -128,6 +128,13 @@ that behaves like the real venue; `dry_run` is a sizing tool.
 ⚠️ **The defaults differ by method, so read them rather than assuming.**
 `trade()` is `dry_run=False` — it places for real unless you ask otherwise.
 `place_combo()` is `dry_run=True` — it previews unless you pass `dry_run=False`.
+
+⚠️ **`dry_run` is not honored on `venue="kalshi"`.** Kalshi BYOW has no preview
+pricing path yet, so `client.trade(..., venue="kalshi", dry_run=True)` places
+nothing and returns `success=False` with an error explaining the gap — it does
+not return a preview like Polymarket or sim. If you're building a Kalshi
+agent, don't rely on a preview-then-place pattern; go straight to
+`dry_run=False`.
 
 ## Where to learn more
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.25.1"
+version = "0.25.2"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -5485,16 +5485,23 @@ class SimmerClient:
         # There is no real Kalshi preview path (option c, out of scope) so we
         # fail closed rather than fabricate a preview price.
         if dry_run:
+            error = (
+                "dry_run is not supported for venue='kalshi' — no order was "
+                "placed. Kalshi BYOW has no preview pricing yet; call with "
+                "dry_run=False to place a real order."
+            )
+            # This return bypasses trade()'s shared failure warning, so emit the
+            # same signal here. A bot that logs rather than checking
+            # result.success would otherwise preview in a loop in total silence
+            # — the same invisibility that let the original bug place real
+            # orders unnoticed (codex P2 on this PR).
+            logger.warning("Trade failed on %s: %s", "kalshi", error)
             return TradeResult(
                 success=False,
                 market_id=market_id,
                 side=side,
                 venue="kalshi",
-                error=(
-                    "dry_run is not supported for venue='kalshi' — no order was "
-                    "placed. Kalshi BYOW has no preview pricing yet; call with "
-                    "dry_run=False to place a real order."
-                ),
+                error=error,
                 error_code="dry_run_unsupported",
                 retryable=False
             )

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2699,7 +2699,8 @@ class SimmerClient:
                 shares=shares,
                 action=action,
                 reasoning=reasoning,
-                source=source
+                source=source,
+                dry_run=dry_run
             )
 
         data = self._request(
@@ -5451,7 +5452,8 @@ class SimmerClient:
         shares: float = 0,
         action: str = "buy",
         reasoning: Optional[str] = None,
-        source: Optional[str] = None
+        source: Optional[str] = None,
+        dry_run: bool = False
     ) -> TradeResult:
         """
         Execute a Kalshi trade using BYOW (Bring Your Own Wallet).
@@ -5472,10 +5474,30 @@ class SimmerClient:
             action: 'buy' or 'sell'
             reasoning: Optional trade explanation
             source: Optional source tag
+            dry_run: Kalshi BYOW has no preview path yet (SIM-5041). True
+                refuses before any quote/signing/submit call — it does not
+                simulate a fill.
 
         Returns:
             TradeResult with execution details
         """
+        # SIM-5041: dry_run=True must not reach the quote/sign/submit calls.
+        # There is no real Kalshi preview path (option c, out of scope) so we
+        # fail closed rather than fabricate a preview price.
+        if dry_run:
+            return TradeResult(
+                success=False,
+                market_id=market_id,
+                side=side,
+                venue="kalshi",
+                error=(
+                    "dry_run is not supported for venue='kalshi' — no order was "
+                    "placed. Kalshi BYOW has no preview pricing yet; call with "
+                    "dry_run=False to place a real order."
+                ),
+                error_code="dry_run_unsupported"
+            )
+
         # Check for Solana key
         if not self._solana_key_available:
             return TradeResult(

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -5495,7 +5495,8 @@ class SimmerClient:
                     "placed. Kalshi BYOW has no preview pricing yet; call with "
                     "dry_run=False to place a real order."
                 ),
-                error_code="dry_run_unsupported"
+                error_code="dry_run_unsupported",
+                retryable=False
             )
 
         # Check for Solana key

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -3,7 +3,7 @@ name: simmer
 description: The prediction market interface for AI agents. Trade Polymarket and Kalshi through one API with self-custody wallets, safety rails, and smart context.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "1.25.1"
+  version: "1.25.2"
   displayName: Simmer
   difficulty: beginner
   homepage: "https://simmer.markets"

--- a/skills/simmer/SKILL.md
+++ b/skills/simmer/SKILL.md
@@ -129,6 +129,13 @@ that behaves like the real venue; `dry_run` is a sizing tool.
 `trade()` is `dry_run=False` — it places for real unless you ask otherwise.
 `place_combo()` is `dry_run=True` — it previews unless you pass `dry_run=False`.
 
+⚠️ **`dry_run` is not honored on `venue="kalshi"`.** Kalshi BYOW has no preview
+pricing path yet, so `client.trade(..., venue="kalshi", dry_run=True)` places
+nothing and returns `success=False` with an error explaining the gap — it does
+not return a preview like Polymarket or sim. If you're building a Kalshi
+agent, don't rely on a preview-then-place pattern; go straight to
+`dry_run=False`.
+
 ## Where to learn more
 
 Documentation references — open when the situation matches.

--- a/tests/test_sim_5041_kalshi_dry_run_guard.py
+++ b/tests/test_sim_5041_kalshi_dry_run_guard.py
@@ -165,3 +165,18 @@ def test_sim_dry_run_unchanged():
         )
     mock_request.assert_called_once()
     assert result.success is True
+
+
+def test_kalshi_dry_run_result_is_not_retryable():
+    """A dry_run refusal can never succeed on retry. Six bundled skills branch on
+    TradeResult.retryable to stop a retry loop and the dataclass default is True,
+    so a client-side refusal that leaves it True tells them to try again."""
+    client = _make_client()
+    with patch.object(client, "_request", side_effect=AssertionError("transport called")):
+        result = client.trade(
+            "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+            allow_rebuy=True, dry_run=True,
+        )
+    assert result.success is False
+    assert result.error_code == "dry_run_unsupported"
+    assert result.retryable is False

--- a/tests/test_sim_5041_kalshi_dry_run_guard.py
+++ b/tests/test_sim_5041_kalshi_dry_run_guard.py
@@ -1,0 +1,167 @@
+"""SIM-5041 regression: dry_run=True on venue="kalshi" must not place a real order.
+
+Before this fix, client.trade(venue="kalshi", dry_run=True) ignored dry_run
+entirely — _execute_kalshi_byow_trade had no dry_run parameter, so the call
+fetched a quote, signed a Solana transaction with SOLANA_PRIVATE_KEY, and
+submitted it to /api/sdk/trade/kalshi/submit. A call documented as placing
+nothing placed a real order with real money.
+
+Fix: dry_run is threaded into _execute_kalshi_byow_trade and short-circuits
+before any quote/sign/submit call, returning a failure TradeResult that
+names the limitation (Kalshi BYOW has no preview path — option (a)/(c) are
+out of scope here).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from simmer_sdk.client import SimmerClient, TradeResult
+
+
+def _make_client(*, solana_key_available: bool = True) -> SimmerClient:
+    """Live-mode client with network calls and Solana signing stubbed out."""
+    client = SimmerClient.__new__(SimmerClient)
+    client.live = True
+    client.venue = "kalshi"
+    client._readonly = False
+    client._private_key = None
+    client._ows_wallet = None
+    client._solana_wallet_address = None
+    client._solana_wallet_registered = True
+    client._solana_key_available = solana_key_available
+    client._held_markets_cache = {}
+    client._held_markets_ts = 0
+    client._approvals_warned = False
+    client.ORDER_TYPES = {"FAK", "FOK", "GTC", "GTD"}
+    client.VENUES = {"sim", "polymarket", "kalshi", "simmer"}
+    return client
+
+
+def test_kalshi_dry_run_never_calls_transport():
+    """dry_run=True must not reach the quote or submit endpoints."""
+    client = _make_client()
+    with patch.object(client, "_request", side_effect=AssertionError("transport called")) as mock_request:
+        result = client.trade(
+            "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+            allow_rebuy=True, dry_run=True,
+        )
+    mock_request.assert_not_called()
+    assert isinstance(result, TradeResult)
+    assert result.success is False
+    assert "dry_run" in result.error.lower()
+    assert "kalshi" in result.error.lower()
+
+
+def test_kalshi_dry_run_never_calls_solana_signer():
+    """dry_run=True must not invoke the Solana signing entry point."""
+    client = _make_client()
+    with patch("simmer_sdk.solana_signing.sign_solana_transaction") as mock_sign:
+        with patch.object(client, "_request", side_effect=AssertionError("transport called")):
+            client.trade(
+                "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+                allow_rebuy=True, dry_run=True,
+            )
+    mock_sign.assert_not_called()
+
+
+def test_kalshi_dry_run_leaves_held_markets_cache_untouched():
+    """dry_run=True must not mutate the held-markets cache."""
+    client = _make_client()
+    seed = {"MKT-EXISTING": ["sdk:some-strategy"]}
+    client._held_markets_cache = dict(seed)
+    with patch.object(client, "_request", side_effect=AssertionError("transport called")):
+        client.trade(
+            "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+            allow_rebuy=True, dry_run=True,
+        )
+    assert client._held_markets_cache == seed
+
+
+def test_kalshi_dry_run_returns_explicit_failure_result():
+    """The returned TradeResult names both 'no order placed' and 'dry-run unsupported'."""
+    client = _make_client()
+    with patch.object(client, "_request", side_effect=AssertionError("transport called")):
+        result = client.trade(
+            "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+            allow_rebuy=True, dry_run=True,
+        )
+    assert result.success is False
+    assert result.venue == "kalshi"
+    assert "no order" in result.error.lower() or "not placed" in result.error.lower()
+    assert "dry" in result.error.lower()
+
+
+def test_kalshi_dry_run_false_still_places_real_order():
+    """Regression guard: the short-circuit must not swallow real (dry_run=False) trades."""
+    client = _make_client()
+
+    def _request_side_effect(method, path, json=None, **kwargs):
+        if path == "/api/sdk/trade/kalshi/quote":
+            return {"success": True, "transaction": "unsigned-tx-b64", "quote_id": "q-1"}
+        if path == "/api/sdk/trade/kalshi/submit":
+            return {
+                "success": True,
+                "trade_id": "t-1",
+                "market_id": "MKT-1",
+                "side": "yes",
+                "shares_bought": 20.0,
+                "shares_requested": 20.0,
+                "cost": 10.0,
+                "new_price": 0.5,
+            }
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    with patch("simmer_sdk.solana_signing.sign_solana_transaction", return_value="signed-tx-b64") as mock_sign:
+        with patch.object(client, "_request", side_effect=_request_side_effect) as mock_request:
+            result = client.trade(
+                "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+                allow_rebuy=True, dry_run=False,
+            )
+
+    mock_sign.assert_called_once_with("unsigned-tx-b64")
+    called_paths = [c.args[1] for c in mock_request.call_args_list]
+    assert "/api/sdk/trade/kalshi/quote" in called_paths
+    assert "/api/sdk/trade/kalshi/submit" in called_paths
+    assert result.success is True
+    assert result.trade_id == "t-1"
+
+
+def test_polymarket_dry_run_unchanged():
+    """venue='polymarket' dry-run still goes through the generic /api/sdk/trade path."""
+    client = _make_client()
+    client.venue = "polymarket"
+
+    def _request_side_effect(method, path, json=None, **kwargs):
+        assert path == "/api/sdk/trade"
+        assert json.get("dry_run") is True
+        return {"success": True, "market_id": "MKT-1", "side": "yes", "shares_bought": 20.0}
+
+    with patch.object(client, "_request", side_effect=_request_side_effect) as mock_request:
+        result = client.trade(
+            "MKT-1", "yes", 10.0, action="buy", venue="polymarket",
+            allow_rebuy=True, dry_run=True,
+        )
+    mock_request.assert_called_once()
+    assert result.success is True
+
+
+def test_sim_dry_run_unchanged():
+    """venue='sim' dry-run still goes through the generic /api/sdk/trade path."""
+    client = _make_client()
+    client.venue = "sim"
+
+    def _request_side_effect(method, path, json=None, **kwargs):
+        assert path == "/api/sdk/trade"
+        assert json.get("dry_run") is True
+        return {"success": True, "market_id": "MKT-1", "side": "yes", "shares_bought": 20.0}
+
+    with patch.object(client, "_request", side_effect=_request_side_effect) as mock_request:
+        result = client.trade(
+            "MKT-1", "yes", 10.0, action="buy", venue="sim",
+            allow_rebuy=True, dry_run=True,
+        )
+    mock_request.assert_called_once()
+    assert result.success is True

--- a/tests/test_sim_5041_kalshi_dry_run_guard.py
+++ b/tests/test_sim_5041_kalshi_dry_run_guard.py
@@ -180,3 +180,20 @@ def test_kalshi_dry_run_result_is_not_retryable():
     assert result.success is False
     assert result.error_code == "dry_run_unsupported"
     assert result.retryable is False
+
+
+def test_kalshi_dry_run_refusal_emits_the_shared_failure_warning():
+    """The short-circuit returns before trade()'s shared failure warning, so it
+    must emit the same signal itself. A bot that logs instead of checking
+    result.success would otherwise preview in a loop in total silence."""
+    client = _make_client()
+    with patch.object(client, "_request", side_effect=AssertionError("transport called")):
+        with patch("simmer_sdk.client.logger.warning") as warn:
+            client.trade(
+                "MKT-1", "yes", 10.0, action="buy", venue="kalshi",
+                allow_rebuy=True, dry_run=True,
+            )
+    assert warn.call_count == 1
+    logged = warn.call_args[0]
+    assert "kalshi" in logged
+    assert "dry_run is not supported" in logged[-1]


### PR DESCRIPTION
MONEY PATH. `trade(dry_run=True, venue="kalshi")` fetched a Kalshi quote, signed a Solana transaction with `SOLANA_PRIVATE_KEY`, and submitted a real order — `_execute_kalshi_byow_trade` had no `dry_run` parameter at all, so the flag was silently dropped on the BYOW path. `skills/simmer/SKILL.md` documents preview-then-place unconditionally, so a Kalshi agent following the quickstart placed two real orders.

Implements the shape from Adrian's written rule on the ticket (option b): thread `dry_run` through and short-circuit before any quote/sign/submit call. There is no real Kalshi preview pricing yet (option c, out of scope), so a dry run now returns an explicit failure `TradeResult` naming the gap rather than fabricating a preview price.

## Changes
- `simmer_sdk/client.py`: `_execute_kalshi_byow_trade` gains `dry_run: bool = False`; the `:2681`-ish dispatch in `trade()` now passes it through; the method short-circuits at the top, before any network call, signing, or held-markets cache mutation.
- `skills/simmer/SKILL.md`: documents that `dry_run` is not honored on `venue="kalshi"` — no preview, just a refusal.
- `CHANGELOG.md` / `pyproject.toml`: 0.24.8 entry.
- `tests/test_sim_5041_kalshi_dry_run_guard.py`: new module, 7 tests.

## Tests
```
python3 -m pytest tests/test_sim_5041_kalshi_dry_run_guard.py -v
7 passed
```
All assertions drive `client.trade(...)`, not source text:
- transport (`_request`) never called on `dry_run=True`
- Solana signer never called on `dry_run=True`
- `_held_markets_cache` byte-for-byte unchanged on `dry_run=True`
- returned `TradeResult` is `success=False` with an error naming both "no order placed" and "dry-run unsupported"
- `dry_run=False` regression guard: quote → sign → submit all still fire, `TradeResult.success` reflects the mocked response
- `venue="polymarket"` and `venue="sim"` dry-run behavior unchanged (one test each)

**Mutation check:** reverted the `client.py` fix (kept the tests), reran — 2 of 7 tests went RED (`test_kalshi_dry_run_never_calls_transport`, `test_kalshi_dry_run_returns_explicit_failure_result`), confirming they can actually fail. Restored the fix — all 7 GREEN again.

Full suite: `python3 -m pytest tests/ -q` — 48 failures in `test_poly_1271_signing.py` / `test_polymarket_v2.py`, all `ModuleNotFoundError: py_clob_client`. Verified this is a pre-existing environment gap by stashing my changes and rerunning against untouched `origin/main` — same 45+ failures, same root cause. Not touched by this PR.

## Risk
Low blast radius, high stakes-if-wrong: this only touches the `venue="kalshi"` + `dry_run=True` branch, which previously placed real orders — after this change it can only refuse more (fail-closed), never place. `dry_run=False` (the only path anyone relying on the old bug would have used to actually trade) is unchanged and covered by the regression test.

Closes SIM-5041