### PR TITLE
fix(sdk): paper dry_run must not mutate PaperPortfolio; LIVE warn gated on live=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 0.25.1 (2026-09-06)
 
 - **Paper `trade(dry_run=True)` no longer books paper inventory.** On a `live=False` client the dry run applied the fill to the in-memory portfolio before checking the flag, so a preview followed by the real paper trade on the same market double-booked shares and cost_basis, and paper expectancy drifted from what the strategy actually did. The dry run still settles any resolved paper positions first (as `get_positions()` does) and returns the same `TradeResult`; it just leaves the book alone. Live-venue dry_run already worked this way.
-- **`venue='polymarket'` with `live=False` no longer prints "LIVE trading with real funds".** The warning keyed off the venue string alone, so a paper client trading against real Polymarket prices announced itself as live. It now warns only when `live=True`. `venue='hyperliquid'` keeps a warning at `live=False` because `client.hyperliquid.place_order()` submits to mainnet without consulting `live`.
+- **`venue='polymarket'` with `live=False` no longer prints "LIVE trading with real funds".** The warning keyed off the venue string alone, so a paper client trading against real Polymarket prices announced itself as live. It now warns only when `live=True`.
+- **`client.hyperliquid` honours `live=False` and `readonly()`.** The HIP-4 adapter signs and submits locally, so nothing upstream stopped a paper or readonly client from placing a real Hyperliquid order — `trade()` went to paper, `client.hyperliquid.place_order()` went to mainnet. Reads (positions, balances, book) still work on such a client; `place_order`, `cancel_order`, and `approve_agent` now raise instead of submitting.
 
 ## 0.25.0 (2026-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.1 (2026-09-06)
+
+- **Paper `trade(dry_run=True)` no longer books paper inventory.** On a `live=False` client the dry run applied the fill to the in-memory portfolio before checking the flag, so a preview followed by the real paper trade on the same market double-booked shares and cost_basis, and paper expectancy drifted from what the strategy actually did. The dry run still settles any resolved paper positions first (as `get_positions()` does) and returns the same `TradeResult`; it just leaves the book alone. Live-venue dry_run already worked this way.
+- **`venue='polymarket'` with `live=False` no longer prints "LIVE trading with real funds".** The warning keyed off the venue string alone, so a paper client trading against real Polymarket prices announced itself as live. It now warns only when `live=True`. `venue='hyperliquid'` keeps a warning at `live=False` because `client.hyperliquid.place_order()` submits to mainnet without consulting `live`.
+
 ## 0.25.0 (2026-09-05)
 
 - **`simmer backtest` now charges fees by default, and its numbers will change.** The vendored replay engine was ~3 months behind the backend it is supposed to mirror while both reported `ENGINE_VERSION 0.1.1`, so the CLI and the server quietly disagreed for the same bundle. Re-vendored at engine **0.2.0**. Three user-visible consequences: (1) `--fee-rate` defaults to the engine's rate (currently `0.05`) instead of `0`, so every backtest now has cost drag — pass `--fee-rate 0` for the old behaviour; (2) fees use Polymarket's real shape, `notional x base x (1 - price)`, and resting limit fills that cross pay **0** as makers, where the old model charged a flat rate on notional; (3) every `config_hash` changes, so a re-run of a saved backtest will not match its stored report. Baselines now pay the same fee as the strategy's own fills and are derived from executed fills rather than logged decisions, so a limit order that never crossed no longer counts as a buy-and-hold entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.25.0"
+version = "0.25.1"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -372,6 +372,15 @@ class SimmerClient:
             )
         elif live:
             logger.warning("venue='%s' — LIVE trading with real funds.", venue)
+        elif venue == "hyperliquid":
+            # live=False routes trade() to paper, but the HIP-4 adapter
+            # (client.hyperliquid.place_order) signs and submits to Hyperliquid
+            # mainnet without consulting self.live. Warn until that is gated.
+            logger.warning(
+                "venue='hyperliquid' with live=False — trade() is paper, but "
+                "client.hyperliquid.place_order() signs and submits to "
+                "Hyperliquid mainnet regardless of live. Real funds."
+            )
         self._private_key: Optional[str] = None  # EVM private key (Polymarket)
         self._wallet_address: Optional[str] = None  # EVM wallet address
         self._wallet_linked: Optional[bool] = None  # Cached linking status
@@ -2410,7 +2419,9 @@ class SimmerClient:
                 the returned TradeResult.
             dry_run: Validate and price the trade without executing it. No money
                 moves and no order is signed or submitted. Use it to confirm the
