### PR TITLE
fix(weather-trader): read Polymarket's reworded station criteria (v1.23.6)

### DIFF
--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Added
 - Parse-coverage guard. When a run reads a station out of fewer than 50% of the events that had criteria, the skill says so loudly (surviving `--quiet`) instead of reporting a clean scan. A parser that falls behind upstream wording throws nothing, fails no trade and retries nothing, so every downstream health metric stays green while the skill quietly stops entering — this was invisible for two weeks. The warning names the real cause: it is not finding no opportunities, it is failing to look.
 - `parse_resolution_station_result(criteria)` — returns the station plus the reason it could not be read (`SKIP_MISSING_CRITERIA` / `SKIP_UNPARSEABLE_CRITERIA`). `parse_resolution_station()` is unchanged for existing callers.
+- Whitespace in the station phrase is collapsed before matching, so the pattern uses literal single spaces. The first cut used `\s+` around the lazy capture, which let the engine repartition a whitespace run on every failure — `recorded at the` followed by 1,600 spaces took 6.8s, growing ~8x per doubling. Criteria text is authored upstream, so one malformed market would have stalled the whole scan. Collapsing first also means a station phrase wrapped across newlines now parses, which the old pattern could not do.
 - `tests/test_resolution_criteria_reword.py` — pins the new and old wording, the reason split, alias-to-coordinate integrity, and the coverage guard's thresholds against live criteria strings.
 
 ### Thanks

--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.23.6] - 2026-09-06
+
+### Fixed
+- **Polymarket reworded every weather-temperature market on 2026-08-22 and the station parser stopped reading all of them.** The criteria dropped their Wunderground URL (resolution source moved to NOAA) and gained an agency clause — `recorded BY NOAA at the LaGuardia Airport Station`. Both parser patterns matched neither, so `parse_resolution_station()` returned `None` on 100% of current criteria and the skill skipped every event without entering. Verified against the live corpus: 2,195 of 2,596 active weather-temperature markets carry the new wording; only 84 keep the old. The station phrase now accepts an optional, generic agency clause, so `by NWS` or `by the National Weather Service` will not break it again.
+- Added name aliases for three stations Polymarket cites under a different name than our coordinate tables hold: `Hartsfield-Jackson International Airport` → `KATL`, `Amsterdam Airport Schiphol` → `EHAM`, `Malpensa Intl Airport` → `LIMC`. With these, all 16 advertised locations route again — the six US cities in `SIMMER_WEATHER_LOCATIONS` plus every international alias. Aliases may only point at stations we already have coordinates for; routing a market to an airport we cannot forecast is the silent KDFW/KDAL failure mode.
+- The skip log no longer claims `need SDK ≥ 2026-05-03` when criteria is present. Missing criteria and unreadable criteria were sharing one message that blamed a stale SDK for both; they are now distinct reasons.
+
+### Added
+- Parse-coverage guard. When a run reads a station out of fewer than 50% of the events that had criteria, the skill says so loudly (surviving `--quiet`) instead of reporting a clean scan. A parser that falls behind upstream wording throws nothing, fails no trade and retries nothing, so every downstream health metric stays green while the skill quietly stops entering — this was invisible for two weeks. The warning names the real cause: it is not finding no opportunities, it is failing to look.
+- `parse_resolution_station_result(criteria)` — returns the station plus the reason it could not be read (`SKIP_MISSING_CRITERIA` / `SKIP_UNPARSEABLE_CRITERIA`). `parse_resolution_station()` is unchanged for existing callers.
+- `tests/test_resolution_criteria_reword.py` — pins the new and old wording, the reason split, alias-to-coordinate integrity, and the coverage guard's thresholds against live criteria strings.
+
+### Thanks
+- Reported by the Grok Bot dogfood seat, which caught it on a clean v1.23.5 install and correctly identified that the log message was lying about the cause.
+
+
 ## [1.23.4] - 2026-07-22
 
 ### Fixed

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.5"
+  version: "1.23.6"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).

