### PR TITLE
fix(backtest): resync vendored replay engine to simmer@5daddb9ec; stop overriding its fee default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.0 (2026-09-05)
+
+- **`simmer backtest` now charges fees by default, and its numbers will change.** The vendored replay engine was ~3 months behind the backend it is supposed to mirror while both reported `ENGINE_VERSION 0.1.1`, so the CLI and the server quietly disagreed for the same bundle. Re-vendored at engine **0.2.0**. Three user-visible consequences: (1) `--fee-rate` defaults to the engine's rate (currently `0.05`) instead of `0`, so every backtest now has cost drag — pass `--fee-rate 0` for the old behaviour; (2) fees use Polymarket's real shape, `notional x base x (1 - price)`, and resting limit fills that cross pay **0** as makers, where the old model charged a flat rate on notional; (3) every `config_hash` changes, so a re-run of a saved backtest will not match its stored report. Baselines now pay the same fee as the strategy's own fills and are derived from executed fills rather than logged decisions, so a limit order that never crossed no longer counts as a buy-and-hold entry.
+- **Reports say what they charged.** New `summary.fee_rate`, `summary.fees_paid`, `reproducibility.fee_rate`, and a `fee` on every entry in `fills[]`. Previously nothing in a report revealed the fee assumption behind its P&L.
+- **A worthless position can be closed again.** `sell()` briefly rejected a price of exactly 0 — the case where YES prints 1.0 and a NO position is worth nothing — leaving it on the book to be marked and settled instead of exited. Prices outside the valid range are still rejected, and now name the price instead of surfacing as "insufficient balance".
+
 ## 0.24.7 (2026-09-05)
 
 - **`find_markets()` stopped discarding tag matches.** The server's `q` filter matches each token against the market question OR its tags, and `find_markets()` then re-filtered the results on question text alone -- so every tag-only hit was thrown away. `find_markets("weather")` returned nothing while `get_markets(q="weather")` returned a full page, because weather markets are titled "Austin 82-83F on Sep 7" and carry `weather` as a tag. The server's matches are now returned as-is. The client-side substring narrowing remains on the sub-2-char fallback path, where the server does no filtering at all.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.24.7"
