### PR TITLE
fix(skills): handle a null balance_usdc instead of crashing on it

### DIFF
--- a/skills/kalshi-weather-trader/SKILL.md
+++ b/skills/kalshi-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: kalshi-weather-trader
 description: Trade Kalshi weather markets using NOAA forecasts via Simmer SDK and DFlow on Solana. Port of the popular polymarket-weather-trader. Use when user wants to trade temperature markets on Kalshi, automate weather bets, or check NOAA forecasts.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.10"
+  version: "1.0.11"
   displayName: Kalshi Weather Trader
   difficulty: intermediate
   attribution: Strategy inspired by gopfan2, powered by DFlow

--- a/skills/kalshi-weather-trader/scripts/status.py
+++ b/skills/kalshi-weather-trader/scripts/status.py
@@ -40,11 +40,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
         sys.exit(1)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/kalshi-weather-trader/scripts/status.py
+++ b/skills/kalshi-weather-trader/scripts/status.py
@@ -39,8 +39,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
         print(f"❌ Connection error: {e.reason}")
         sys.exit(1)
 
-def format_usd(amount: float) -> str:
-    """Format as USD."""
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -58,7 +62,7 @@ def main():
     print("📊 Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/kalshi-weather-trader/weather_trader.py
+++ b/skills/kalshi-weather-trader/weather_trader.py
@@ -651,7 +651,7 @@ def calculate_position_size(default_size: float, smart_sizing: bool) -> float:
         print(f"  ⚠️  Smart sizing failed, using default ${default_size:.2f}")
         return default_size
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc") or 0
     if balance <= 0:
         print(f"  ⚠️  No available balance, using default ${default_size:.2f}")
         return default_size
@@ -822,7 +822,7 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         log("\n💰 Portfolio:")
         portfolio = get_portfolio()
         if portfolio:
-            log(f"  Balance: ${portfolio.get('balance_usdc', 0):.2f}")
+            log(f"  Balance: ${portfolio.get('balance_usdc') or 0:.2f}")
             log(f"  Exposure: ${portfolio.get('total_exposure', 0):.2f}")
             log(f"  Positions: {portfolio.get('positions_count', 0)}")
             by_source = portfolio.get('by_source', {})

--- a/skills/polymarket-copytrading/SKILL.md
+++ b/skills/polymarket-copytrading/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-copytrading
 description: Mirror positions from top Polymarket traders. Polling mode (free) for portfolio-style copying, Reactor mode (Pro) for event-driven real-time mirroring via Simmer's on-chain signal infrastructure.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.12.2"
+  version: "1.12.3"
   displayName: Polymarket Copytrading
   difficulty: beginner
 ---

--- a/skills/polymarket-copytrading/scripts/status.py
+++ b/skills/polymarket-copytrading/scripts/status.py
@@ -34,8 +34,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
     """Make authenticated request to Simmer API via SimmerClient."""
     return get_client(api_key)._request("GET", endpoint)
 
-def format_usd(amount: float) -> str:
-    """Format as USD."""
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -53,7 +57,7 @@ def main():
     print("📊 Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/polymarket-copytrading/scripts/status.py
+++ b/skills/polymarket-copytrading/scripts/status.py
@@ -35,11 +35,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
     return get_client(api_key)._request("GET", endpoint)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/polymarket-elon-tweets/SKILL.md
+++ b/skills/polymarket-elon-tweets/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-elon-tweets
 description: 'Trade Polymarket "Elon Musk # tweets" markets using XTracker post count data. Buys adjacent range buckets when combined cost < $1 for structural edge. Use when user wants to trade tweet count markets, automate Elon tweet bets, check XTracker stats, or run noovd-style trading.'
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.5"
+  version: "1.3.6"
   displayName: Polymarket Elon Tweet Trader
   difficulty: advanced
   attribution: Strategy inspired by @noovd

--- a/skills/polymarket-elon-tweets/elon_tweets.py
+++ b/skills/polymarket-elon-tweets/elon_tweets.py
@@ -328,7 +328,7 @@ def execute_trade(market_id, side, amount, reasoning=None, signal_data=None):
     # Pre-check: verify sufficient balance before hitting the API
     portfolio = get_portfolio()
     if portfolio:
-        balance = portfolio.get("balance_usdc", 0)
+        balance = portfolio.get("balance_usdc") or 0
         if balance < amount:
             return {"error": f"Insufficient balance: ${balance:.2f} available, ${amount:.2f} required. "
                              f"Deposit USDC.e to your Polymarket wallet and retry."}
@@ -458,7 +458,7 @@ def calculate_position_size(default_size, smart_sizing):
     portfolio = get_portfolio()
     if not portfolio:
         return default_size
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc") or 0
     if balance <= 0:
         return default_size
     smart_size = min(balance * SMART_SIZING_PCT, MAX_POSITION_USD)
@@ -813,7 +813,7 @@ def run_strategy(dry_run=True, positions_only=False, show_config=False,
     if smart_sizing:
         portfolio = get_portfolio()
         if portfolio:
-            log(f"\n💰 Balance: ${portfolio.get('balance_usdc', 0):.2f}")
+            log(f"\n💰 Balance: ${portfolio.get('balance_usdc') or 0:.2f}")
 
     for event_id, event_data in events.items():
         event_name = event_data["name"]

--- a/skills/polymarket-elon-tweets/scripts/status.py
+++ b/skills/polymarket-elon-tweets/scripts/status.py
@@ -40,11 +40,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
         sys.exit(1)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/polymarket-elon-tweets/scripts/status.py
+++ b/skills/polymarket-elon-tweets/scripts/status.py
@@ -39,8 +39,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
         print(f"❌ Connection error: {e.reason}")
         sys.exit(1)
 
-def format_usd(amount: float) -> str:
-    """Format as USD."""
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -58,7 +62,7 @@ def main():
     print("📊 Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/polymarket-fast-loop/SKILL.md
+++ b/skills/polymarket-fast-loop/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-fast-loop
 description: Trade Polymarket BTC 5-minute and 15-minute fast markets using CEX price momentum signals via Simmer API. Default signal is Binance BTC/USDT klines. Use when user wants to trade sprint/fast markets, automate short-term crypto trading, or use CEX momentum as a Polymarket signal.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.7.3"
+  version: "1.7.4"
   displayName: Polymarket FastLoop Trader
   difficulty: advanced
 ---

--- a/skills/polymarket-fast-loop/fastloop_trader.py
+++ b/skills/polymarket-fast-loop/fastloop_trader.py
@@ -875,7 +875,7 @@ def calculate_position_size(max_size, smart_sizing=False):
     portfolio = get_portfolio()
     if not portfolio or portfolio.get("error"):
         return max_size
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc") or 0
     if balance <= 0:
         return max_size
     smart_size = balance * SMART_SIZING_PCT
@@ -1012,7 +1012,7 @@ def run_fast_market_strategy(dry_run=True, positions_only=False, show_config=Fal
         log("\n💰 Portfolio:")
         portfolio = get_portfolio()
         if portfolio and not portfolio.get("error"):
-            log(f"  Balance: ${portfolio.get('balance_usdc', 0):.2f}")
+            log(f"  Balance: ${portfolio.get('balance_usdc') or 0:.2f}")
 
     # Step 1: Discover fast markets
     log(f"\n🔍 Discovering {ASSET} fast markets...")

--- a/skills/polymarket-mert-sniper/SKILL.md
+++ b/skills/polymarket-mert-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-mert-sniper
 description: Near-expiry conviction trading on Polymarket. The skill scans markets in their final minutes, filters for strongly-skewed splits (60/40+), and places bounded trades against the under-priced side. Defaults — $10 max per trade, 5 trades/run, 8-minute expiry window, dry-run unless `--live`.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.5"
+  version: "1.3.6"
   displayName: Mert Sniper
   difficulty: advanced
   attribution: Strategy inspired by @mert — https://x.com/mert/status/2020216613279060433

--- a/skills/polymarket-mert-sniper/mert_sniper.py
+++ b/skills/polymarket-mert-sniper/mert_sniper.py
@@ -223,7 +223,7 @@ def calculate_position_size(default_size, smart_sizing):
         print(f"  Smart sizing failed, using default ${default_size:.2f}")
         return default_size
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc") or 0
     if balance <= 0:
         print(f"  No available balance, using default ${default_size:.2f}")
         return default_size
@@ -487,7 +487,7 @@ def run_mert_strategy(dry_run=True, positions_only=False, show_config=False,
         print("\n  Portfolio:")
         portfolio = get_portfolio()
         if portfolio:
-            print(f"  Balance: ${portfolio.get('balance_usdc', 0):.2f}")
+            print(f"  Balance: ${portfolio.get('balance_usdc') or 0:.2f}")
             print(f"  Exposure: ${portfolio.get('total_exposure', 0):.2f}")
             print(f"  Positions: {portfolio.get('positions_count', 0)}")
 

--- a/skills/polymarket-mert-sniper/scripts/status.py
+++ b/skills/polymarket-mert-sniper/scripts/status.py
@@ -40,11 +40,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
         sys.exit(1)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/polymarket-mert-sniper/scripts/status.py
+++ b/skills/polymarket-mert-sniper/scripts/status.py
@@ -39,8 +39,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
         print(f"❌ Connection error: {e.reason}")
         sys.exit(1)
 
-def format_usd(amount: float) -> str:
-    """Format as USD."""
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -58,7 +62,7 @@ def main():
     print("📊 Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/polymarket-signal-sniper/SKILL.md
+++ b/skills/polymarket-signal-sniper/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-signal-sniper
 description: Snipe Polymarket opportunities from your own signal sources. Monitors RSS feeds with Trading Agent-grade safeguards.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.5.3"
+  version: "1.5.4"
   displayName: Polymarket Signal Sniper
   difficulty: intermediate
 ---

--- a/skills/polymarket-signal-sniper/scripts/status.py
+++ b/skills/polymarket-signal-sniper/scripts/status.py
@@ -40,11 +40,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
         sys.exit(1)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/polymarket-signal-sniper/scripts/status.py
+++ b/skills/polymarket-signal-sniper/scripts/status.py
@@ -39,8 +39,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
         print(f"❌ Connection error: {e.reason}")
         sys.exit(1)
 
-def format_usd(amount: float) -> str:
-    """Format as USD."""
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -58,7 +62,7 @@ def main():
     print("📊 Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/polymarket-wallet-xray/SKILL.md
+++ b/skills/polymarket-wallet-xray/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-wallet-xray
 description: X-ray any Polymarket wallet — skill level, entry quality, bot detection, and edge analysis. Queries Polymarket's public APIs, no authentication needed. Inspired by @thejayden's "Autopsy of a Polymarket Whale" analysis.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.1.4"
+  version: "1.1.5"
   displayName: Polymarket Wallet X-Ray
   difficulty: beginner
 ---

--- a/skills/polymarket-wallet-xray/scripts/status.py
+++ b/skills/polymarket-wallet-xray/scripts/status.py
@@ -40,11 +40,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
         sys.exit(1)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/polymarket-wallet-xray/scripts/status.py
+++ b/skills/polymarket-wallet-xray/scripts/status.py
@@ -39,8 +39,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
         print(f"❌ Connection error: {e.reason}")
         sys.exit(1)
 
-def format_usd(amount: float) -> str:
-    """Format as USD."""
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -58,7 +62,7 @@ def main():
     print("📊 Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.4"
+  version: "1.23.5"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/scripts/status.py
+++ b/skills/polymarket-weather-trader/scripts/status.py
@@ -16,11 +16,15 @@ sys.stdout.reconfigure(line_buffering=True)
 
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 

--- a/skills/polymarket-weather-trader/scripts/status.py
+++ b/skills/polymarket-weather-trader/scripts/status.py
@@ -15,7 +15,12 @@ import argparse
 sys.stdout.reconfigure(line_buffering=True)
 
 
-def format_usd(amount: float) -> str:
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 
@@ -45,7 +50,7 @@ def main():
         print(f"API Error: {e}")
         sys.exit(1)
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -1227,7 +1227,7 @@ def calculate_position_size(default_size: float, smart_sizing: bool) -> float:
         print(f"  ⚠️  Smart sizing failed, using default ${default_size:.2f}")
         return default_size
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc") or 0
     if balance <= 0:
         print(f"  ⚠️  No available balance, using default ${default_size:.2f}")
         return default_size
@@ -1419,7 +1419,7 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         log("\n💰 Portfolio:")
         portfolio = get_portfolio()
         if portfolio:
-            log(f"  Balance: ${portfolio.get('balance_usdc', 0):.2f}")
+            log(f"  Balance: ${portfolio.get('balance_usdc') or 0:.2f}")
             log(f"  Exposure: ${portfolio.get('total_exposure', 0):.2f}")
             log(f"  Positions: {portfolio.get('positions_count', 0)}")
             by_source = portfolio.get('by_source', {})

--- a/skills/simmer-skill-builder/SKILL.md
+++ b/skills/simmer-skill-builder/SKILL.md
@@ -3,7 +3,7 @@ name: simmer-skill-builder
 description: Generate complete, installable OpenClaw trading skills from natural language strategy descriptions. Use when your human wants to create a new trading strategy, build a bot, generate a skill, automate a trade idea, turn a tweet into a strategy, or asks "build me a skill that...". Produces a full skill folder (SKILL.md + Python script + config) ready to install and run.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.3.9"
+  version: "1.3.10"
   displayName: Simmer Skill Builder
   difficulty: beginner
 ---

--- a/skills/simmer-skill-builder/references/example-llm-oracle.md
+++ b/skills/simmer-skill-builder/references/example-llm-oracle.md
@@ -177,7 +177,7 @@ def evaluate_and_trade(market_id, raw_prob, confidence, side, reasoning, live=Fa
         return None
 
     portfolio = client.get_portfolio()
-    bankroll = portfolio.get("balance_usdc", 0) + portfolio.get("total_exposure", 0)
+    bankroll = (portfolio.get("balance_usdc") or 0) + portfolio.get("total_exposure", 0)
 
     amount = size_position(
         p_win=corrected_prob,

--- a/skills/simmer-skill-builder/references/skill-template.md
+++ b/skills/simmer-skill-builder/references/skill-template.md
@@ -301,7 +301,7 @@ def run_strategy(dry_run=True, positions_only=False, show_config=False,
     # --- Strategy logic ---
     markets = fetch_markets()
     portfolio = get_portfolio() or {}
-    bankroll = min(portfolio.get("balance_usdc", 0.0), MAX_POSITION_USD * MAX_TRADES_PER_RUN)
+    bankroll = min(portfolio.get("balance_usdc") or 0.0, MAX_POSITION_USD * MAX_TRADES_PER_RUN)
     trades_executed = 0
 
     for market in markets:

--- a/skills/simmer-skill-builder/scripts/status.py
+++ b/skills/simmer-skill-builder/scripts/status.py
@@ -40,11 +40,15 @@ def api_request(api_key: str, endpoint: str) -> dict:
         sys.exit(1)
 
 def format_usd(amount) -> str:
-    """Format as USD. None means unknown -- an API key with no linked account
-    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """Format as USD. None means unavailable, not zero.
+
+    The API returns null whenever it cannot report the balance -- an API key
+    with no linked account, a sim-only query, or a failed lookup. Printing
+    $0.00 would invent a number; naming one of those causes would guess at
+    which one, so stay neutral.
     """
     if amount is None:
-        return "n/a (no linked account)"
+        return "n/a"
     return f"${amount:,.2f}"
 
 def main():

--- a/skills/simmer-skill-builder/scripts/status.py
+++ b/skills/simmer-skill-builder/scripts/status.py
@@ -39,7 +39,12 @@ def api_request(api_key: str, endpoint: str) -> dict:
         print(f"Connection error: {e.reason}")
         sys.exit(1)
 
-def format_usd(amount: float) -> str:
+def format_usd(amount) -> str:
+    """Format as USD. None means unknown -- an API key with no linked account
+    cannot see a real-venue balance, and printing $0.00 would invent one.
+    """
+    if amount is None:
+        return "n/a (no linked account)"
     return f"${amount:,.2f}"
 
 def main():
@@ -56,7 +61,7 @@ def main():
     print("Fetching account status...\n")
     portfolio = api_request(api_key, "/api/sdk/portfolio")
 
-    balance = portfolio.get("balance_usdc", 0)
+    balance = portfolio.get("balance_usdc")
     exposure = portfolio.get("total_exposure", 0)
     positions_count = portfolio.get("positions_count", 0)
     pnl_total = portfolio.get("pnl_total")


### PR DESCRIPTION
## Why

`GET /api/sdk/portfolio` can return `balance_usdc: null`. These scripts read it
with `.get("balance_usdc", 0)`, which returns `None` — not `0` — when the key is
present with a null value, and then raise:

```
TypeError: unsupported format string passed to NoneType.__format__
```

**Already reachable today** via `?venue=sim`. [SupaFund/simmer#2246][pr] widens it:
an API key with no linked account now gets a populated $SIM portfolio with the
real-venue fields null, instead of a 400.

That is the right API answer — an account-less key genuinely cannot see a
Polymarket balance, and reporting `0` would invent one an agent could size a trade
against — but it means these scripts hit the null on the ordinary path. So this
lands **before** #2246, to avoid a window where an account-less agent running
`status.py` gets a traceback where it used to get a clean 400.

[pr]: https://github.com/SupaFund/simmer/pull/2246

## What

Two shapes, matching how each site uses the value.

**The 8 `scripts/status.py` files display it.** `format_usd` now renders `None` as
`n/a (no linked account)`, and the read drops its `0` default so the null reaches
it. Printing `$0.00` would just move the same falsehood from the API into the CLI.
These files already handle a null `pnl_total` exactly this way, so this follows
their own idiom.

**The 5 trader scripts do arithmetic with it** — `balance * SMART_SIZING_PCT`,
`if balance <= 0` — so they coerce with `or 0`. That matches
`polymarket-mil-aircraft-tracker/milaircraft_tracker.py:492`, the one script that
already got this right.

**Two references** — `skill-template.md` and `example-llm-oracle.md` — propagate
the pattern into every skill built from them, so they're fixed too. Arguably the
most important two files here.

`milaircraft_tracker.py` needed no change.

## Verification

```
old format_usd(None) -> TypeError: unsupported format string passed to NoneType.__format__
new format_usd(None) -> 'n/a (no linked account)'
new format_usd(98.5) -> '$98.50'
```

All `skills/**/*.py` parse. No `get("balance_usdc", 0)` remains anywhere under
`skills/`.

## Note

These are published skills, so this needs a ClawHub republish after merge — not
done, and it needs your approval.