--- a/skills/polymarket-weather-trader/tests/test_resolution_criteria_reword.py
+++ b/skills/polymarket-weather-trader/tests/test_resolution_criteria_reword.py
@@ -176,6 +176,42 @@ class TestSkipReasonSplit(unittest.TestCase):
         self.assertIsNone(wt.parse_resolution_station_result(NEW_FORM_NYC)["reason"])
 
 
+class TestPathologicalInput(unittest.TestCase):
+    """Criteria text is authored upstream — one bad market must not stall a scan."""
+
+    def test_whitespace_run_does_not_blow_up(self):
+        # The first cut of this regex used \\s+ around a lazy capture; the engine
+        # repartitioned the run on every failure and took 6.8s at 1600 spaces,
+        # growing ~8x per doubling. A stalled parse blocks every later market,
+        # the coverage report, and the exit check.
+        import time
+
+        start = time.perf_counter()
+        self.assertIsNone(wt.parse_resolution_station("recorded at the" + " " * 20000 + "x"))
+        self.assertLess(time.perf_counter() - start, 1.0)
+
+    def test_repeated_agency_clause_does_not_blow_up(self):
+        import time
+
+        start = time.perf_counter()
+        wt.parse_resolution_station("recorded" + " by NOAA" * 500 + " at the X Station")
+        self.assertLess(time.perf_counter() - start, 1.0)
+
+    def test_station_phrase_wrapped_across_newlines_still_parses(self):
+        # Falls out of collapsing whitespace before matching; the old regex
+        # could not read a phrase broken over wrapped lines.
+        parsed = wt.parse_resolution_station(
+            "highest temperature recorded by NOAA at the\n   LaGuardia Airport\n   Station"
+        )
+        self.assertEqual(parsed["station_name"], "LaGuardia Airport")
+
+    def test_every_advertised_station_name_fits_the_capture_bound(self):
+        # The capture is bounded to keep the match linear; a name longer than
+        # the bound would silently stop routing.
+        for name in TestAdvertisedLocationsRoute.CASES:
+            self.assertLess(len(name), 120, f"{name!r} exceeds the capture bound")
+
+
 class TestParseCoverageGuard(unittest.TestCase):
     """The guard must actually discriminate — silent then, loud now."""
 

