### PR TITLE
fix(weather-trader): min-entry floor + env-ify hours-to-resolve (#349)

### DIFF
--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.23.7] - 2026-09-08
+
+### Added
+- `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off). Rejects entries below this mid so a raised `ENTRY_THRESHOLD` (upper bound only) cannot buy lottery tickets. Same entry-price check as before; this is the missing floor.
+- `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default `2`). Env override of the hardcoded time-decay constant inside `check_context_safeguards`. No new gate, no calendar-day skip.
+
+### Docs
+- `ENTRY_THRESHOLD` is documented as an upper bound only. Raising it above the `0.45` exit default will self-exit unless `EXIT_THRESHOLD` is raised too.
+
 ## [1.23.6] - 2026-09-06
 
 ### Fixed

--- a/skills/polymarket-weather-trader/CHANGELOG.md
+++ b/skills/polymarket-weather-trader/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 - `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off). Rejects entries below this mid so a raised `ENTRY_THRESHOLD` (upper bound only) cannot buy lottery tickets. Same entry-price check as before; this is the missing floor.
-- `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default `2`). Env override of the hardcoded time-decay constant inside `check_context_safeguards`. No new gate, no calendar-day skip.
+- `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default `2`). Env override of the hardcoded time-decay constant inside `check_context_safeguards`. Entry-only: exits keep the original 2h floor. No new gate, no calendar-day skip.
 
 ### Docs
 - `ENTRY_THRESHOLD` is documented as an upper bound only. Raising it above the `0.45` exit default will self-exit unless `EXIT_THRESHOLD` is raised too.

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: polymarket-weather-trader
 description: Trade Polymarket weather markets using NOAA (US) and Open-Meteo (international) forecasts via Simmer API. Inspired by gopfan2's weather trading approach. Use when user wants to trade temperature markets, automate weather bets, check forecasts, or run weather-based strategies.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.23.6"
+  version: "1.23.7"
   displayName: Polymarket Weather Trader
   difficulty: beginner
   attribution: Strategy inspired by gopfan2 (public Polymarket trader — approach referenced, not endorsed).
@@ -26,8 +26,8 @@ This skill executes real-money trades on Polymarket only when the `--live` flag 
 - **Per-trade cap.** `SIMMER_WEATHER_MAX_POSITION_USD` defaults to `$2.00` per trade. Configurable via env var, capped at the user's dashboard-set platform per-trade limit.
 - **Daily caps.** Platform-level daily caps apply (max trades/day, max USD/day). Set at [simmer.markets/dashboard](https://simmer.markets/dashboard?ref=sdk-skill&utm_campaign=sdk-skill) → SDK settings.
 - **Auto stop-loss is ON by default.** Server-side risk monitor watches every buy. Threshold is configurable per user at simmer.markets/dashboard → Settings → Auto Risk Monitor. **It cannot protect against gap-resolution, though:** weather temperature buckets jump straight to about 0 at resolution rather than decaying through your stop, so a percentage stop has no price to trigger on and no liquidity to exit into. Size for the full loss, not for the stop. See [DISCLAIMER.md](./DISCLAIMER.md).
-- **Strategy-side safeguards.** Beyond platform risk monitors, this skill checks flip-flop, slippage (`SIMMER_WEATHER_SLIPPAGE_MAX`, default 15%), time-decay, and resolved-market status before every order. Disable only with `--no-safeguards` (not recommended).
-- **Reversibility.** Open positions exit automatically when price > `SIMMER_WEATHER_EXIT_THRESHOLD` (default `0.45`), or via `client.cancel_order()` / a manual sell.
+- **Strategy-side safeguards.** Beyond platform risk monitors, this skill checks flip-flop, slippage (`SIMMER_WEATHER_SLIPPAGE_MAX`, default 15%), time-decay (`SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE`, default 2h), and resolved-market status before every order. Disable only with `--no-safeguards` (not recommended).
+- **Reversibility.** Open positions exit automatically when price > `SIMMER_WEATHER_EXIT_THRESHOLD` (default `0.45`), or via `client.cancel_order()` / a manual sell. `ENTRY_THRESHOLD` is an **upper** bound (buy *below*). If you raise it above the exit default (e.g. entry `0.50` vs exit `0.45`), the skill will try to sell the same position on the next cycle — raise `EXIT_THRESHOLD` too, or own exits yourself.
 
 If anything above isn't clear, stop and ask the user before passing `--live`.
 
@@ -49,6 +49,11 @@ Use this skill when the user wants to:
 - Buy low on weather predictions
 - Check their weather trading positions
 - Configure trading thresholds or locations
+
+## What's New in v1.23.7
+
+- **Min entry price.** `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off) rejects lottery-ticket mids below the floor. `SIMMER_WEATHER_ENTRY_THRESHOLD` remains an **upper** bound only (buy when price is below it).
+- **Hours-to-resolve is now an env knob.** `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` overrides the previous hardcoded 2h time-decay safeguard. Same check, same `check_context_safeguards` path — raise it (e.g. `24`) to skip resolve-day entries.
 
 ## What's New in v1.23.3
 