-                exact fill count before committing size.
+                exact fill count before committing size. On a ``live=False``
+                client it prices the paper fill the same way and books nothing,
+                so a preview followed by the real paper trade applies one fill.
 
                 Two things it deliberately does NOT do, so don't lean on it for
                 either. It is **not a permission check** — the server skips
@@ -2809,10 +2820,14 @@ class SimmerClient:
         """
         import time as _time
 
-        # Auto-settle any resolved paper positions before trading.
-        # A dry run must not settle either — that would mutate the book.
-        if not dry_run:
-            self._settle_paper_positions()
+        # Auto-settle any resolved paper positions before trading. This runs on
+        # a dry run too: settlement is the book catching up with a market that
+        # already resolved, not the previewed order — get_positions() and
+        # get_total_pnl() settle on a pure read for the same reason. Skipping it
+        # priced the preview against a stale book, so a dry run reported
+        # "insufficient balance" for a buy that then succeeded, and reported a
+        # fill for a sell of a position that had already settled away.
+        self._settle_paper_positions()
 
         # Fetch current price from the venue
         try:

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -372,15 +372,6 @@ class SimmerClient:
             )
         elif live:
             logger.warning("venue='%s' — LIVE trading with real funds.", venue)
-        elif venue == "hyperliquid":
-            # live=False routes trade() to paper, but the HIP-4 adapter
-            # (client.hyperliquid.place_order) signs and submits to Hyperliquid
-            # mainnet without consulting self.live. Warn until that is gated.
-            logger.warning(
-                "venue='hyperliquid' with live=False — trade() is paper, but "
-                "client.hyperliquid.place_order() signs and submits to "
-                "Hyperliquid mainnet regardless of live. Real funds."
-            )
         self._private_key: Optional[str] = None  # EVM private key (Polymarket)
         self._wallet_address: Optional[str] = None  # EVM wallet address
         self._wallet_linked: Optional[bool] = None  # Cached linking status
@@ -782,7 +773,13 @@ class SimmerClient:
             ).lower() not in ("1", "true", "yes")
             main_address = os.environ.get("SIMMER_HYPERLIQUID_MAIN_ADDRESS") or None
             self._hyperliquid_venue = HyperliquidVenue(
-                signer, is_mainnet=is_mainnet, main_address=main_address
+                signer,
+                is_mainnet=is_mainnet,
+                main_address=main_address,
+                # live=False and readonly() must not move real funds. trade()
+                # honours both upstream; the adapter submits locally, so it
+                # carries the same gate itself.
+                submit_enabled=self.live and not self._readonly,
             )
         return self._hyperliquid_venue
 

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -360,15 +360,17 @@ class SimmerClient:
         # and defaults to "sim" (paper). NOTE: the TRADING_VENUE env var is
         # intentionally NOT read here — do not reintroduce a log that implies
         # an env var controls the venue. SIM construction is info-level so
-        # read-only reporting clients do not emit warning-level noise; live
-        # venues still warn because they can touch real funds.
+        # read-only reporting clients do not emit warning-level noise; a real
+        # venue warns only when live=True, because only then can it touch
+        # real funds. live=False + venue='polymarket' is paper against
+        # real-venue prices (issue #345).
         if venue == "sim":
             logger.info(
                 "venue='sim' — PAPER trading with virtual $SIM (no real money). "
                 "For LIVE trading pass venue='polymarket' per trade, or "
                 "SimmerClient.from_env(venue='polymarket')."
             )
-        else:
+        elif live:
             logger.warning("venue='%s' — LIVE trading with real funds.", venue)
         self._private_key: Optional[str] = None  # EVM private key (Polymarket)
         self._wallet_address: Optional[str] = None  # EVM wallet address
@@ -2552,7 +2554,8 @@ class SimmerClient:
         # Paper trading: simulate with real prices (no live API calls)
         if not self.live:
             return self._paper_trade(
-                market_id, side, amount, shares, action, effective_venue
+                market_id, side, amount, shares, action, effective_venue,
+                dry_run=dry_run,
             )
 
         # Position conflict checks (buy only — sells always allowed)
@@ -2793,17 +2796,23 @@ class SimmerClient:
     # conservative.  Overridden when the market returns ``spread_cents``.
     _POLY_PAPER_DEFAULT_HALF_SPREAD = 0.01
 
-    def _paper_trade(self, market_id, side, amount, shares, action, venue):
+    def _paper_trade(self, market_id, side, amount, shares, action, venue, dry_run=False):
         """Simulate a trade using real market prices.
 
         For Polymarket venues, models the CLOB bid-ask spread so paper P&L
         is closer to what a live FAK order would experience.  Buys fill at
         the ask (mid + half-spread), sells at the bid (mid - half-spread).