--- a/skills/polymarket-weather-trader/tests/test_resolution_criteria_reword.py
+++ b/skills/polymarket-weather-trader/tests/test_resolution_criteria_reword.py
@@ -1,0 +1,215 @@
+"""
+Regression tests for the 2026-08-22 Polymarket resolution_criteria reword.
+
+Polymarket changed every weather-temperature market's criteria on the same
+day: the Wunderground URL was dropped (resolution source moved to NOAA) and
+the station phrase gained an agency clause. Both parser patterns died at
+once and the skill silently stopped entering — no error, no failed trade,
+no retry, so nothing downstream noticed for two weeks.
+
+These tests pin the new wording, the old wording, the reason split, and the
+coverage guard that makes the next reword visible on the first run.
+
+Criteria strings below are copied verbatim from the live corpus on 2026-09-06.
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15, "exit_threshold": 0.45, "max_position_usd": 2.0,
+    "sizing_pct": 0.05, "max_trades_per_run": 5, "locations": "NYC",
+    "binary_only": False, "slippage_max": 0.15, "min_liquidity": 0.0,
+    "order_type": "GTC", "vol_targeting": False, "target_vol": 0.20,
+    "vol_max_leverage": 2.0, "vol_min_allocation": 0.2, "vol_span": 10,
+    "require_source_agreement": False, "canary_on_adjacent": True,
+    "max_canary_usd": 2.0, "max_source_spread_f": 2.0,
+}
+
+_skill_mod = types.ModuleType("simmer_sdk.skill")
+_skill_mod.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_mod.update_config = lambda updates, file, slug=None: None
+_skill_mod.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = MagicMock()
+sys.modules["simmer_sdk.skill"] = _skill_mod
+
+import weather_trader as wt  # noqa: E402
+
+
+# Verbatim from markets.resolution_criteria, 2026-09-06.
+NEW_FORM_NYC = (
+    "This market will resolve to the temperature range that contains the "
+    "highest temperature recorded by NOAA at the LaGuardia Airport Station "
+    "in degrees Fahrenheit on 6 Sep '26.\n\nThe resolution source for this "
+    "market will be information from NOAA, specifically the highest reading "
+    'under the "Temp" column.'
+)
+
+# The pre-2026-08-22 shape, still live on a residual ~84 markets.
+OLD_FORM_TAIPEI = (
+    "This market will resolve to the temperature range that contains the "
+    "highest temperature recorded at the Taipei Songshan Airport Station in "
+    "degrees Celsius on 2 May '26.\n\nThe resolution source for this market "
+    "will be information from Wunderground, available here: "
+    "https://www.wunderground.com/history/daily/tw/taipei/RCSS."
+)
+
+
+class TestNewFormWording(unittest.TestCase):
+    """The reword must not skip the market."""
+
+    def test_agency_clause_does_not_break_the_parse(self):
+        parsed = wt.parse_resolution_station(NEW_FORM_NYC)
+        self.assertIsNotNone(
+            parsed, "the 'recorded by NOAA at the ...' wording must parse"
+        )
+        self.assertEqual(parsed["station_name"], "LaGuardia Airport")
+
+    def test_nyc_routes_to_klga(self):
+        parsed = wt.parse_resolution_station(NEW_FORM_NYC)
+        self.assertEqual(
+            wt.resolve_station_id_from_name(parsed["station_name"]), "KLGA"
+        )
+
+    def test_a_future_agency_reword_still_parses(self):
+        # The clause is generic on purpose: the point of the fix is that the
+        # next rename does not cost us another two silent weeks.
+        for agency in ("NOAA", "NWS", "the National Weather Service"):
+            criteria = NEW_FORM_NYC.replace("by NOAA", f"by {agency}")
+            with self.subTest(agency=agency):
+                parsed = wt.parse_resolution_station(criteria)
+                self.assertIsNotNone(parsed)
+                self.assertEqual(parsed["station_name"], "LaGuardia Airport")
+
+
+class TestOldFormStillWorks(unittest.TestCase):
+    """~84 markets still carry the pre-reword shape."""
+
+    def test_wunderground_url_still_yields_the_icao(self):
+        parsed = wt.parse_resolution_station(OLD_FORM_TAIPEI)
+        self.assertEqual(parsed["station_id"], "RCSS")
+        self.assertEqual(parsed["station_name"], "Taipei Songshan Airport")
+
+
+class TestAdvertisedLocationsRoute(unittest.TestCase):
+    """Every location the skill advertises must route under the new wording.
+
+    clawhub.json promises six US cities; parse_weather_event() adds the
+    international aliases. A location we advertise but cannot route is a
+    silent no-op for the agent that configured it.
+    """
+
+    # station name Polymarket cites today -> ICAO we must land on
+    CASES = {
+        "LaGuardia Airport": "KLGA",
+        "Chicago O'Hare Intl Airport": "KORD",
+        "Seattle-Tacoma International Airport": "KSEA",
+        "Hartsfield-Jackson International Airport": "KATL",
+        "Dallas Love Field": "KDAL",
+        "Miami Intl Airport": "KMIA",
+        "Munich Airport": "EDDM",
+        "London City Airport": "EGLC",
+        "Tokyo Haneda Airport": "RJTT",
+        "Incheon Intl Airport": "RKSI",
+        "Esenboğa Intl Airport": "LTAC",
+        "Chaudhary Charan Singh Intl Airport": "VILK",
+        "Wellington Intl Airport": "NZWN",
+        "Adolfo Suárez Madrid-Barajas Airport": "LEMD",
+        "Malpensa Intl Airport": "LIMC",
+        "Amsterdam Airport Schiphol": "EHAM",
+    }
+
+    def test_each_advertised_station_routes(self):
+        for cited_name, expected_icao in self.CASES.items():
+            criteria = NEW_FORM_NYC.replace("LaGuardia Airport", cited_name)
+            with self.subTest(station=cited_name):
+                parsed = wt.parse_resolution_station(criteria)
+                self.assertIsNotNone(parsed, f"{cited_name} failed to parse")
+                icao = parsed["station_id"] or wt.resolve_station_id_from_name(
+                    parsed["station_name"]
+                )
+                self.assertEqual(icao, expected_icao)
+                self.assertTrue(
+                    icao in wt.STATION_ID_TO_NOAA
+                    or icao in wt.INTERNATIONAL_STATION_COORDS,
+                    f"{icao} has no coordinates, so the market would be skipped",
+                )
+
+    def test_aliases_only_point_at_stations_we_have_coords_for(self):
+        # Guard against the KDFW/KDAL failure mode: an alias that routes a
+        # market to an airport we cannot forecast is worse than no alias.
+        for name, icao in wt._STATION_NAME_ALIASES.items():
+            with self.subTest(alias=name):
+                self.assertTrue(
+                    icao in wt.STATION_ID_TO_NOAA
+                    or icao in wt.INTERNATIONAL_STATION_COORDS,
+                    f"alias {name!r} -> {icao} has no coordinates",
+                )
+
+
+class TestSkipReasonSplit(unittest.TestCase):
+    """Missing criteria and unreadable criteria are different failures."""
+
+    def test_empty_criteria_reports_missing(self):
+        for empty in ("", None, 123):
+            with self.subTest(value=empty):
+                result = wt.parse_resolution_station_result(empty)
+                self.assertIsNone(result["station"])
+                self.assertEqual(result["reason"], wt.SKIP_MISSING_CRITERIA)
+
+    def test_present_but_unreadable_reports_unparseable(self):
+        result = wt.parse_resolution_station_result(
+            "This market resolves on measurable precipitation per the NWS "
+            "Daily Climate Report (CLI) for the city's station."
+        )
+        self.assertIsNone(result["station"])
+        self.assertEqual(result["reason"], wt.SKIP_UNPARSEABLE_CRITERIA)
+
+    def test_a_good_parse_carries_no_reason(self):
+        self.assertIsNone(wt.parse_resolution_station_result(NEW_FORM_NYC)["reason"])
+
+
+class TestParseCoverageGuard(unittest.TestCase):
+    """The guard must actually discriminate — silent then, loud now."""
+
+    def _capture(self, ok, unreadable):
+        lines = []
+        wt._report_parse_coverage(ok, unreadable, lambda m, **kw: lines.append(m))
+        return "\n".join(lines)
+
+    def test_the_warning_survives_quiet_mode(self):
+        # A guard that --quiet swallows is not a guard.
+        seen = {}
+        wt._report_parse_coverage(0, 40, lambda m, **kw: seen.update(kw))
+        self.assertTrue(seen.get("force"), "coverage warning must pass force=True")
+
+    def test_fires_when_the_parser_falls_behind(self):
+        # The Aug-22 shape: criteria everywhere, readable nowhere.
+        out = self._capture(ok=0, unreadable=40)
+        self.assertIn("0/40", out)
+        self.assertIn("failing to look", out)
+
+    def test_silent_on_a_healthy_run(self):
+        self.assertEqual(self._capture(ok=40, unreadable=0), "")
+
+    def test_silent_on_ordinary_per_market_noise(self):
+        self.assertEqual(self._capture(ok=38, unreadable=2), "")
+
+    def test_silent_when_no_events_carried_criteria(self):
+        # Nothing to conclude from an empty scan; don't cry wolf.
+        self.assertEqual(self._capture(ok=0, unreadable=0), "")
+
+    def test_fires_at_the_threshold_boundary(self):
+        self.assertEqual(self._capture(ok=5, unreadable=5), "")      # 50% == floor
+        self.assertIn("4/10", self._capture(ok=4, unreadable=6))     # 40% < floor
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-weather-trader/tests/test_station_name_resolve.py
+++ b/skills/polymarket-weather-trader/tests/test_station_name_resolve.py
@@ -138,11 +138,19 @@ class TestResolveStationIdFromName(unittest.TestCase):
 class TestStationNameIndex(unittest.TestCase):
 
     def test_index_covers_all_stations(self):
-        # Every entry in both coord tables should produce a name-index entry.
-        expected_count = len(wt.STATION_ID_TO_NOAA) + len(
-            wt.INTERNATIONAL_STATION_COORDS
+        # Every entry in both coord tables should produce a name-index entry,
+        # plus one per alias for the names Polymarket cites differently.
+        expected_count = (
+            len(wt.STATION_ID_TO_NOAA)
+            + len(wt.INTERNATIONAL_STATION_COORDS)
+            + len(wt._STATION_NAME_ALIASES)
         )
         self.assertEqual(len(wt._STATION_NAME_INDEX), expected_count)
+        # Stronger than the count alone: name every station we claim to cover.
+        for table in (wt.STATION_ID_TO_NOAA, wt.INTERNATIONAL_STATION_COORDS):
+            for icao, info in table.items():
+                nm = wt._normalize_station_name(info.get("name", ""))
+                self.assertIn(nm, wt._STATION_NAME_INDEX, f"{icao} missing from index")
 
     def test_index_values_are_valid_icaos(self):
         all_icaos = (

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -403,10 +403,23 @@ _WUNDERGROUND_URL_RE = re.compile(
 # None on 100% of current criteria and the skill skipped every event. The
 # agency clause is optional and generic here so the next reword ("by NWS",
 # "by the National Weather Service") does not break us again.
+# Matched against whitespace-collapsed text (see _collapse_ws), so every gap
+# here is a literal single space. Writing them as \s+ instead lets the runs
+# overlap the lazy (.+?) capture, and the engine repartitions the whitespace
+# on every failure: "recorded at the" + 1600 spaces took 6.8s, growing ~8x per
+# doubling. Criteria text is authored upstream, so a single malformed market
+# would stall the whole scan. Keep the gaps literal.
 _STATION_PHRASE_RE = re.compile(
-    r"recorded(?:\s+by\s+[A-Za-z][A-Za-z .'-]*?)?\s+at\s+the\s+(.+?)\s+Station\b",
+    r"recorded(?: by [A-Za-z][A-Za-z .'-]{0,60}?)? at the (.{1,120}?) Station\b",
     re.IGNORECASE,
 )
+
+
+def _collapse_ws(text: str) -> str:
+    """Collapse whitespace runs to single spaces so the station phrase can be
+    matched with literal spaces. Criteria arrives with newlines and wrapped
+    indentation; station names themselves never contain a run."""
+    return " ".join(text.split())
 
 
 def parse_resolution_station(criteria: str) -> dict:
@@ -457,7 +470,7 @@ def parse_resolution_station_result(criteria: str) -> dict:
         station_id = url_match.group(1).upper()
 
     station_name = None
-    phrase_match = _STATION_PHRASE_RE.search(criteria)
+    phrase_match = _STATION_PHRASE_RE.search(_collapse_ws(criteria))
     if phrase_match:
         station_name = phrase_match.group(1).strip()
 

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -335,8 +335,26 @@ def _build_station_name_index() -> dict:
         nm = _normalize_station_name(info.get("name", ""))
         if nm:
             index[nm] = icao
+    for alias, icao in _STATION_NAME_ALIASES.items():
+        index[_normalize_station_name(alias)] = icao
     return index
 
+
+# Names Polymarket cites that don't normalize onto the name our coord tables
+# carry for the same airport. Verified against the live criteria corpus on
+# 2026-09-06: each alias is the exact station Polymarket names, mapped to the
+# ICAO we already hold coordinates for. Aliases only — never add an entry here
+# for an airport whose coordinates we don't have, because routing a market to
+# the wrong airport is silent and profitable-looking (the KDFW/KDAL Dallas
+# bug). A genuinely new station needs a coord-table entry, not an alias.
+_STATION_NAME_ALIASES = {
+    # ours: "Hartsfield-Jackson Atlanta International Airport"
+    "Hartsfield-Jackson International Airport": "KATL",
+    # ours: "Amsterdam Schiphol Airport"
+    "Amsterdam Airport Schiphol": "EHAM",
+    # ours: "Milan Malpensa Airport"
+    "Malpensa Intl Airport": "LIMC",
+}
 
 _STATION_NAME_INDEX = _build_station_name_index()
 
@@ -378,8 +396,15 @@ _WUNDERGROUND_URL_RE = re.compile(
     r"wunderground\.com/history/daily/[a-z]{2}/(?:[a-z0-9_\-]+/)+([A-Z]{4})\b",
     re.IGNORECASE,
 )
+# Polymarket reworded every weather-temperature market on 2026-08-22: the
+# Wunderground URL was dropped (resolution source moved to NOAA) and the
+# station phrase gained an agency clause — "recorded BY NOAA at the LaGuardia
+# Airport Station". The old pattern matched neither, so the parser returned
+# None on 100% of current criteria and the skill skipped every event. The
+# agency clause is optional and generic here so the next reword ("by NWS",
+# "by the National Weather Service") does not break us again.
 _STATION_PHRASE_RE = re.compile(
-    r"recorded at the (.+?) Station",
+    r"recorded(?:\s+by\s+[A-Za-z][A-Za-z .'-]*?)?\s+at\s+the\s+(.+?)\s+Station\b",
     re.IGNORECASE,
 )
 
@@ -390,9 +415,41 @@ def parse_resolution_station(criteria: str) -> dict:
     Returns a dict with `station_id` (4-letter ICAO, uppercase) and
     `station_name` (human-readable airport name), or None if the criteria
     doesn't reference a recognized weather station.
+
+    Use parse_resolution_station_result() when you need to tell "the market
+    carries no criteria at all" apart from "criteria is present but names a
+    station we can't read" — the two used to share one (wrong) log line.
+    """
+    result = parse_resolution_station_result(criteria)
+    return result["station"]
+
+
+# Why a market could not be routed to a station. Distinct values so the caller
+# can log the true cause instead of blaming a stale SDK for both.
+SKIP_MISSING_CRITERIA = "missing_criteria"
+SKIP_UNPARSEABLE_CRITERIA = "unparseable_criteria"
+
+# Fraction of criteria-bearing events we must be able to read a station out of
+# before a run is considered healthy. Below this, the parser has almost
+# certainly fallen behind Polymarket's wording rather than hit a few odd
+# markets. Polymarket reworded every weather market at once on 2026-08-22 and
+# our coverage went to zero, so the realistic failure is total, not gradual —
+# a half threshold separates it from normal per-market noise.
+MIN_STATION_PARSE_COVERAGE = 0.5
+
+
+def parse_resolution_station_result(criteria: str) -> dict:
+    """parse_resolution_station() plus the reason it failed.
+
+    Returns {"station": {...} | None, "reason": str | None}. `reason` is
+    SKIP_MISSING_CRITERIA when the market carries no criteria text, and
+    SKIP_UNPARSEABLE_CRITERIA when criteria is present but no station phrase
+    or Wunderground URL could be read out of it. That second case is the one
+    that means "our parser is behind Polymarket's wording", and it is the
+    signal the coverage guard counts.
     """
     if not criteria or not isinstance(criteria, str):
