### PR TITLE
fix(backtest): resync replay fee realism gaps

### DIFF
--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ f23de362b27f
+# vendored from simmer_v3/replay/candles_service.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ f23de362b27f
+# vendored from simmer_v3/replay/duckdb_store.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ f23de362b27f
+# vendored from simmer_v3/replay/engine.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 
@@ -40,8 +40,10 @@ REALISM_GAPS = [
     "no queue position",
     "no latency",
     "no maker rebates (maker fills pay 0 fee, but the 20% rebate is not credited)",
-    "single blended base fee rate, not per-category (crypto/sports/other differ; "
-    "see _dev/reference/trading-economics.md)",
+    "single blended base fee rate, not per-category (crypto 0.07; sports, "
+    "economics, culture, weather, other/general 0.05; finance, politics, "
+    "mentions, tech 0.04; geopolitics 0.00; see "
+    "_dev/reference/trading-economics.md)",
     "trade-tape prices, not orderbook",
 ]
 

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ f23de362b27f
+# vendored from simmer_v3/replay/feeds/binance.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ f23de362b27f
+# vendored from simmer_v3/replay/harness.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ f23de362b27f
+# vendored from simmer_v3/replay/server.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ f23de362b27f
+# vendored from simmer_v3/replay/simstate.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ f23de362b27f
+# vendored from simmer_v3/replay/store.py @ 10853b3589e4
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 


### PR DESCRIPTION
Refs SIM-5065
Companion to SupaFund/simmer#2251.

## Summary

- Resync vendored replay modules from `SupaFund/simmer` SIM-5065 branch commit `10853b3589e4`
- Carries the updated `REALISM_GAPS` fee-bucket disclosure into `simmer-sdk`
- Clears the vendored replay-engine drift guard noted in AI review

## Verification

- `python3 scripts/sync_replay_engine.py --source /Users/simmer-ops/Documents/code/active/kozy/simmer --check`
- `python3 -m pytest tests/test_backtest_run.py tests/test_skills_replay_gate.py` (23 passed, 1 skipped)