+version = "0.25.0"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/backtest/__init__.py
+++ b/simmer_sdk/backtest/__init__.py
@@ -146,7 +146,7 @@ def run_backtest(
     api_key: Optional[str] = None,
     cadence: Union[str, int, float, timedelta] = "15m",
     balance: float = 1000.0,
-    fee_rate: float = 0.0,
+    fee_rate: Optional[float] = None,
     seed: int = 0,
     max_evaluations: int = 50_000,
     args: Union[str, list, tuple, None] = None,
@@ -176,7 +176,11 @@ def run_backtest(
             env — the same key you trade with). Ignored for a local ``tape``.
         cadence: tick spacing — ``15m`` / ``12h`` / ``30d``, minutes, or timedelta.
         balance: starting balance.
-        fee_rate: per-fill fee rate (0 = none; baselines ignore fees in v0).
+        fee_rate: BASE fee rate, charged as ``notional x rate x (1 - price)`` on
+            taker fills (maker/limit fills pay 0). ``None`` (default) defers to
+            the engine's own default so the CLI never silently overrides it;
+            pass ``0`` to run fee-free. Baselines pay the same fee as the
+            strategy's fills.
         seed: RNG seed for the random baseline.
         max_evaluations: hard ticks×markets budget (engine truncates past it).
         args: entrypoint CLI args (string split on whitespace, or list).
@@ -254,7 +258,11 @@ def run_backtest(
             t1=t1_dt,
             cadence=cadence_td,
             starting_balance=balance,
-            fee_rate=fee_rate,
+            # Forward only when the caller set it, so ReplayConfig owns the
+            # default. Passing 0.0 unconditionally here (and from cli.py) is how
+            # the SDK kept producing zero-fee reports stamped with the current
+            # ENGINE_VERSION after the engine's default changed.
+            **({} if fee_rate is None else {"fee_rate": fee_rate}),
             skill_slug=os.path.basename(bundle.rstrip("/")),
             skill_version=_bundle_skill_version(bundle),
             dataset_rev=_dataset_rev(tape),

--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/candles_service.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ a759c3089aa2
+# vendored from simmer_v3/replay/candles_service.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ a759c3089aa2
+# vendored from simmer_v3/replay/duckdb_store.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/duckdb_store.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/engine.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ a759c3089aa2
+# vendored from simmer_v3/replay/engine.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 
@@ -26,20 +26,22 @@ from typing import Any, Optional, Protocol
 from fastapi.testclient import TestClient
 
 from .server import ReplaySession, create_app
-from .simstate import SimState
+from .simstate import SimState, fee_for
 from .store import HistoricalStore
 
 # Canonical engine version — bump on any change that can alter results (fill
 # model, look-ahead semantics, fee handling). The catalog's stale_engine badge
 # compares stored reports' reproducibility.engine against this.
-ENGINE_VERSION = "0.1.1"  # 0.1.1: snap resolved binary outcome to {0,1} (SIM-3070 hit_rate fix)
+ENGINE_VERSION = "0.2.0"  # 0.2.0: Polymarket fee shape + nonzero default base rate
 
 REALISM_GAPS = [
     "no slippage",
     "no market impact at size",
     "no queue position",
     "no latency",
-    "no maker rebates",
+    "no maker rebates (maker fills pay 0 fee, but the 20% rebate is not credited)",
+    "single blended base fee rate, not per-category (crypto/sports/other differ; "
+    "see _dev/reference/trading-economics.md)",
     "trade-tape prices, not orderbook",
 ]
 
@@ -54,7 +56,15 @@ class ReplayConfig:
     t1: datetime
     cadence: timedelta = timedelta(minutes=15)
     starting_balance: float = 1000.0
-    fee_rate: float = 0.0
+    # BASE fee rate, applied as notional x fee_rate x (1 - price) — see
+    # SimState._fee. 0.05 is derived from the only fees we have actually
+    # measured: 6,812 V2 trades back-filled from on-chain `fee_usdc` between
+    # 2026-04-28 and 2026-06-15 came in at a median 246 bps EFFECTIVE at an
+    # average price of 0.522, which implies a base near 500 bps. Zero was never
+    # right: post-April `real_trades.fee_rate_bps = 0` is a sentinel meaning
+    # "unknown at placement time" (polymarket_client.get_polymarket_fee_rate),
+    # not "free".
+    fee_rate: float = 0.05
     skill_slug: str = "unknown"
     skill_version: str = "0"
     dataset_rev: str = "unknown"
@@ -147,6 +157,11 @@ class ReplayEngine:
                 "hit_rate": (wins / decided) if decided else None,
                 "pnl": equity - cfg.starting_balance,
                 "final_equity": equity,
+                # fee_rate is the BASE rate (see SimState._fee); fees_paid is
+                # the realised total so a reader can see how much of pnl is
+                # cost drag without re-deriving it from config_hash.
+                "fee_rate": cfg.fee_rate,
+                "fees_paid": round(sum(f.fee for f in trades), 6),
                 "max_drawdown": _max_drawdown([p["equity"] for p in self.equity_curve]),
                 "ticks": self.tick_count,
                 "evaluations": self.session.evaluations,
@@ -157,7 +172,7 @@ class ReplayEngine:
             "fills": [
                 {"ts": f.ts.isoformat(), "market_id": f.market_id, "side": f.side,
                  "action": f.action, "shares": round(f.shares, 6), "price": f.price,
-                 "usd": round(f.usd, 6), "kind": f.kind}
+                 "usd": round(f.usd, 6), "fee": round(f.fee, 6), "kind": f.kind}
                 for f in self.sim.fills
             ],
             "equity_curve": self.equity_curve,
@@ -179,40 +194,55 @@ class ReplayEngine:
                 "cadence": f"{int(cfg.cadence.total_seconds())}s",
                 "skill": f"{cfg.skill_slug}@{cfg.skill_version}",
                 "engine": cfg.engine_version,
+                "fee_rate": cfg.fee_rate,
                 "config_hash": cfg.config_hash(),
                 "seed": cfg.seed,
             },
         }
 
     def _baselines(self) -> dict:
-        """Same markets, same entry times, same notionals — different side rule.
+        """Same markets, same entry FILLS, same notionals — different side rule.
 
-        buy_and_hold_yes: buy YES at the strategy's entry print, hold to
+        Derived from executed buy fills, not from decisions. The session logs
+        a decision before it knows whether sim.buy() filled or rested
+        (server.py), so decisions over-count entries for any limit strategy: a
+        resting order that never crossed, or lapsed for cash, is not an entry.
+
+        buy_and_hold_yes: buy YES at the fill's price and time, hold to
         resolution (or mark at window end). random: coin-flip side per entry
-        (seeded). Both ignore fees for v0 (documented)."""
-        entries = [d for d in self.session.decisions if d.get("action") == "buy"]
+        (seeded). Each leg pays the fee for ITS OWN trade: same notional, same
+        base rate, same kind as the strategy's fill (so maker fills stay free),
+        but at the baseline's own entry price — fee_for is not symmetric in
+        price, so a NO-side strategy fill and its YES baseline pay different
+        amounts by design. Settlement is fee-free on both sides
+        (SimState.settle). A fee-charged strategy measured against fee-free
+        baselines would report as losing to buy-and-hold on identical entries."""
+        buys = [f for f in self.sim.fills if f.action == "buy"]
         rng = random.Random(self.config.seed)
-        out = {"buy_and_hold_yes": 0.0, "random": 0.0, "note": "same entries/notional; fees ignored in baselines v0"}
-        for d in entries:
-            mid = d["market_id"]
-            amt = float(d.get("amount") or 0.0)
+        out = {"buy_and_hold_yes": 0.0, "random": 0.0,
+               "note": ("same entry fills/notional; each leg pays the fee for its own trade "
+                        "(same base rate and kind, own entry price; maker fills free); "
+                        "settlement fee-free")}
+        rate = self.config.fee_rate
+        for f in buys:
+            mid = f.market_id
+            amt = -f.usd - f.fee  # Fill.usd for a buy is -(notional + fee)
             if amt <= 0:
                 continue
-            entry_point = self.store.price(mid, datetime.fromisoformat(d["ts"]))
+            entry_yes = f.price if f.side == "yes" else 1.0 - f.price
             res = self.store.resolution(mid)
-            if entry_point is None:
-                continue
             final_yes = res.outcome_yes if (res and res.resolved_at <= self.config.t1) else None
             if final_yes is None:
                 last = self.store.price(mid, self.config.t1)
-                final_yes = last.price if last else entry_point.price
-            if entry_point.price > 0:
-                out["buy_and_hold_yes"] += amt * (final_yes / entry_point.price) - amt
+                final_yes = last.price if last else entry_yes
+            if entry_yes > 0:
+                out["buy_and_hold_yes"] += (amt * (final_yes / entry_yes) - amt
+                                            - fee_for(amt, entry_yes, rate, f.kind))
             side = rng.choice(["yes", "no"])
-            px = entry_point.price if side == "yes" else 1.0 - entry_point.price
+            px = entry_yes if side == "yes" else 1.0 - entry_yes
             payout = final_yes if side == "yes" else 1.0 - final_yes
             if px > 0:
-                out["random"] += amt * (payout / px) - amt
+                out["random"] += amt * (payout / px) - amt - fee_for(amt, px, rate, f.kind)
         out["buy_and_hold_yes"] = round(out["buy_and_hold_yes"], 6)
         out["random"] = round(out["random"], 6)
         return out

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ a759c3089aa2
+# vendored from simmer_v3/replay/feeds/binance.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/feeds/binance.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/harness.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ a759c3089aa2
+# vendored from simmer_v3/replay/harness.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/server.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ a759c3089aa2
+# vendored from simmer_v3/replay/server.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 
@@ -150,11 +150,24 @@ def create_app(session: ReplaySession) -> FastAPI:
         }
 
     @app.get("/api/sdk/markets")