-        return None
+        return {"station": None, "reason": SKIP_MISSING_CRITERIA}
 
     station_id = None
     url_match = _WUNDERGROUND_URL_RE.search(criteria)
@@ -405,9 +462,12 @@ def parse_resolution_station(criteria: str) -> dict:
         station_name = phrase_match.group(1).strip()
 
     if not station_id and not station_name:
-        return None
+        return {"station": None, "reason": SKIP_UNPARSEABLE_CRITERIA}
 
-    return {"station_id": station_id, "station_name": station_name}
+    return {
+        "station": {"station_id": station_id, "station_name": station_name},
+        "reason": None,
+    }
 
 
 OPEN_METEO_BASE = "https://api.open-meteo.com/v1/forecast"
@@ -1475,6 +1535,14 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
     total_usd_spent = 0.0
     opportunities_found = 0
     skip_reasons = []
+    # Coverage guard: count how many events carried readable criteria vs how
+    # many carried criteria our parser could not read. A parser that has
+    # fallen behind Polymarket's wording fails silently — it throws nothing,
+    # retries nothing, and every downstream health metric stays green while
+    # the skill quietly stops entering. Counting it here, where the failure is
+    # known, is the only place it is cheap to see. See _report_parse_coverage.
+    station_parse_ok = 0
+    station_parse_unreadable = 0
     execution_errors = []
 
     for event_id, event_markets in events.items():