@@ -88,8 +93,10 @@ Then `pip install --upgrade simmer-sdk` (>=0.13.0) and configure tunables below.
 | Setting | Environment Variable | Default | Description |
 |---------|---------------------|---------|-------------|
 | Trading venue | `TRADING_VENUE` | polymarket | Venue to trade on. Set `sim` for paper trading. |
-| Entry threshold | `SIMMER_WEATHER_ENTRY_THRESHOLD` | 0.15 | Buy when price below this |
-| Exit threshold | `SIMMER_WEATHER_EXIT_THRESHOLD` | 0.45 | Sell when price above this |
+| Entry threshold | `SIMMER_WEATHER_ENTRY_THRESHOLD` | 0.15 | **Upper** bound — buy when price is *below* this |
+| Min entry price | `SIMMER_WEATHER_MIN_ENTRY_PRICE` | 0 | **Lower** bound — skip lottery tickets below this (`0` = off). Dogfood sets `0.15`. |
+| Min hours to resolve | `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` | 2 | Skip if market resolves in fewer than this many hours |
+| Exit threshold | `SIMMER_WEATHER_EXIT_THRESHOLD` | 0.45 | Sell when price above this. Raise this if you raise entry above `0.45`, or the skill will self-exit. |
 | Max position | `SIMMER_WEATHER_MAX_POSITION_USD` | 2.00 | Maximum USD per trade |
 | Max trades/run | `SIMMER_WEATHER_MAX_TRADES_PER_RUN` | 5 | Maximum trades per scan cycle |
 | Locations | `SIMMER_WEATHER_LOCATIONS` | NYC | Comma-separated cities (NYC, Chicago, Seattle, Atlanta, Dallas, Miami) |
@@ -179,7 +186,7 @@ Each cycle the script:
 5. Finds the temperature bucket that matches the forecast
 6. **Safeguards**: Checks context for flip-flop warnings, slippage, time decay
 7. **Trend Detection**: Looks for recent price drops (stronger buy signal)
-8. **Entry**: If bucket price < threshold and safeguards pass → BUY
+8. **Entry**: If min-entry ≤ bucket price < entry threshold and safeguards pass → BUY
 9. **Exit**: Checks open positions, sells if price > exit threshold
 10. **Tagging**: All trades tagged with `sdk:weather` for tracking
 
@@ -206,11 +213,13 @@ position_size = base_size × clamp(target_vol / realized_vol, min_alloc, max_lev
 
 Before trading, the skill checks:
 - **Flip-flop warning**: Skips if you've been reversing too much
-- **Slippage**: Skips if estimated slippage > 15% (tunable)
-- **Time decay**: Skips if market resolves in < 2 hours
+- **Slippage**: Skips if estimated slippage > 15% (tunable via `SIMMER_WEATHER_SLIPPAGE_MAX`)
+- **Time decay**: Skips if market resolves in < `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` hours (default 2)
 - **Market status**: Skips if market already resolved
 
-Disable with `--no-safeguards` (not recommended).
+`SIMMER_WEATHER_MIN_ENTRY_PRICE` (default 0 = off) is the other side of the entry-price check, not this list — `--no-safeguards` does not disable it.
+
+Disable the flip-flop / slippage / time-decay / resolved checks with `--no-safeguards` (not recommended).
 
 ## Source Tagging
 
@@ -225,7 +234,9 @@ All trades are tagged with `source: "sdk:weather"`. This means:
 
 **"Slippage too high"** — market is illiquid; reduce position size or skip.
 
-**"Resolves in Xh - too soon"** — market resolving soon, risk is elevated.
+**"Resolves in Xh - too soon"** — market resolving sooner than `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default 2h). Raise the env to skip resolve-day entries.
+
+**"Price $X.XX below min entry"** — mid is below `SIMMER_WEATHER_MIN_ENTRY_PRICE`. Lottery-ticket floor; default is off (`0`).
 
 **"No weather markets found"** — weather markets may not be active (seasonal).
 

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -53,7 +53,7 @@ Use this skill when the user wants to:
 ## What's New in v1.23.7
 
 - **Min entry price.** `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off) rejects lottery-ticket mids below the floor. `SIMMER_WEATHER_ENTRY_THRESHOLD` remains an **upper** bound only (buy when price is below it).
-- **Hours-to-resolve is now an env knob.** `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` overrides the previous hardcoded 2h time-decay safeguard. Same check, same `check_context_safeguards` path — raise it (e.g. `24`) to skip resolve-day entries.
+- **Hours-to-resolve is now an env knob.** `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` overrides the previous hardcoded 2h time-decay safeguard. Same check, same `check_context_safeguards` path — raise it (e.g. `24`) to skip resolve-day entries. That path also runs on exits, so `24` will skip resolve-day sells unless you pass `--no-safeguards` or flatten elsewhere.
 
 ## What's New in v1.23.3
 
@@ -95,7 +95,7 @@ Then `pip install --upgrade simmer-sdk` (>=0.13.0) and configure tunables below.
 | Trading venue | `TRADING_VENUE` | polymarket | Venue to trade on. Set `sim` for paper trading. |
 | Entry threshold | `SIMMER_WEATHER_ENTRY_THRESHOLD` | 0.15 | **Upper** bound — buy when price is *below* this |
 | Min entry price | `SIMMER_WEATHER_MIN_ENTRY_PRICE` | 0 | **Lower** bound — skip lottery tickets below this (`0` = off). Dogfood sets `0.15`. |