-    def markets(limit: int = 50, q: Optional[str] = None, status: Optional[str] = None):
-        metas = session.view.markets(limit=limit)
+    def markets(
+        limit: int = 50,
+        q: Optional[str] = None,
+        status: Optional[str] = None,
+        sort: Optional[str] = None,
+        venue: Optional[str] = None,
+    ):
+        metas = session.view.markets(limit=max(limit * 4, limit))
         if q:
             ql = q.lower()
             metas = [m for m in metas if ql in m.question.lower() or ql in m.slug.lower()]
+        sort_norm = sort.strip().lower() if sort else None
+        if sort_norm == "created":
+            sort_norm = "recent"
+        if sort_norm == "recent":
+            metas = sorted(metas, key=lambda m: m.created_at, reverse=True)
+        else:
+            metas = sorted(metas, key=lambda m: (m.volume is not None, m.volume or 0.0, m.created_at), reverse=True)
         rows = _budgeted(metas[:limit])
         return {"markets": [_market_payload(session, m) for m in rows]}
 

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/simstate.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 
@@ -105,8 +105,11 @@ def fee_for(notional: float, px: float, base_rate: float, kind: str = "market") 
     makers pay no fee (_dev/reference/trading-economics.md). The 20% maker
     rebate is NOT credited; see REALISM_GAPS.
 
-    Clamped at zero: a tape print above 1.0 would otherwise turn the fee into
-    a rebate that credits cash.
+    Clamped at zero as defence-in-depth: buy()/sell() now reject px outside
+    their valid range, so an out-of-range price cannot reach here. Were it to,
+    a clamp is still safer than a negative fee that credits cash — though note
+    a clamp alone would turn a bad print into a FREE fill, which is why the
+    range check lives at the call sites and not only here.
 
     Module-level on purpose: the engine's baselines charge the same fee, and
     the first cut of the fee change diverged exactly where that arithmetic was
@@ -147,12 +150,16 @@ class SimState:
         if limit_price is not None and px > limit_price:
             return self._rest_order(view, market_id, side, "buy", limit_price, usd_amount=usd_amount)
 
+        # Price sanity BEFORE cost: a buy divides by px, and an out-of-range
+        # print makes the fee term nonsense, which used to surface as
+        # "insufficient balance: need <inflated>" and send debugging toward
+        # sizing instead of the bad tape print.
+        if not 0 < px <= 1:
+            raise ReplayTradeError(f"{side} price out of range (0,1]: {px}")
         fee = self._fee(usd_amount, px)
         total = usd_amount + fee
         if total > self.cash + 1e-9:
             raise ReplayTradeError(f"insufficient balance: need {total:.2f}, have {self.cash:.2f}")
-        if px <= 0:
-            raise ReplayTradeError(f"non-positive {side} price {px}")
         shares = usd_amount / px
         self.cash -= total
         pos = self.positions.setdefault(market_id, Position())
@@ -181,11 +188,15 @@ class SimState:
         if limit_price is not None and px < limit_price:
             return self._rest_order(view, market_id, side, "sell", limit_price, shares=shares)
 
-        if px <= 0:
-            # Mirrors buy(). A yes print above 1.0 (the dataset value is
-            # unclamped) makes the NO side price negative; without this guard
-            # proceeds AND fee go negative and cash is debited on a "sale".
-            raise ReplayTradeError(f"non-positive {side} price {px}")
+        # Range is [0,1] here, NOT (0,1] as in buy(): a sell multiplies rather
+        # than divides, so px == 0 is a legitimate zero-proceeds exit — dumping
+        # a worthless NO position when YES prints 1.0. Rejecting it (the first
+        # cut of this guard did) strands the position on the book to be marked
+        # and settled instead of closed, which live trading would not do.
+        # px < 0 or px > 1 is a corrupt print: it would make proceeds and fee
+        # negative and debit cash on a "sale".
+        if not 0 <= px <= 1:
+            raise ReplayTradeError(f"{side} price out of range [0,1]: {px}")
         proceeds = shares * px
         fee = self._fee(proceeds, px)
         self.cash += proceeds - fee

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ a759c3089aa2
+# vendored from simmer_v3/replay/simstate.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 
@@ -8,8 +8,8 @@ Implements the v1 fill model from replay-contract.md, deliberately simple:
     no size impact, no partial fills.
   - Resting limit orders fill when the tape prints through the limit price
     (fill AT the limit price). No queue-position modeling.