@@ -1507,11 +1575,19 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         # rather skip than trade against the wrong forecast (which is the
         # bug this code path replaces).
         sample_criteria = event_markets[0].get("resolution_criteria", "")
-        parsed = parse_resolution_station(sample_criteria)
+        parse_result = parse_resolution_station_result(sample_criteria)
+        parsed = parse_result["station"]
         if not parsed:
-            log(f"  ⏭️  Skipping — no resolution_criteria on market (need SDK ≥ 2026-05-03)")
-            skip_reasons.append("no resolution_criteria")
+            if parse_result["reason"] == SKIP_MISSING_CRITERIA:
+                log("  ⏭️  Skipping — market carries no resolution_criteria")
+                skip_reasons.append("missing resolution_criteria")
+            else:
+                station_parse_unreadable += 1
+                log("  ⏭️  Skipping — resolution_criteria present but no station "
+                    "could be read from it (parser may be behind Polymarket's wording)")
+                skip_reasons.append("unparseable resolution_criteria")
             continue
+        station_parse_ok += 1
 
         station_id = parsed.get("station_id")
         station_name = parsed.get("station_name") or station_id or "?"
@@ -1767,6 +1843,8 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         else:
             log(f"  ⏸️  Price ${price:.2f} above threshold ${ENTRY_THRESHOLD:.2f} - skip")
 