+
+        ``dry_run=True`` prices the fill and returns a TradeResult but does
+        not mutate PaperPortfolio — same invariant as live-venue dry_run,
+        which skips signing and the held-markets cache (issue #345).
         """
         import time as _time
 
-        # Auto-settle any resolved paper positions before trading
-        self._settle_paper_positions()
+        # Auto-settle any resolved paper positions before trading.
+        # A dry run must not settle either — that would mutate the book.
+        if not dry_run:
+            self._settle_paper_positions()
 
         # Fetch current price from the venue
         try:
@@ -2864,7 +2873,14 @@ class SimmerClient:
                 )
             cost = shares_filled * fill_price
 
-        self._paper_portfolio.log_trade(market_id, side, action, shares_filled, cost, fill_price, venue=venue)
+        # A dry run places nothing, so it must not book paper inventory.
+        # It used to: log_trade applied the fill, and the next real paper
+        # trade on the same market double-booked shares / cost_basis
+        # (Grok Bot dogfood, issue #345).
+        if not dry_run:
+            self._paper_portfolio.log_trade(
+                market_id, side, action, shares_filled, cost, fill_price, venue=venue
+            )
 
         # SIM-2238: route filled shares to shares_sold for paper sells; otherwise shares_bought
         is_sell_action = action == "sell"

--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -539,7 +539,10 @@ class SimmerClient:
             self._paper_portfolio = PaperPortfolio(starting_balance=starting_balance)
             logger.info(
                 "Paper trading mode enabled (venue=%s, balance=%.2f). "
-                "Trades will be simulated with real market data.",
+                "trade(), place_combo() and client.hyperliquid orders are "
+                "simulated with real market data. Wallet operations (approvals, "
+                "redemption, deposit-wallet activation, risk-alert processing) "
+                "still act on the real wallet.",
                 venue, starting_balance
             )
 

--- a/simmer_sdk/hyperliquid_venue.py
+++ b/simmer_sdk/hyperliquid_venue.py
@@ -64,14 +64,31 @@ class HyperliquidVenue:
         vault_address: Optional[str] = None,
         main_address: Optional[str] = None,
         timeout: float = DEFAULT_TIMEOUT,
+        submit_enabled: bool = True,
     ):
         self._signer = signer
+        # False for a paper (live=False) or readonly SimmerClient: reads still
+        # work, but any signed /exchange submission is refused. HL orders sign
+        # and submit locally, so nothing upstream can stop them otherwise.
+        self._submit_enabled = submit_enabled
         self.signer_address = signer.address
         self.address = main_address or signer.address
         self.is_mainnet = is_mainnet
         self.base_url = base_url or (MAINNET_API_URL if is_mainnet else TESTNET_API_URL)
         self.vault_address = vault_address
         self._timeout = timeout
+
+    def _require_submit(self) -> None:
+        # Checked before building or signing an action (no key work for a
+        # refused order, and no [hyperliquid] extra needed to refuse) and
+        # again in submit_action for callers that build actions elsewhere.
+        if not self._submit_enabled:
+            raise RuntimeError(
+                "Hyperliquid submission refused: this SimmerClient is live=False "
+                "(paper) or readonly, and Hyperliquid orders sign and submit "
+                "locally with real funds. Construct a live, non-readonly client "
+                "to place, cancel, or approve on Hyperliquid."
+            )
 
     # ---- transport -------------------------------------------------------
 
@@ -91,6 +108,7 @@ class HyperliquidVenue:
         action elsewhere but submits through this exact path, so there is one
         transport + error-handling implementation on the money path.
         """
+        self._require_submit()
         payload: Dict[str, Any] = {
             "action": action,
             "nonce": nonce,
@@ -135,6 +153,7 @@ class HyperliquidVenue:
         Returns the parsed ``/exchange`` response. On a resting order the
         ``oid`` is under ``response.data.statuses[i]``.
         """
+        self._require_submit()
         asset = outcome_asset_id(outcome_id, side)
         action = build_order_action(
             asset,
@@ -154,6 +173,7 @@ class HyperliquidVenue:
 
     def cancel_order(self, *, order_id: int, outcome_id: int, side: str = "yes") -> Dict[str, Any]:
         """Cancel a resting order by its venue order id."""
+        self._require_submit()
         asset = outcome_asset_id(outcome_id, side)
         action = build_cancel_action(asset, order_id)
         nonce = next_nonce(self.signer_address)
@@ -206,6 +226,7 @@ class HyperliquidVenue:
         main key). The agent key can place/cancel orders but cannot withdraw —
         the recommended bot-host setup (P0 finding Q3).
         """
+        self._require_submit()
         nonce = next_nonce(self.signer_address)
         action: Dict[str, Any] = {
             "type": "approveAgent",

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -118,6 +118,35 @@ def test_paper_real_venue_construction_does_not_warn_live(monkeypatch, caplog):
     assert not any("LIVE trading with real funds" in r.getMessage() for r in caplog.records)
 
 
+def test_paper_hyperliquid_construction_still_warns_real_funds(monkeypatch, caplog):
+    """venue='hyperliquid' + live=False still warns.
+
+    trade() goes to paper, but client.hyperliquid.place_order() signs and
+    submits to mainnet without consulting live, so this client can move real
+    funds and must not read as silent paper.
+    """
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("SIMMER_PRIVATE_KEY", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client = SimmerClient(
+            api_key="sk_live_test_hl_paper",
+            venue="hyperliquid",
+            live=False,
+        )
+
+    assert client.live is False
+    assert any(
+        "hyperliquid.place_order() signs and submits" in r.getMessage()
+        for r in caplog.records
+    )
+
+
 def test_from_env_raises_when_api_key_missing(monkeypatch):
     """from_env() raises RuntimeError with a dashboard pointer when SIMMER_API_KEY is unset."""
     monkeypatch.delenv("SIMMER_API_KEY", raising=False)

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -88,7 +88,34 @@ def test_live_venue_construction_still_warns_real_funds(monkeypatch, caplog):
         client = SimmerClient(api_key="sk_live_test_live", venue="polymarket")
 
     assert client.venue == "polymarket"
+    assert client.live is True
     assert any("LIVE trading with real funds" in r.getMessage() for r in caplog.records)
+
+
+def test_paper_real_venue_construction_does_not_warn_live(monkeypatch, caplog):
+    """venue='polymarket' + live=False is paper, not a live-funds warning.
+
+    The warn used to key off the venue string alone, so a paper client
+    printed ``LIVE trading with real funds`` (issue #345).
+    """
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("SIMMER_PRIVATE_KEY", raising=False)
+    monkeypatch.setattr(
+        "simmer_sdk.version_check.check_server_version_compatibility",
+        lambda *args, **kwargs: None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
+        client = SimmerClient(
+            api_key="sk_live_test_paper",
+            venue="polymarket",
+            live=False,
+        )
+
+    assert client.venue == "polymarket"
+    assert client.live is False
+    assert not any("LIVE trading with real funds" in r.getMessage() for r in caplog.records)
 
 
 def test_from_env_raises_when_api_key_missing(monkeypatch):

--- a/tests/test_client_constructors.py
+++ b/tests/test_client_constructors.py
@@ -118,35 +118,6 @@ def test_paper_real_venue_construction_does_not_warn_live(monkeypatch, caplog):
     assert not any("LIVE trading with real funds" in r.getMessage() for r in caplog.records)
 
 
-def test_paper_hyperliquid_construction_still_warns_real_funds(monkeypatch, caplog):
-    """venue='hyperliquid' + live=False still warns.
-
-    trade() goes to paper, but client.hyperliquid.place_order() signs and
-    submits to mainnet without consulting live, so this client can move real
-    funds and must not read as silent paper.
-    """
-    monkeypatch.delenv("OWS_WALLET", raising=False)
-    monkeypatch.delenv("WALLET_PRIVATE_KEY", raising=False)
-    monkeypatch.delenv("SIMMER_PRIVATE_KEY", raising=False)
-    monkeypatch.setattr(
-        "simmer_sdk.version_check.check_server_version_compatibility",
-        lambda *args, **kwargs: None,
-    )
-
-    with caplog.at_level(logging.WARNING, logger="simmer_sdk.client"):
-        client = SimmerClient(
-            api_key="sk_live_test_hl_paper",
-            venue="hyperliquid",
-            live=False,
-        )
-
-    assert client.live is False
-    assert any(
-        "hyperliquid.place_order() signs and submits" in r.getMessage()
-        for r in caplog.records
-    )
-
-
 def test_from_env_raises_when_api_key_missing(monkeypatch):
     """from_env() raises RuntimeError with a dashboard pointer when SIMMER_API_KEY is unset."""
     monkeypatch.delenv("SIMMER_API_KEY", raising=False)

--- a/tests/test_hyperliquid_client_integration.py
+++ b/tests/test_hyperliquid_client_integration.py
@@ -72,3 +72,56 @@ def test_unified_trade_hyperliquid_guarded(monkeypatch):
     c = SimmerClient(api_key="test", private_key=TEST_KEY)
     with pytest.raises(NotImplementedError, match="client.hyperliquid.place_order"):
         c.trade(market_id="m1", side="yes", amount=5.0, venue="hyperliquid")
+
+
+def _offline(monkeypatch, posts):
+    """Sign without the [hyperliquid] extra and record /exchange POSTs instead
+    of sending them, so the gate tests run in CI (which installs no extras)."""
+    import simmer_sdk.hyperliquid_signing as hs
+    import simmer_sdk.hyperliquid_venue as hv
+
+    monkeypatch.setattr(
+        hs.RawKeyHyperliquidSigner, "sign_l1_action", lambda self, *a, **k: {"r": "0x0"}
+    )
+    monkeypatch.setattr(hv, "build_order_action", lambda *a, **k: {"type": "order"})
+    monkeypatch.setattr(
+        hv.HyperliquidVenue, "_post",
+        lambda self, path, body: posts.append(path) or {"status": "ok", "response": {}},
+    )
+
+
+def test_paper_client_hyperliquid_refuses_submission(monkeypatch):
+    """live=False routes trade() to paper; the HL adapter signs and submits
+    locally, so it must carry the same gate or a paper client moves real funds."""
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    posts = []
+    _offline(monkeypatch, posts)
+    c = SimmerClient(api_key="test", private_key=TEST_KEY, live=False)
+    with pytest.raises(RuntimeError, match="live=False"):
+        c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
+    with pytest.raises(RuntimeError, match="live=False"):
+        c.hyperliquid.cancel_order(order_id=1, outcome_id=1)
+    assert posts == []
+
+
+def test_readonly_client_hyperliquid_refuses_submission(monkeypatch):
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    posts = []
+    _offline(monkeypatch, posts)
+    c = SimmerClient.readonly(api_key="test", private_key=TEST_KEY)
+    with pytest.raises(RuntimeError, match="readonly"):
+        c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
+    assert posts == []
+
+
+def test_live_client_hyperliquid_submits(monkeypatch):
+    """The gate must not catch the live client: submission reaches _post."""
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    posts = []
+    _offline(monkeypatch, posts)
+    c = SimmerClient(api_key="test", private_key=TEST_KEY)
+    c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
+    assert posts == ["/exchange"]

--- a/tests/test_hyperliquid_client_integration.py
+++ b/tests/test_hyperliquid_client_integration.py
@@ -74,54 +74,80 @@ def test_unified_trade_hyperliquid_guarded(monkeypatch):
         c.trade(market_id="m1", side="yes", amount=5.0, venue="hyperliquid")
 
 
-def _offline(monkeypatch, posts):
-    """Sign without the [hyperliquid] extra and record /exchange POSTs instead
-    of sending them, so the gate tests run in CI (which installs no extras)."""
+def _offline(monkeypatch, posts, signs):
+    """Sign without the [hyperliquid] extra and record /exchange and /info
+    POSTs instead of sending them, so the gate tests run in CI (which
+    installs no extras). ``signs`` records every signer call."""
     import simmer_sdk.hyperliquid_signing as hs
     import simmer_sdk.hyperliquid_venue as hv
 
     monkeypatch.setattr(
-        hs.RawKeyHyperliquidSigner, "sign_l1_action", lambda self, *a, **k: {"r": "0x0"}
+        hs.RawKeyHyperliquidSigner, "sign_l1_action",
+        lambda self, *a, **k: signs.append("l1") or {"r": "0x0"},
+    )
+    monkeypatch.setattr(
+        hs.RawKeyHyperliquidSigner, "sign_user_action",
+        lambda self, *a, **k: signs.append("user") or {"r": "0x0"},
     )
     monkeypatch.setattr(hv, "build_order_action", lambda *a, **k: {"type": "order"})
     monkeypatch.setattr(
         hv.HyperliquidVenue, "_post",
-        lambda self, path, body: posts.append(path) or {"status": "ok", "response": {}},
+        lambda self, path, body: posts.append(path) or {"status": "ok", "response": {}, "assetPositions": [], "marginSummary": {}},
     )
+
+
+def _gated_client(monkeypatch, posts, signs, **kwargs):
+    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
+    monkeypatch.delenv("OWS_WALLET", raising=False)
+    _offline(monkeypatch, posts, signs)
+    if kwargs.pop("readonly", False):
+        return SimmerClient.readonly(api_key="test", private_key=TEST_KEY, **kwargs)
+    return SimmerClient(api_key="test", private_key=TEST_KEY, **kwargs)
+
+
+def _assert_refuses_every_submission(c, posts, signs, match):
+    """Every signed path refuses before the signer runs and before any POST;
+    submit_action refuses on its own for callers that build actions elsewhere."""
+    with pytest.raises(RuntimeError, match=match):
+        c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
+    with pytest.raises(RuntimeError, match=match):
+        c.hyperliquid.cancel_order(order_id=1, outcome_id=1)
+    with pytest.raises(RuntimeError, match=match):
+        c.hyperliquid.approve_agent("0x" + "ab" * 20)
+    with pytest.raises(RuntimeError, match=match):
+        c.hyperliquid.submit_action({"type": "order"}, {"r": "0x0"}, 1)
+    assert posts == []
+    assert signs == []
 
 
 def test_paper_client_hyperliquid_refuses_submission(monkeypatch):
     """live=False routes trade() to paper; the HL adapter signs and submits
     locally, so it must carry the same gate or a paper client moves real funds."""
-    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
-    monkeypatch.delenv("OWS_WALLET", raising=False)
-    posts = []
-    _offline(monkeypatch, posts)
-    c = SimmerClient(api_key="test", private_key=TEST_KEY, live=False)
-    with pytest.raises(RuntimeError, match="live=False"):
-        c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
-    with pytest.raises(RuntimeError, match="live=False"):
-        c.hyperliquid.cancel_order(order_id=1, outcome_id=1)
-    assert posts == []
+    posts, signs = [], []
+    c = _gated_client(monkeypatch, posts, signs, live=False)
+    _assert_refuses_every_submission(c, posts, signs, match="live=False")
 
 
 def test_readonly_client_hyperliquid_refuses_submission(monkeypatch):
-    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
-    monkeypatch.delenv("OWS_WALLET", raising=False)
-    posts = []
-    _offline(monkeypatch, posts)
-    c = SimmerClient.readonly(api_key="test", private_key=TEST_KEY)
-    with pytest.raises(RuntimeError, match="readonly"):
-        c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
-    assert posts == []
+    posts, signs = [], []
+    c = _gated_client(monkeypatch, posts, signs, readonly=True)
+    _assert_refuses_every_submission(c, posts, signs, match="readonly")
+
+
+def test_paper_client_hyperliquid_reads_still_work(monkeypatch):
+    """The gate is on submission only: a paper client can still read HL state."""
+    posts, signs = [], []
+    c = _gated_client(monkeypatch, posts, signs, live=False)
+    c.hyperliquid.get_positions()
+    c.hyperliquid.get_balances()
+    assert posts == ["/info", "/info"]
+    assert signs == []
 
 
 def test_live_client_hyperliquid_submits(monkeypatch):
-    """The gate must not catch the live client: submission reaches _post."""
-    monkeypatch.setenv("WALLET_PRIVATE_KEY", TEST_KEY)
-    monkeypatch.delenv("OWS_WALLET", raising=False)
-    posts = []
-    _offline(monkeypatch, posts)
-    c = SimmerClient(api_key="test", private_key=TEST_KEY)
+    """The gate must not catch the live client: submission signs and reaches /exchange."""
+    posts, signs = [], []
+    c = _gated_client(monkeypatch, posts, signs)
     c.hyperliquid.place_order(size=1.0, limit_px=0.5, is_buy=True, outcome_id=1)
     assert posts == ["/exchange"]
+    assert signs == ["l1"]

--- a/tests/test_paper_dry_run.py
+++ b/tests/test_paper_dry_run.py
@@ -14,20 +14,31 @@ from simmer_sdk.client import SimmerClient
 from simmer_sdk.paper import PaperPortfolio
 
 
-def _paper_client(starting_balance: float = 10_000.0) -> SimmerClient:
+_OPEN_MARKET = {
+    "question": "Will NYC hit 90F?",
+    "external_price_yes": 0.50,
+    "current_probability": 0.50,
+    "status": "active",
+}
+_RESOLVED_YES_MARKET = {
+    "question": "Resolved YES",
+    "external_price_yes": 1.0,
+    "current_probability": 1.0,
+    "status": "resolved",
+    "outcome": "yes",
+}
+
+
+def _paper_client(starting_balance: float = 10_000.0, markets=None) -> SimmerClient:
     client = SimmerClient.__new__(SimmerClient)
     client._readonly = False
     client.live = False
     client.venue = "polymarket"
     client._paper_portfolio = PaperPortfolio(starting_balance=starting_balance)
-    client.get_market_context = MagicMock(return_value={
-        "market": {
-            "question": "Will NYC hit 90F?",
-            "external_price_yes": 0.50,
-            "current_probability": 0.50,
-            "status": "active",
-        }
-    })
+    markets = markets or {"m1": _OPEN_MARKET}
+    client.get_market_context = MagicMock(
+        side_effect=lambda market_id, *a, **k: {"market": markets[market_id]}
+    )
     return client
 
 
@@ -65,3 +76,46 @@ def test_paper_trade_after_dry_run_books_once():
     # TradeResult rounds shares_bought to 6 decimals; the book stores raw.
     assert summary["positions"]["m1"]["shares_yes"] == pytest.approx(1.0 / 0.51)
     assert placed.shares_bought == pytest.approx(1.0 / 0.51, abs=1e-6)
+
+
+def _client_with_resolved_position() -> SimmerClient:
+    """Balance 50 and 100 YES shares of a market that has since resolved YES."""
+    client = _paper_client(
+        starting_balance=100.0,
+        markets={"m1": _RESOLVED_YES_MARKET, "m2": _OPEN_MARKET},
+    )
+    client._paper_portfolio.log_trade("m1", "yes", "buy", 100.0, 50.0, 0.50, venue="polymarket")
+    assert client._paper_portfolio.balance == 50.0
+    return client
+
+
+def test_paper_dry_run_settles_before_pricing_a_buy():
+    """A dry run must see the same book the real trade would.
+
+    Settlement is the book catching up with a resolved market, not the
+    previewed order. With it skipped, the preview said "insufficient
+    balance" for a buy that then succeeded once settlement credited the win.
+    """
+    client = _client_with_resolved_position()
+
+    preview = client.trade("m2", "yes", amount=80.0, venue="polymarket", dry_run=True)
+    placed = client.trade("m2", "yes", amount=80.0, venue="polymarket")
+
+    assert preview.success, preview.error
+    assert placed.success, placed.error
+    # 50 + 100 settlement - 80 buy; the dry run itself booked nothing.
+    assert client._paper_portfolio.balance == 70.0
+    assert client._paper_portfolio.summary()["positions"]["m2"]["cost_basis"] == 80.0
+
+
+def test_paper_dry_run_sell_of_settled_position_matches_real_sell():
+    """A dry run must not report a fill on shares settlement already removed."""
+    client = _client_with_resolved_position()
+
+    preview = client.trade("m1", "yes", shares=100.0, action="sell", venue="polymarket", dry_run=True)
+    placed = client.trade("m1", "yes", shares=100.0, action="sell", venue="polymarket")
+
+    assert not preview.success
+    assert not placed.success
+    assert preview.error == placed.error
+    assert "No paper position to sell" in preview.error

--- a/tests/test_paper_dry_run.py
+++ b/tests/test_paper_dry_run.py
@@ -1,0 +1,66 @@
+"""Paper ``trade(dry_run=True)`` must not mutate PaperPortfolio.
+
+Live-venue dry_run already skips apply (no signed order, no held-markets
+cache write). Paper used to call ``log_trade`` before checking dry_run, so
+a preview then a real paper fill on the same market double-booked shares
+and cost_basis (Grok Bot dogfood, issue #345).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from simmer_sdk.client import SimmerClient
+from simmer_sdk.paper import PaperPortfolio
+
+
+def _paper_client(starting_balance: float = 10_000.0) -> SimmerClient:
+    client = SimmerClient.__new__(SimmerClient)
+    client._readonly = False
+    client.live = False
+    client.venue = "polymarket"
+    client._paper_portfolio = PaperPortfolio(starting_balance=starting_balance)
+    client.get_market_context = MagicMock(return_value={
+        "market": {
+            "question": "Will NYC hit 90F?",
+            "external_price_yes": 0.50,
+            "current_probability": 0.50,
+            "status": "active",
+        }
+    })
+    return client
+
+
+def test_paper_dry_run_leaves_portfolio_unchanged():
+    client = _paper_client()
+    before = client._paper_portfolio.summary()
+
+    result = client.trade("m1", "yes", amount=1.0, venue="polymarket", dry_run=True)
+
+    after = client._paper_portfolio.summary()
+    assert result.success
+    assert result.simulated
+    assert result.cost == 1.0
+    assert result.shares_bought > 0
+    assert after == before
+    assert after["balance"] == 10_000.0
+    assert after["open_positions"] == 0
+    assert after["positions"] == {}
+
+
+def test_paper_trade_after_dry_run_books_once():
+    """Preview then place must apply a single fill, not stack two."""
+    client = _paper_client()
+
+    preview = client.trade("m1", "yes", amount=1.0, venue="polymarket", dry_run=True)
+    placed = client.trade("m1", "yes", amount=1.0, venue="polymarket")
+
+    summary = client._paper_portfolio.summary()
+    assert preview.success
+    assert placed.success
+    assert summary["balance"] == 9_999.0
+    assert summary["open_positions"] == 1
+    assert summary["positions"]["m1"]["cost_basis"] == 1.0
+    assert summary["positions"]["m1"]["shares_yes"] == placed.shares_bought
+    # Mid 0.50 + 1¢ half-spread → fill 0.51, so ~1.96 shares, not ~3.92.
+    assert placed.shares_bought == pytest.approx(1.0 / 0.51)

--- a/tests/test_paper_dry_run.py
+++ b/tests/test_paper_dry_run.py
@@ -61,6 +61,7 @@ def test_paper_trade_after_dry_run_books_once():
     assert summary["balance"] == 9_999.0
     assert summary["open_positions"] == 1
     assert summary["positions"]["m1"]["cost_basis"] == 1.0
-    assert summary["positions"]["m1"]["shares_yes"] == placed.shares_bought
     # Mid 0.50 + 1¢ half-spread → fill 0.51, so ~1.96 shares, not ~3.92.
-    assert placed.shares_bought == pytest.approx(1.0 / 0.51)
+    # TradeResult rounds shares_bought to 6 decimals; the book stores raw.
+    assert summary["positions"]["m1"]["shares_yes"] == pytest.approx(1.0 / 0.51)
+    assert placed.shares_bought == pytest.approx(1.0 / 0.51, abs=1e-6)


### PR DESCRIPTION
## Summary
Fixes #345

- Paper `trade(..., dry_run=True)` no longer applies fills to `PaperPortfolio` (mirrors the live dry_run invariant). It still settles resolved paper positions first, as `get_positions()` does, so the preview sees the same book the real trade would.
- LIVE warning only when `live=True` and venue is not `sim`.
- `client.hyperliquid` honours `live=False` and `readonly()`: `place_order`, `cancel_order`, `approve_agent` refuse before signing; reads still work. Before, the adapter signed and submitted to mainnet regardless of `live`, and removing the polymarket warn would have left that path with no signal at all.
- Bumped to 0.25.1 with a CHANGELOG entry so `publish-packages` ships it.
- `trade()` dry_run docstring states the paper invariant.

## Review trail
- a75e5b5 gated `_settle_paper_positions()` on `not dry_run`. Reproduced both directions with a held position that had resolved since the last call: dry-run buy said "Insufficient paper balance (50 < 80)" while the real buy succeeded (settlement credited first); dry-run sell reported a fill on shares the real sell then rejected. Fixed in d96c398 by settling unconditionally; only `log_trade` stays gated.
- d96c398 warned on `venue='hyperliquid'` + `live=False`, but `client.hyperliquid` is reachable on any venue with a signer. Replaced with the adapter gate above.

## Tests
- `tests/test_paper_dry_run.py` — dry_run leaves portfolio unchanged; preview-then-place books once; preview/place parity on a resolved position (buy + sell)
- `tests/test_client_constructors.py` — LIVE warn on default-live polymarket; silent on `live=False` polymarket
- `tests/test_hyperliquid_client_integration.py` — paper and readonly clients refuse HL submission with no POST; live client reaches `/exchange`. Run without the `[hyperliquid]` extra so CI executes them.

Every new test fails on the code it guards (mutation-checked). Full suite: 730 passed, 9 skipped. Codex review: P2 (submit_action test hole) fixed in 47bea11; P1 is #347.

## Follow-up
- #347 — `live=False` does not gate wallet ops (`get_briefing()` cancels real orders while its exit sells on paper; approvals/redeem/DW activation ignore `live`). Pre-existing; found by Codex on this PR. The paper-mode log in this PR now states what `live=False` covers.

## Merge notes
- `Publish Lag Check` is red by design until 0.25.1 is on PyPI (not a required check).
- #343 also claims 0.25.1; whichever merges second folds its CHANGELOG entry under the same heading, then publish 0.25.1 once.