-| Min hours to resolve | `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` | 2 | Skip if market resolves in fewer than this many hours |
+| Min hours to resolve | `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` | 2 | Skip if market resolves in fewer than this many hours. Same path runs on exits — raising this (e.g. `24`) also skips resolve-day sells. |
 | Exit threshold | `SIMMER_WEATHER_EXIT_THRESHOLD` | 0.45 | Sell when price above this. Raise this if you raise entry above `0.45`, or the skill will self-exit. |
 | Max position | `SIMMER_WEATHER_MAX_POSITION_USD` | 2.00 | Maximum USD per trade |
 | Max trades/run | `SIMMER_WEATHER_MAX_TRADES_PER_RUN` | 5 | Maximum trades per scan cycle |

--- a/skills/polymarket-weather-trader/SKILL.md
+++ b/skills/polymarket-weather-trader/SKILL.md
@@ -53,7 +53,7 @@ Use this skill when the user wants to:
 ## What's New in v1.23.7
 
 - **Min entry price.** `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off) rejects lottery-ticket mids below the floor. `SIMMER_WEATHER_ENTRY_THRESHOLD` remains an **upper** bound only (buy when price is below it).
-- **Hours-to-resolve is now an env knob.** `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` overrides the previous hardcoded 2h time-decay safeguard. Same check, same `check_context_safeguards` path — raise it (e.g. `24`) to skip resolve-day entries. That path also runs on exits, so `24` will skip resolve-day sells unless you pass `--no-safeguards` or flatten elsewhere.
+- **Hours-to-resolve is now an env knob.** `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` overrides the previous hardcoded 2h time-decay safeguard. Same check, same `check_context_safeguards` path — raise it (e.g. `24`) to skip resolve-day entries. Entry-only: exits keep the original 2h floor, so a raised value never blocks a sell.
 
 ## What's New in v1.23.3
 
@@ -94,8 +94,8 @@ Then `pip install --upgrade simmer-sdk` (>=0.13.0) and configure tunables below.
 |---------|---------------------|---------|-------------|
 | Trading venue | `TRADING_VENUE` | polymarket | Venue to trade on. Set `sim` for paper trading. |
 | Entry threshold | `SIMMER_WEATHER_ENTRY_THRESHOLD` | 0.15 | **Upper** bound — buy when price is *below* this |
-| Min entry price | `SIMMER_WEATHER_MIN_ENTRY_PRICE` | 0 | **Lower** bound — skip lottery tickets below this (`0` = off). Dogfood sets `0.15`. |
-| Min hours to resolve | `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` | 2 | Skip if market resolves in fewer than this many hours. Same path runs on exits — raising this (e.g. `24`) also skips resolve-day sells. |
+| Min entry price | `SIMMER_WEATHER_MIN_ENTRY_PRICE` | 0 | **Lower** bound — skip lottery tickets below this (`0` = off), e.g. `0.15` to skip sub-15¢ tickets. Must be below the entry threshold. |
+| Min hours to resolve | `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` | 2 | Skip entries if the market resolves in fewer than this many hours. Entry-only; exits keep a fixed 2h floor. |
 | Exit threshold | `SIMMER_WEATHER_EXIT_THRESHOLD` | 0.45 | Sell when price above this. Raise this if you raise entry above `0.45`, or the skill will self-exit. |
 | Max position | `SIMMER_WEATHER_MAX_POSITION_USD` | 2.00 | Maximum USD per trade |
 | Max trades/run | `SIMMER_WEATHER_MAX_TRADES_PER_RUN` | 5 | Maximum trades per scan cycle |

--- a/skills/polymarket-weather-trader/clawhub.json
+++ b/skills/polymarket-weather-trader/clawhub.json
@@ -38,7 +38,7 @@
     {
       "name": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE",
       "required": false,
-      "description": "Skip if market resolves in fewer than this many hours (default 2). Also gates exits."
+      "description": "Skip entries if the market resolves in fewer than this many hours (default 2). Entry-only; exits keep a 2h floor."
     },
     {
       "name": "SIMMER_WEATHER_EXIT_THRESHOLD",

--- a/skills/polymarket-weather-trader/clawhub.json
+++ b/skills/polymarket-weather-trader/clawhub.json
@@ -38,12 +38,12 @@
     {
       "name": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE",
       "required": false,
-      "description": "Skip if market resolves in fewer than this many hours (default 2)."
+      "description": "Skip if market resolves in fewer than this many hours (default 2). Also gates exits."
     },
     {
       "name": "SIMMER_WEATHER_EXIT_THRESHOLD",
       "required": false,
-      "description": "Sell when price above this (default 0.45)."
+      "description": "Sell when price above this (default 0.45). Raise this if you raise ENTRY above 0.45, or the skill will self-exit."
     },
     {
       "name": "SIMMER_WEATHER_MAX_POSITION_USD",

--- a/skills/polymarket-weather-trader/clawhub.json
+++ b/skills/polymarket-weather-trader/clawhub.json
@@ -28,7 +28,17 @@
     {
       "name": "SIMMER_WEATHER_ENTRY_THRESHOLD",
       "required": false,
-      "description": "Buy when bucket price below this (default 0.15)."
+      "description": "Upper bound: buy when bucket price is below this (default 0.15)."
+    },
+    {
+      "name": "SIMMER_WEATHER_MIN_ENTRY_PRICE",
+      "required": false,
+      "description": "Lower bound: skip lottery-ticket mids below this (default 0 = off)."
+    },
+    {
+      "name": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE",
+      "required": false,
+      "description": "Skip if market resolves in fewer than this many hours (default 2)."
     },
     {
       "name": "SIMMER_WEATHER_EXIT_THRESHOLD",
@@ -137,7 +147,29 @@
         0.3
       ],
       "step": 0.01,
-      "label": "Entry edge threshold"
+      "label": "Entry edge threshold (upper bound)"
+    },
+    {
+      "env": "SIMMER_WEATHER_MIN_ENTRY_PRICE",
+      "type": "number",
+      "default": 0,
+      "range": [
+        0,
+        0.5
+      ],
+      "step": 0.01,
+      "label": "Min entry price (lottery-ticket floor; 0 = off)"
+    },
+    {
+      "env": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE",
+      "type": "number",
+      "default": 2,
+      "range": [
+        0,
+        72
+      ],
+      "step": 1,
+      "label": "Min hours to resolution (time-decay skip)"
     },
     {
       "env": "SIMMER_WEATHER_EXIT_THRESHOLD",

--- a/skills/polymarket-weather-trader/tests/test_entry_safeguards.py
+++ b/skills/polymarket-weather-trader/tests/test_entry_safeguards.py
@@ -138,7 +138,7 @@ class TestMinHoursToResolve(unittest.TestCase):
         spec = wt.CONFIG_SCHEMA["min_hours_to_resolve"]
         self.assertEqual(spec["env"], "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE")
         self.assertEqual(spec["default"], 2)
-        self.assertIs(spec["type"], int)
+        self.assertIs(spec["type"], float)
 
     def test_default_two_hours_rejects_one_hour(self):
         wt.TIME_TO_RESOLUTION_MIN_HOURS = 2
@@ -165,9 +165,18 @@ class TestMinHoursToResolve(unittest.TestCase):
         self.assertTrue(ok)
         self.assertFalse(any("too soon" in r for r in reasons))
 
-    def test_module_constant_reads_schema_default(self):
-        self.assertEqual(wt.TIME_TO_RESOLUTION_MIN_HOURS, 2)
-        self.assertEqual(wt.MIN_ENTRY_PRICE, 0.0)
+    def test_exits_keep_two_hour_floor_when_entry_knob_is_raised(self):
+        """Pinned: MIN_HOURS=24 must not block a resolve-day sell (exit path passes its own floor)."""
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, reasons = wt.check_context_safeguards(_context("10h"), min_hours=wt.EXIT_MIN_HOURS_TO_RESOLVE)
+        self.assertTrue(ok)
+        self.assertFalse(any("too soon" in r for r in reasons))
+
+    def test_exit_floor_is_the_original_two_hours(self):
+        self.assertEqual(wt.EXIT_MIN_HOURS_TO_RESOLVE, 2)
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, _ = wt.check_context_safeguards(_context("1h"), min_hours=wt.EXIT_MIN_HOURS_TO_RESOLVE)
+        self.assertFalse(ok)
 
 
 if __name__ == "__main__":

--- a/skills/polymarket-weather-trader/tests/test_entry_safeguards.py
+++ b/skills/polymarket-weather-trader/tests/test_entry_safeguards.py
@@ -120,6 +120,13 @@ class TestMinEntryPrice(unittest.TestCase):
         ok, _ = wt.check_entry_price(0.50)
         self.assertFalse(ok)
 
+    def test_floor_is_invisible_to_context_safeguards(self):
+        """Exits call check_context_safeguards only — the floor must not reject there."""
+        wt.MIN_ENTRY_PRICE = 0.15
+        ok, reasons = wt.check_context_safeguards(_context("3h"))
+        self.assertTrue(ok)
+        self.assertFalse(any("min entry" in r for r in reasons))
+
 
 class TestMinHoursToResolve(unittest.TestCase):
     """TIME_TO_RESOLUTION_MIN_HOURS stays in check_context_safeguards."""

--- a/skills/polymarket-weather-trader/tests/test_entry_safeguards.py
+++ b/skills/polymarket-weather-trader/tests/test_entry_safeguards.py
@@ -1,0 +1,167 @@
+"""
+Pinned proofs for #349: min-entry floor + env-ified hours-to-resolve.
+
+Both gates reuse existing reject paths:
+  - check_entry_price() is the ENTRY_THRESHOLD upper-bound check plus the
+    missing MIN_ENTRY_PRICE floor (entry path only).
+  - TIME_TO_RESOLUTION_MIN_HOURS still lives in check_context_safeguards
+    beside flip-flop / slippage / resolved — now an env-backed knob.
+
+Pure-unit: no network, no SIMMER_API_KEY.
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15,
+    "min_entry_price": 0.0,
+    "min_hours_to_resolve": 2,
+    "exit_threshold": 0.45,
+    "max_position_usd": 2.00,
+    "sizing_pct": 0.05,
+    "max_trades_per_run": 5,
+    "locations": "NYC",
+    "binary_only": False,
+    "slippage_max": 0.15,
+    "min_liquidity": 0.0,
+    "order_type": "GTC",
+    "vol_targeting": False,
+    "target_vol": 0.20,
+    "vol_max_leverage": 2.0,
+    "vol_min_allocation": 0.2,
+    "vol_span": 10,
+    "require_source_agreement": False,
+    "canary_on_adjacent": True,
+    "max_canary_usd": 2.0,
+    "max_source_spread_f": 2.0,
+}
+
+_skill_mod = types.ModuleType("simmer_sdk.skill")
+_skill_mod.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_mod.update_config = lambda updates, file, slug=None: None
+_skill_mod.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = MagicMock()
+sys.modules["simmer_sdk.skill"] = _skill_mod
+
+import weather_trader as wt  # noqa: E402
+
+
+def _context(time_to_resolution=""):
+    return {
+        "market": {"time_to_resolution": time_to_resolution},
+        "warnings": [],
+        "discipline": {},
+        "slippage": {},
+        "edge": {},
+    }
+
+
+class TestMinEntryPrice(unittest.TestCase):
+    """Dogfood bought Amsterdam ~$0.10 with ENTRY=0.50 and no floor."""
+
+    def tearDown(self):
+        wt.MIN_ENTRY_PRICE = 0.0
+        wt.ENTRY_THRESHOLD = 0.15
+
+    def test_schema_knob_is_env_backed_default_off(self):
+        spec = wt.CONFIG_SCHEMA["min_entry_price"]
+        self.assertEqual(spec["env"], "SIMMER_WEATHER_MIN_ENTRY_PRICE")
+        self.assertEqual(spec["default"], 0.0)
+        self.assertIs(spec["type"], float)
+
+    def test_default_zero_allows_lottery_mid(self):
+        """Back-compat: default 0 does not reject a 10¢ ticket under a raised entry."""
+        wt.MIN_ENTRY_PRICE = 0.0
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.10)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_floor_rejects_dogfood_lottery_ticket(self):
+        """Pinned: mid 0.10 / ENTRY 0.50 / MIN 0.15 → reject (Amsterdam resolve-day)."""
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.10)
+        self.assertFalse(ok)
+        self.assertIn("below min entry", reason)
+        self.assertIn("0.10", reason)
+        self.assertIn("0.15", reason)
+
+    def test_floor_allows_mid_inside_band(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.20)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_upper_bound_still_rejects_above_entry(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.55)
+        self.assertFalse(ok)
+        self.assertIn("above threshold", reason)
+
+    def test_boundary_min_is_inclusive(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, _ = wt.check_entry_price(0.15)
+        self.assertTrue(ok)
+
+    def test_boundary_entry_is_exclusive(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, _ = wt.check_entry_price(0.50)
+        self.assertFalse(ok)
+
+
+class TestMinHoursToResolve(unittest.TestCase):
+    """TIME_TO_RESOLUTION_MIN_HOURS stays in check_context_safeguards."""
+
+    def tearDown(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 2
+
+    def test_schema_knob_is_env_backed_default_two(self):
+        spec = wt.CONFIG_SCHEMA["min_hours_to_resolve"]
+        self.assertEqual(spec["env"], "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE")
+        self.assertEqual(spec["default"], 2)
+        self.assertIs(spec["type"], int)
+
+    def test_default_two_hours_rejects_one_hour(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 2
+        ok, reasons = wt.check_context_safeguards(_context("1h"))
+        self.assertFalse(ok)
+        self.assertTrue(any("too soon" in r for r in reasons))
+
+    def test_default_two_hours_allows_three_hours(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 2
+        ok, reasons = wt.check_context_safeguards(_context("3h"))
+        self.assertTrue(ok)
+        self.assertFalse(any("too soon" in r for r in reasons))
+
+    def test_raised_floor_skips_resolve_day(self):
+        """Pinned: MIN_HOURS=24 rejects a same-day 10h print (dogfood resolve-day)."""
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, reasons = wt.check_context_safeguards(_context("10h"))
+        self.assertFalse(ok)
+        self.assertTrue(any("too soon" in r for r in reasons))
+
+    def test_raised_floor_allows_next_day(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, reasons = wt.check_context_safeguards(_context("1d 3h"))
+        self.assertTrue(ok)
+        self.assertFalse(any("too soon" in r for r in reasons))
+
+    def test_module_constant_reads_schema_default(self):
+        self.assertEqual(wt.TIME_TO_RESOLUTION_MIN_HOURS, 2)
+        self.assertEqual(wt.MIN_ENTRY_PRICE, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = {
     "entry_threshold":   {"env": "SIMMER_WEATHER_ENTRY_THRESHOLD",   "default": 0.15,  "type": float},
     "min_entry_price":   {"env": "SIMMER_WEATHER_MIN_ENTRY_PRICE",   "default": 0.0,   "type": float,
                           "help": "Reject entries below this mid (lottery-ticket floor). 0 = disabled (back-compat). ENTRY_THRESHOLD is the upper bound only."},
-    "min_hours_to_resolve": {"env": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE", "default": 2, "type": int,
+    "min_hours_to_resolve": {"env": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE", "default": 2, "type": float,
                              "help": "Skip if market resolves in fewer than this many hours (time-decay safeguard)."},
     "exit_threshold":    {"env": "SIMMER_WEATHER_EXIT_THRESHOLD",    "default": 0.45,  "type": float},
     "max_position_usd":  {"env": "SIMMER_WEATHER_MAX_POSITION_USD",  "default": 2.00,  "type": float},
@@ -177,7 +177,8 @@ VOL_SPAN = _config["vol_span"]
 # Context safeguard thresholds
 SLIPPAGE_MAX_PCT = _config["slippage_max"]  # Skip if slippage exceeds this (tunable)
 MIN_LIQUIDITY_USD = _config["min_liquidity"]  # Skip markets with liquidity below this (0 = disabled)
-TIME_TO_RESOLUTION_MIN_HOURS = _config.get("min_hours_to_resolve", 2)  # Skip if resolving sooner
+TIME_TO_RESOLUTION_MIN_HOURS = _config.get("min_hours_to_resolve", 2)  # Entry-only: skip if resolving sooner
+EXIT_MIN_HOURS_TO_RESOLVE = 2  # Exits keep the original 2h floor regardless of the env knob
 
 # Multi-source bucket-confidence (SIM-2420)
 REQUIRE_SOURCE_AGREEMENT = _config["require_source_agreement"]
@@ -946,13 +947,15 @@ def check_entry_price(price: float) -> tuple:
     return True, ""
 
 
-def check_context_safeguards(context: dict, use_edge: bool = True) -> tuple:
+def check_context_safeguards(context: dict, use_edge: bool = True, min_hours: float = None) -> tuple:
     """
     Check context for safeguards. Returns (should_trade, reasons).
     
     Args:
         context: Context response from SDK
         use_edge: If True, respect edge recommendation (TRADE/HOLD/SKIP)
+        min_hours: Time-decay floor in hours. Defaults to the entry knob
+            TIME_TO_RESOLUTION_MIN_HOURS; exits pass EXIT_MIN_HOURS_TO_RESOLVE.
     """
     if not context:
         return True, []  # No context = proceed (fail open)
@@ -990,7 +993,8 @@ def check_context_safeguards(context: dict, use_edge: bool = True) -> tuple:
                     h_part = h_part.split("d")[-1].strip()
                 hours += int(h_part)
 
-            if hours < TIME_TO_RESOLUTION_MIN_HOURS:
+            floor = TIME_TO_RESOLUTION_MIN_HOURS if min_hours is None else min_hours
+            if hours < floor:
                 return False, [f"Resolves in {hours}h - too soon"]
         except (ValueError, IndexError):
             pass
@@ -1378,7 +1382,7 @@ def check_exit_opportunities(dry_run: bool = False, use_safeguards: bool = True)
             # Check safeguards before selling
             if use_safeguards:
                 context = get_market_context(market_id)
-                should_trade, reasons = check_context_safeguards(context)
+                should_trade, reasons = check_context_safeguards(context, min_hours=EXIT_MIN_HOURS_TO_RESOLVE)
                 if not should_trade:
                     print(f"     ⏭️  Skipped: {'; '.join(reasons)}")
                     continue
@@ -1454,7 +1458,9 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
     log(f"  Entry threshold: {ENTRY_THRESHOLD:.0%} (buy below this; upper bound only)")
     if MIN_ENTRY_PRICE > 0:
         log(f"  Min entry price: {MIN_ENTRY_PRICE:.0%} (reject below this)")
-    log(f"  Min hours to resolve: {TIME_TO_RESOLUTION_MIN_HOURS}")
+        if MIN_ENTRY_PRICE >= ENTRY_THRESHOLD:
+            log(f"  ⚠️  Min entry ${MIN_ENTRY_PRICE:.2f} >= entry threshold ${ENTRY_THRESHOLD:.2f}: every candidate will be skipped", force=True)
+    log(f"  Min hours to resolve: {TIME_TO_RESOLUTION_MIN_HOURS:g} (entries only; exits keep {EXIT_MIN_HOURS_TO_RESOLVE}h)")
     log(f"  Exit threshold:  {EXIT_THRESHOLD:.0%} (sell above this)")
     log(f"  Max position:    ${MAX_POSITION_USD:.2f}")
     log(f"  Max trades/run:  {MAX_TRADES_PER_RUN}")

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -1762,11 +1762,6 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                 trend_bonus = f" 📈 (up {trend['change_24h']:.0%} in 24h)"
 
         should_enter, entry_reason = check_entry_price(price)
-        if price < MIN_ENTRY_PRICE:
-            log(f"  ⏭️  {entry_reason} - skip")
-            skip_reasons.append("below min entry")
-            continue
-
         if should_enter:
             position_size = calculate_position_size(MAX_POSITION_USD, smart_sizing)
 
@@ -1881,7 +1876,11 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                     log(f"  ❌ Trade failed: {error}", force=True)
                     execution_errors.append(error[:120])
         else:
-            log(f"  ⏸️  {entry_reason} - skip")
+            if "below min entry" in entry_reason:
+                log(f"  ⏭️  {entry_reason} - skip")
+                skip_reasons.append("below min entry")
+            else:
+                log(f"  ⏸️  {entry_reason} - skip")
 
     _report_parse_coverage(station_parse_ok, station_parse_unreadable, log)
 

--- a/skills/polymarket-weather-trader/weather_trader.py
+++ b/skills/polymarket-weather-trader/weather_trader.py
@@ -55,6 +55,10 @@ from simmer_sdk.skill import load_config, update_config, get_config_path
 # resolved as fallbacks below for backwards compatibility.
 CONFIG_SCHEMA = {
     "entry_threshold":   {"env": "SIMMER_WEATHER_ENTRY_THRESHOLD",   "default": 0.15,  "type": float},
+    "min_entry_price":   {"env": "SIMMER_WEATHER_MIN_ENTRY_PRICE",   "default": 0.0,   "type": float,
+                          "help": "Reject entries below this mid (lottery-ticket floor). 0 = disabled (back-compat). ENTRY_THRESHOLD is the upper bound only."},
+    "min_hours_to_resolve": {"env": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE", "default": 2, "type": int,
+                             "help": "Skip if market resolves in fewer than this many hours (time-decay safeguard)."},
     "exit_threshold":    {"env": "SIMMER_WEATHER_EXIT_THRESHOLD",    "default": 0.45,  "type": float},
     "max_position_usd":  {"env": "SIMMER_WEATHER_MAX_POSITION_USD",  "default": 2.00,  "type": float},
     "sizing_pct":        {"env": "SIMMER_WEATHER_SIZING_PCT",        "default": 0.05,  "type": float},
@@ -150,6 +154,7 @@ MIN_TICK_SIZE = 0.01        # Minimum tradeable price
 
 # Strategy parameters - from config
 ENTRY_THRESHOLD = _config["entry_threshold"]
+MIN_ENTRY_PRICE = _config.get("min_entry_price", 0.0)
 EXIT_THRESHOLD = _config["exit_threshold"]
 MAX_POSITION_USD = _config["max_position_usd"]
 
@@ -172,7 +177,7 @@ VOL_SPAN = _config["vol_span"]
 # Context safeguard thresholds
 SLIPPAGE_MAX_PCT = _config["slippage_max"]  # Skip if slippage exceeds this (tunable)
 MIN_LIQUIDITY_USD = _config["min_liquidity"]  # Skip markets with liquidity below this (0 = disabled)
-TIME_TO_RESOLUTION_MIN_HOURS = 2  # Skip if resolving in < 2 hours
+TIME_TO_RESOLUTION_MIN_HOURS = _config.get("min_hours_to_resolve", 2)  # Skip if resolving sooner
 
 # Multi-source bucket-confidence (SIM-2420)
 REQUIRE_SOURCE_AGREEMENT = _config["require_source_agreement"]
@@ -928,6 +933,19 @@ def get_price_history(market_id: str) -> list:
         return []
 
 
+def check_entry_price(price: float) -> tuple:
+    """ENTRY_THRESHOLD is an upper bound. MIN_ENTRY_PRICE is the optional floor (0 = off).
+
+    Returns (should_enter, reason). reason is empty when should_enter is True.
+    Used on the entry path only — exits must not inherit the lottery-ticket floor.
+    """
+    if price < MIN_ENTRY_PRICE:
+        return False, f"Price ${price:.2f} below min entry ${MIN_ENTRY_PRICE:.2f}"
+    if price >= ENTRY_THRESHOLD:
+        return False, f"Price ${price:.2f} above threshold ${ENTRY_THRESHOLD:.2f}"
+    return True, ""
+
+
 def check_context_safeguards(context: dict, use_edge: bool = True) -> tuple:
     """
     Check context for safeguards. Returns (should_trade, reasons).
@@ -1433,7 +1451,10 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         log("\n  [PAPER MODE] Trades will be simulated with real prices. Use --live for real trades.")
 
     log(f"\n⚙️  Configuration:")
-    log(f"  Entry threshold: {ENTRY_THRESHOLD:.0%} (buy below this)")
+    log(f"  Entry threshold: {ENTRY_THRESHOLD:.0%} (buy below this; upper bound only)")
+    if MIN_ENTRY_PRICE > 0:
+        log(f"  Min entry price: {MIN_ENTRY_PRICE:.0%} (reject below this)")
+    log(f"  Min hours to resolve: {TIME_TO_RESOLUTION_MIN_HOURS}")
     log(f"  Exit threshold:  {EXIT_THRESHOLD:.0%} (sell above this)")
     log(f"  Max position:    ${MAX_POSITION_USD:.2f}")
     log(f"  Max trades/run:  {MAX_TRADES_PER_RUN}")
@@ -1740,7 +1761,13 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
             elif trend["direction"] == "up":
                 trend_bonus = f" 📈 (up {trend['change_24h']:.0%} in 24h)"
 
-        if price < ENTRY_THRESHOLD:
+        should_enter, entry_reason = check_entry_price(price)
+        if price < MIN_ENTRY_PRICE:
+            log(f"  ⏭️  {entry_reason} - skip")
+            skip_reasons.append("below min entry")
+            continue
+
+        if should_enter:
             position_size = calculate_position_size(MAX_POSITION_USD, smart_sizing)
 
             # Apply volatility targeting
@@ -1854,7 +1881,7 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                     log(f"  ❌ Trade failed: {error}", force=True)
                     execution_errors.append(error[:120])
         else:
-            log(f"  ⏸️  Price ${price:.2f} above threshold ${ENTRY_THRESHOLD:.2f} - skip")
+            log(f"  ⏸️  {entry_reason} - skip")
 
     _report_parse_coverage(station_parse_ok, station_parse_unreadable, log)
 
@@ -1941,6 +1968,8 @@ if __name__ == "__main__":
             _config = load_config(CONFIG_SCHEMA, __file__, slug="polymarket-weather-trader")
             # Update module-level vars
             globals()["ENTRY_THRESHOLD"] = _config["entry_threshold"]
+            globals()["MIN_ENTRY_PRICE"] = _config.get("min_entry_price", 0.0)
+            globals()["TIME_TO_RESOLUTION_MIN_HOURS"] = _config.get("min_hours_to_resolve", 2)
             globals()["EXIT_THRESHOLD"] = _config["exit_threshold"]
             globals()["MAX_POSITION_USD"] = _config["max_position_usd"]
             globals()["SMART_SIZING_PCT"] = _config["sizing_pct"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #349.

## Plan (design-first)

Reuse the existing reject paths. Do not add a second gate system.

1. **Hours-to-resolve** already lives in `check_context_safeguards` beside flip-flop / slippage / resolved. Env-ify that constant the same way `SLIPPAGE_MAX` is wired. No calendar-day skip.
2. **Min mid** is the missing lower bound of `if price < ENTRY_THRESHOLD`. Keep it on the entry-price check — `check_context_safeguards` also runs on **exits**, so a floor there would block flattening lottery tickets.
3. Two env knobs only, defaults preserve back-compat: `SIMMER_WEATHER_MIN_ENTRY_PRICE=0`, `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE=2`.
4. Docs: ENTRY is an upper bound; raising it above the 0.45 exit default self-exits unless EXIT is raised too.
5. Pin both gates in unit tests. Run `npm run bundle-skills` (weather is not in the core MCP allowlist; bundle stays unchanged).

## What changed

- `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off). Set `0.15` to reject lottery tickets. Rejects the Amsterdam ~$0.10 / ENTRY=0.50 resolve-day ticket. Startup warns if the floor is `>=` the entry threshold (empty band).
- `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default `2`, float so `1.5` is valid). Same time-decay check on **entries**. Exits keep a fixed 2h floor (`EXIT_MIN_HOURS_TO_RESOLVE`) so a raised knob never blocks a sell.
- Skill v1.23.7. `SKILL.md` + `clawhub.json` tunables/envVars updated.

## Follow-ups on this branch

- Loop is one `should_enter` / `entry_reason` branch.
- `test_floor_is_invisible_to_context_safeguards` pins that the price floor cannot reject exits.
- Hours is entry-only: `check_context_safeguards(..., min_hours=EXIT_MIN_HOURS_TO_RESOLVE)` on the sell path. `test_exits_keep_two_hour_floor_when_entry_knob_is_raised` pins MIN_HOURS=24 + `10h` still allows a sell.
- clawhub EXIT envVar text matches the SKILL.md raise-EXIT-with-ENTRY note.

## Out of scope

- Desk TP/SL numbers
- Canary $2 vs ~5-share min notional
- Live venue trading

## Proofs

```
python3 -m unittest discover -s skills/polymarket-weather-trader/tests -v
# 75 tests OK, including:
#   test_floor_rejects_dogfood_lottery_ticket  (0.10 / ENTRY 0.50 / MIN 0.15)
#   test_default_zero_allows_lottery_mid       (back-compat)
#   test_floor_is_invisible_to_context_safeguards
#   test_raised_floor_skips_resolve_day        (MIN_HOURS=24 rejects 10h on entry)
#   test_exits_keep_two_hour_floor_when_entry_knob_is_raised
#   test_exit_floor_is_the_original_two_hours
```

`npm run bundle-skills` in `mcp/` — weather-trader is not in the core allowlist; `check:bundle-skills` reports fresh.

## How to use ($SIM)

```bash
export TRADING_VENUE=sim
export SIMMER_WEATHER_MIN_ENTRY_PRICE=0.15
export SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE=24
# hours knob is entry-only; resolve-day sells still use the 2h exit floor
```

Draft only; do not merge.

AI-assisted. The hours-entry-only / float / inverted-band commit is from @adlai88.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e300fa0f-dcc0-4957-860c-b207a44f10b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e300fa0f-dcc0-4957-860c-b207a44f10b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