-  - Fees: flat taker fee rate on notional (default 0.0 — Polymarket's
-    historical default; configurable per run).
+  - Fees: Polymarket's taker shape, base_rate x shares x p x (1 - p), which
+    equals notional x base_rate x (1 - p). `fee_rate` is the BASE rate.
   - Settlement: at resolution, YES shares pay outcome_yes each, NO shares
     pay (1 - outcome_yes).
 
@@ -92,6 +92,31 @@ def _side_price(yes_price: float, side: str) -> float:
     return yes_price if side == "yes" else 1.0 - yes_price
 
 
+def fee_for(notional: float, px: float, base_rate: float, kind: str = "market") -> float:
+    """Polymarket taker fee for a fill of ``notional`` USD at side price ``px``.
+
+    Live: ``base_rate x shares x p x (1 - p)`` (sdk_trade.py taker_fee_saved).
+    Since ``notional = shares x p`` that is ``notional x base_rate x (1 - p)``.
+    The shape matters: a flat rate overstates cost on favourites and
+    understates it near 0.50, and prediction-market strategies cluster at
+    the extremes.
+
+    ``kind="limit"`` (a resting order that filled as maker) pays 0 — live
+    makers pay no fee (_dev/reference/trading-economics.md). The 20% maker
+    rebate is NOT credited; see REALISM_GAPS.
+
+    Clamped at zero: a tape print above 1.0 would otherwise turn the fee into
+    a rebate that credits cash.
+
+    Module-level on purpose: the engine's baselines charge the same fee, and
+    the first cut of the fee change diverged exactly where that arithmetic was
+    written twice.
+    """
+    if kind == "limit":
+        return 0.0
+    return notional * base_rate * max(0.0, 1.0 - px)
+
+
 class SimState:
     """Mutable per-replay portfolio. One instance per replay job/session."""
 
@@ -103,6 +128,9 @@ class SimState:
         self.open_orders: dict[str, LimitOrder] = {}
         self.fills: list[Fill] = []
         self._order_seq = 0
+
+    def _fee(self, notional: float, px: float, kind: str = "market") -> float:
+        return fee_for(notional, px, self.fee_rate, kind)
 
     # -- marketable orders ---------------------------------------------------
 
@@ -119,7 +147,7 @@ class SimState:
         if limit_price is not None and px > limit_price:
             return self._rest_order(view, market_id, side, "buy", limit_price, usd_amount=usd_amount)
 
-        fee = usd_amount * self.fee_rate
+        fee = self._fee(usd_amount, px)
         total = usd_amount + fee
         if total > self.cash + 1e-9:
             raise ReplayTradeError(f"insufficient balance: need {total:.2f}, have {self.cash:.2f}")
@@ -153,8 +181,13 @@ class SimState:
         if limit_price is not None and px < limit_price:
             return self._rest_order(view, market_id, side, "sell", limit_price, shares=shares)
 
+        if px <= 0:
+            # Mirrors buy(). A yes print above 1.0 (the dataset value is
+            # unclamped) makes the NO side price negative; without this guard
+            # proceeds AND fee go negative and cash is debited on a "sale".
+            raise ReplayTradeError(f"non-positive {side} price {px}")
         proceeds = shares * px
-        fee = proceeds * self.fee_rate
+        fee = self._fee(proceeds, px)
         self.cash += proceeds - fee
         pos.reduce_basis(side, shares, held)
         if side == "yes":
@@ -219,7 +252,7 @@ class SimState:
     def _execute_at_limit(self, view: ReplayView, order: LimitOrder) -> Optional[Fill]:
         px = order.limit_price
         if order.action == "buy":
-            fee = order.usd_amount * self.fee_rate
+            fee = self._fee(order.usd_amount, px, kind="limit")
             total = order.usd_amount + fee
             if total > self.cash + 1e-9:
                 return None  # order lapses — insufficient cash at cross time
@@ -241,7 +274,7 @@ class SimState:
             if shares <= 0:
                 return None
             proceeds = shares * px