+    _report_parse_coverage(station_parse_ok, station_parse_unreadable, log)
+
     exits_found, exits_executed = check_exit_opportunities(dry_run, use_safeguards)
 
     log("\n" + "=" * 50)
@@ -1781,6 +1859,32 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
 
     if dry_run and show_summary:
         print("\n  [PAPER MODE - trades simulated with real prices]")
+
+
+def _report_parse_coverage(parsed_ok: int, unreadable: int, log) -> None:
+    """Shout when the station parser has stopped reading Polymarket's criteria.
+
+    Every other health signal this skill emits measures something going wrong
+    — a failed trade, a retry, an error rate. A parser that no longer matches
+    upstream wording produces none of those: it just skips every event and
+    reports a clean run. This is the one line that makes that visible.
+
+    `log` is passed in because the scan's logger is a closure over --quiet;
+    this warning must survive quiet mode, so it forces output.
+    """
+    considered = parsed_ok + unreadable
+    if not considered:
+        return
+    coverage = parsed_ok / considered
+    if coverage >= MIN_STATION_PARSE_COVERAGE:
+        return
+    log(
+        f"\n⚠️  Station parser read only {parsed_ok}/{considered} events "
+        f"({coverage:.0%}) that had resolution_criteria. Polymarket has most "
+        f"likely reworded its criteria and this skill needs a parser update — "
+        f"it is not finding no opportunities, it is failing to look.",
+        force=True,
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
## What broke

Polymarket changed every weather-temperature market's `resolution_criteria` on **2026-08-22**. Two things changed at once, and both parser patterns in `weather_trader.py` died the same day:

| | before 8/22 | after 8/22 |
|---|---|---|
| station phrase | `recorded at the LaGuardia Airport Station` | `recorded **by NOAA** at the LaGuardia Airport Station` |
| source link | `wunderground.com/history/daily/us/ny/…/KLGA` | **gone** — resolution source moved to NOAA |

`parse_resolution_station()` returned `None` on 100% of current criteria, so the skill skipped every event and entered nothing.

## Evidence

Measured against the live `markets` table, not the skill's own logs:

- **2,195** of 2,596 active weather-temperature markets carry the new wording; **84** keep the old; **0** have empty criteria
- the only names that still parsed were Taipei Songshan and Jinan — the residue of the old shape, and exactly the 3-in-100 the dogfood report saw
- month over month: July 17,663 old / 0 new → September 231 old / 5,079 new

The report's diagnosis was right and its framing was better than the log line: the message blamed a stale SDK for a market that had perfectly good criteria.

## Changes

1. **Station phrase tolerates a generic agency clause.** `recorded(?:\s+by\s+…)?\s+at\s+the\s+(.+?)\s+Station`, so `by NWS` or `by the National Weather Service` will not cost us another silent fortnight.
2. **Three name aliases** for stations Polymarket cites differently than our coordinate tables hold: `Hartsfield-Jackson International Airport`→KATL, `Amsterdam Airport Schiphol`→EHAM, `Malpensa Intl Airport`→LIMC. All **16 advertised locations** route again — the six US cities in `SIMMER_WEATHER_LOCATIONS` plus every international alias.
3. **Skip reasons split.** Missing criteria and unreadable criteria no longer share one message, and the false `need SDK ≥ 2026-05-03` claim is gone.
4. **Parse-coverage guard.** Under 50% station reads across a run, the skill says so loudly (surviving `--quiet`) instead of reporting a clean scan.

## Why the guard

Every health signal this skill emits measures something going *wrong* — a failed trade, a retry, an error rate. A parser that no longer matches upstream wording produces none of those. `skill_trading_health` has in fact flagged this skill `degraded` every night for weeks, but for negative median P&L, a retry loop, and `approvals_missing` — never the parser. Its `runtime` dimension reads `ok` on a **lifetime** trade counter, so a skill that goes quiet keeps a perfect error rate forever.

Aliases may only point at stations we already hold coordinates for, enforced by a test. Routing a market to an airport we cannot forecast is silent and profitable-looking — the KDFW/KDAL Dallas failure mode this code was written to avoid.

## Out of scope

Polymarket now lists **26 further stations** (Beijing, Shanghai, Singapore, Manila, Toronto, São Paulo, Austin, Houston Hobby and more). Those are cities this skill never supported. Each needs a verified ICAO and airport coordinates, so they land separately as a feature, not on a hotfix.

## Verification

```
56 passed, 25 subtests passed
```

- new `tests/test_resolution_criteria_reword.py` pins the new wording, the old wording, the reason split, alias-to-coordinate integrity, and the guard's threshold boundaries, using criteria strings copied verbatim from the live corpus
- **mutation-checked**: reverting only the regex fails 22 tests; restoring is byte-identical and returns to green
- writing the guard surfaced a real bug the tests caught — `log()` is a closure inside the scan function, so a module-level call would have raised `NameError` at runtime. It now takes the logger as an argument.
- `tests/test_station_name_resolve.py::test_index_covers_all_stations` asserted an exact index size that the aliases change. Updated to account for aliases **and** to additionally assert every coord-table station appears in the index — strictly stronger than the count alone.

Reported by the Grok Bot dogfood seat.