### PR TITLE
Send skill package version on trades

### DIFF
--- a/simmer_sdk/client.py
+++ b/simmer_sdk/client.py
@@ -2368,6 +2368,7 @@ class SimmerClient:
         allow_rebuy: bool = False,
         signal_data: Optional[dict] = None,
         *,
+        skill_version: Optional[str] = None,
         include_hints: bool = False,
         dry_run: bool = False,
     ) -> TradeResult:
@@ -2408,6 +2409,8 @@ class SimmerClient:
                 Used to track which strategy opened each position.
             skill_slug: Optional skill slug for volume attribution (e.g., "polymarket-weather-trader").
                 Matches the ClawHub slug. Used by Simmer to track skill-level trading volume.
+            skill_version: Optional skill package version for adoption attribution.
+                When omitted, the SDK sends the version auto-detected from the caller's SKILL.md.
             allow_rebuy: If False (default), skip buying a market you already hold a
                 position on (same source). Set True for DCA or averaging-in strategies.
             signal_data: Optional structured signal data for backtest replay.
@@ -2626,8 +2629,16 @@ class SimmerClient:
             payload["reasoning"] = reasoning
         if source:
             payload["source"] = source
-        if skill_slug:
-            payload["skill_slug"] = skill_slug
+        auto_skill_slug = getattr(self, "_skill_slug", None)
+        auto_skill_version = getattr(self, "_skill_version", None)
+        effective_skill_slug = skill_slug or auto_skill_slug
+        effective_skill_version = skill_version
+        if effective_skill_version is None and effective_skill_slug == auto_skill_slug:
+            effective_skill_version = auto_skill_version
+        if effective_skill_slug:
+            payload["skill_slug"] = effective_skill_slug
+        if effective_skill_version:
+            payload["skill_version"] = effective_skill_version
         if signal_data:
             payload["signal_data"] = signal_data
         if price is not None:

--- a/tests/test_fast_markets_status_and_dry_run.py
+++ b/tests/test_fast_markets_status_and_dry_run.py
@@ -81,6 +81,37 @@ def test_dry_run_absent_from_payload_by_default():
     assert "dry_run" not in client._request.call_args.kwargs["json"]
 
 
+def test_auto_detected_skill_slug_and_version_are_forwarded():
+    client = _client(_skill_slug="polymarket-fast-loop", _skill_version="1.7.3")
+    client._request = MagicMock(return_value={"success": True})
+    client._get_held_markets = MagicMock(return_value={})
+
+    client.trade("mkt-1", "yes", amount=5.0, venue="polymarket")
+
+    payload = client._request.call_args.kwargs["json"]
+    assert payload["skill_slug"] == "polymarket-fast-loop"
+    assert payload["skill_version"] == "1.7.3"
+
+
+def test_explicit_skill_slug_and_version_are_forwarded():
+    client = _client(_skill_slug="polymarket-fast-loop", _skill_version="1.7.3")
+    client._request = MagicMock(return_value={"success": True})
+    client._get_held_markets = MagicMock(return_value={})
+
+    client.trade(
+        "mkt-1",
+        "yes",
+        amount=5.0,
+        venue="polymarket",
+        skill_slug="polymarket-mert-sniper",
+        skill_version="2.4.5",
+    )
+
+    payload = client._request.call_args.kwargs["json"]
+    assert payload["skill_slug"] == "polymarket-mert-sniper"
+    assert payload["skill_version"] == "2.4.5"
+
+
 def test_dry_run_does_not_sign_locally():
     """With a signing key configured, a dry run must skip _build_signed_order.
 


### PR DESCRIPTION
## Summary
- include self-reported skill_version in SDK trade payloads alongside skill_slug
- default skill_version from parsed SKILL.md metadata when using the auto-detected skill_slug
- keep explicit caller-provided skill_slug/skill_version overrides available

## Verification
- python3.11 -m pytest tests/test_fast_markets_status_and_dry_run.py -q

Pairs with SupaFund/simmer#2272.

Closes SIM-5071