-            fee = proceeds * self.fee_rate
+            fee = self._fee(proceeds, px, kind="limit")
             self.cash += proceeds - fee
             pos.reduce_basis(order.side, shares, held)
             if order.side == "yes":

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ 5daddb9ecb15
+# vendored from simmer_v3/replay/store.py @ f23de362b27f
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ a759c3089aa2
+# vendored from simmer_v3/replay/store.py @ 5daddb9ecb15
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 

--- a/simmer_sdk/cli.py
+++ b/simmer_sdk/cli.py
@@ -239,7 +239,9 @@ def _build_parser() -> argparse.ArgumentParser:
                     help="tape-service base URL (default: SIMMER_API_URL env or production)")
     bt.add_argument("--cadence", default="15m", help="tick spacing: 15m / 12h / 30d / minutes (default 15m)")
     bt.add_argument("--balance", type=float, default=1000.0, help="starting balance (default 1000)")
-    bt.add_argument("--fee-rate", type=float, default=0.0, dest="fee_rate", help="per-fill fee rate (default 0)")
+    bt.add_argument("--fee-rate", type=float, default=None, dest="fee_rate",
+                    help="BASE fee rate, applied as notional x rate x (1 - price); maker fills pay 0. "
+                         "Default follows the engine (currently 0.05) — pass 0 to run fee-free")
     bt.add_argument("--seed", type=int, default=0, help="RNG seed for the random baseline (default 0)")
     bt.add_argument("--max-evaluations", type=int, default=50_000, dest="max_evaluations",
                     help="hard ticks×markets budget (default 50000)")


### PR DESCRIPTION
## What

Two independent SDK-side problems, one fix.

**1. The vendored replay engine was ~3 months stale.** `simmer_sdk/backtest/replay/` was pinned at `a759c3089` (2026-06-13). simmer `ec9267b26` (#1258, two days later) added `sort`/`venue` and a liquidity-first default to the replay server's `/markets`; the SDK copy never received it. Both engines kept reporting `ENGINE_VERSION 0.1.1`, so `simmer backtest` and the backend harness disagreed for the same bundle with nothing flagging it. Now re-vendored at `5daddb9ec` (engine 0.2.0), which also brings simmer #2245: Polymarket fee shape `notional x base x (1-p)`, maker fills free, baselines paying the same fee from executed fills.

**2. The SDK silently overrode the engine's fee default.** `cli.py` and `backtest/__init__.py` hardcoded `fee_rate=0.0` and passed it unconditionally into `ReplayConfig` — so even after a resync, every SDK report would have been zero-fee while stamped 0.2.0. Default is now `None`, forwarded only when set. `--fee-rate 0` still runs fee-free.

## Before / after — bundled demo, `backtest-demo-favorites`, demo tape 2026-04-28→05-05, 12h

| run | engine | pnl | buy_and_hold_yes | fees_paid |
|---|---|---|---|---|
| before, default | 0.1.1 | −29.5368 | −29.5368 | n/a |
| before, `--fee-rate 0.05` | 0.1.1 | **−42.0368** | −29.5368 | n/a (flat model; baseline fee-free → asymmetric) |
| after, default | 0.2.0 | −34.0868 | −34.0868 | 4.55 |
| after, `--fee-rate 0.05` | 0.2.0 | identical, same `config_hash` | | |
| after, `--fee-rate 0` | 0.2.0 | −29.5368 | −29.5368 | 0.0 |

Three things that table proves: the sentinel forwards the engine default (rows 3–4 share a hash); for this demo the ordering change moved nothing — fee-free after equals before to the cent; and the old flat model charged this favourites strategy **$12.50** where the `(1-p)` shape charges **$4.55** — 2.7×, the reason the shape matters on binaries.

## Verification

- `pytest tests/` — **746 passed, 4 skipped**.
- `scripts/sync_replay_engine.py --check --source <simmer@5daddb9ec>` exits 0.
- `simmer backtest --help` shows the new `--fee-rate` semantics.

## Deliberately NOT here: the CI drift guard

`--check` needs a simmer checkout. simmer is **private** and this repo's CI has no token that can read it; adding one means provisioning a new secret. The guard belongs in **simmer's** CI instead — it can check out this public repo with no secret and run `--check --source .`. That is a separate simmer PR and must land **after** this one, or it goes red on arrival.