### PR TITLE
chore(replay): resync vendored engine — reject tags filter (SIM-5138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to `simmer-sdk` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.25.4 (2026-09-09)
+
+- **`simmer backtest`'s replay server now rejects the `tags` filter on `get_markets()` too.** 0.25.3 closed `venue`/`status`/`category`; `tags` was the one remaining discovery filter the replay engine never implemented, so a backtest narrowed to a tag slice silently ran against the full market universe and reported P&L for markets it never meant to trade. Passing `tags` now raises an error naming the parameter. Omitting it behaves exactly as before. (SIM-5138)
+
 ## 0.25.3 (2026-09-08)
 
 - **`simmer backtest`'s replay server now rejects `venue`/`status` filters on `get_markets()` (and `category` on the importable listing) instead of silently ignoring them.** These were never implemented by the replay engine, so passing one previously returned the full unfiltered market list with no indication the filter was dropped — a backtest filtering for one venue could report P&L against markets from a venue it never meant to trade. Passing any of these now raises a clear error naming the parameter instead of returning a misleading result. Omitting them behaves exactly as before. (SIM-5067)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simmer-sdk"
-version = "0.25.3"
+version = "0.25.4"
 description = "Python SDK for trading prediction markets with AI agents - powers installable trading skills across agent runtimes"
 readme = "README.md"
 authors = [

--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ e3c361585d16
+# vendored from simmer_v3/replay/candles_service.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ e3c361585d16
+# vendored from simmer_v3/replay/duckdb_store.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ e3c361585d16
+# vendored from simmer_v3/replay/engine.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ e3c361585d16
+# vendored from simmer_v3/replay/feeds/binance.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ e3c361585d16
+# vendored from simmer_v3/replay/harness.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ e3c361585d16
+# vendored from simmer_v3/replay/server.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 
@@ -170,8 +170,9 @@ def create_app(session: ReplaySession) -> FastAPI:
         status: Optional[str] = None,
         sort: Optional[str] = None,
         venue: Optional[str] = None,
+        tags: Optional[str] = None,
     ):
-        _reject_unsupported(venue=venue, status=status)
+        _reject_unsupported(venue=venue, status=status, tags=tags)
         metas = session.view.markets(limit=max(limit * 4, limit))
         if q:
             ql = q.lower()

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ e3c361585d16
+# vendored from simmer_v3/replay/simstate.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ e3c361585d16
+# vendored from simmer_v3/replay/store.py @ df6bde474420
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 


### PR DESCRIPTION
## Summary
Resyncs the vendored replay engine from `simmer_v3/replay/` at `df6bde474420` (the head of SupaFund/simmer#2287).

The only substantive change is `server.py`: `get_markets()` now rejects a `tags` filter instead of silently returning the unfiltered universe. This extends 0.25.3's fix (SIM-5067, which closed `venue`/`status`/`category`) to the last discovery filter the replay engine never implemented — a backtest narrowed to a tag slice was reporting P&L against markets it never meant to trade.

The other seven vendored modules take a provenance-sha header bump only; no logic changed in them.

## Why this merges first
SupaFund/simmer#2287's `Guards` job clones **this repo's main** and compares it against the PR's `simmer_v3/replay/`. That check is currently red on #2287. It goes green once this lands.

## Verification
- `python3 -m pytest tests/ -k "replay or backtest" -q` → 24 passed, 1 skipped
- `git diff` reviewed file by file: 7 header-only, 1 substantive (`server.py`, +2/-1)

Version bumped to 0.25.4 with a CHANGELOG entry so the fix reaches PyPI users rather than sitting vendored-but-unreleased.

Note: `Publish Lag Check` is expected red here — red by design on any version-bump PR (repo ahead of registry until the merge publishes).