### PR TITLE
fix: port Kalshi weather entry knobs

### DIFF
--- a/skills/kalshi-weather-trader/CHANGELOG.md
+++ b/skills/kalshi-weather-trader/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — kalshi-weather-trader
 
+## [1.0.12] - 2026-09-09
+
+### Added
+- `SIMMER_WEATHER_MIN_ENTRY_PRICE` (default `0` = off). Rejects entries below this mid so a raised `ENTRY_THRESHOLD` cannot buy lottery tickets.
+- `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default `2`). Env override for the entry time-decay safeguard. Entry-only: exits keep the original 2h floor.
+
+### Fixed
+- The local entry price band now runs before context and trend network calls, so below-floor candidates are rejected with zero context/history requests.
+
 ## [1.0.8] - 2026-05-23
 
 ### Fixed

--- a/skills/kalshi-weather-trader/SKILL.md
+++ b/skills/kalshi-weather-trader/SKILL.md
@@ -3,7 +3,7 @@ name: kalshi-weather-trader
 description: Trade Kalshi weather markets using NOAA forecasts via Simmer SDK and DFlow on Solana. Port of the popular polymarket-weather-trader. Use when user wants to trade temperature markets on Kalshi, automate weather bets, or check NOAA forecasts.
 metadata:
   author: Simmer (@simmer_markets)
-  version: "1.0.11"
+  version: "1.0.12"
   displayName: Kalshi Weather Trader
   difficulty: intermediate
   attribution: Strategy inspired by gopfan2, powered by DFlow
@@ -62,7 +62,9 @@ When user asks to install or configure this skill:
    - USDC on Solana mainnet for trading capital
 
 6. **Ask about settings** (or confirm defaults)
-   - Entry threshold: When to buy (default 15¢)
+   - Entry threshold: Upper bound for when to buy (default 15¢)
+   - Min entry price: Lower bound to skip lottery-ticket mids (default 0 = off)
+   - Min hours to resolve: Skip entries resolving too soon (default 2h; exits keep 2h)
    - Exit threshold: When to sell (default 45¢)
    - Max position: Amount per trade (default $2.00)
    - Locations: Which cities to trade (default NYC)
@@ -75,8 +77,10 @@ When user asks to install or configure this skill:
 
 | Setting | Environment Variable | Default | Description |
 |---------|---------------------|---------|-------------|
-| Entry threshold | `SIMMER_WEATHER_ENTRY_THRESHOLD` | 0.15 | Buy when price below this |
-| Exit threshold | `SIMMER_WEATHER_EXIT_THRESHOLD` | 0.45 | Sell when price above this |
+| Entry threshold | `SIMMER_WEATHER_ENTRY_THRESHOLD` | 0.15 | **Upper** bound — buy when price is *below* this |
+| Min entry price | `SIMMER_WEATHER_MIN_ENTRY_PRICE` | 0 | **Lower** bound — skip lottery tickets below this (`0` = off), e.g. `0.15` to skip sub-15¢ tickets. Must be below the entry threshold. |
+| Min hours to resolve | `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` | 2 | Skip entries if the market resolves in fewer than this many hours. Entry-only; exits keep a fixed 2h floor. |
+| Exit threshold | `SIMMER_WEATHER_EXIT_THRESHOLD` | 0.45 | Sell when price above this. Raise this if you raise entry above `0.45`, or the skill will self-exit. |
 | Max position | `SIMMER_WEATHER_MAX_POSITION_USD` | 2.00 | Maximum USD per trade |
 | Max trades/run | `SIMMER_WEATHER_MAX_TRADES_PER_RUN` | 5 | Maximum trades per scan cycle |
 | Locations | `SIMMER_WEATHER_LOCATIONS` | NYC | Comma-separated cities (NYC, Chicago, Seattle, Atlanta, Dallas, Miami) |
@@ -135,7 +139,7 @@ Each cycle the script:
 5. Finds the temperature bucket that matches the forecast
 6. **Safeguards**: Checks context for flip-flop warnings, slippage, time decay
 7. **Trend Detection**: Looks for recent price drops (stronger buy signal)
-8. **Entry**: If bucket price < threshold and safeguards pass → BUY
+8. **Entry**: If min-entry ≤ bucket price < entry threshold and safeguards pass → BUY
 9. **Exit**: Checks open positions, sells if price > exit threshold
 10. **Tagging**: All trades tagged with `sdk:kalshi-weather` for tracking
 
@@ -143,12 +147,14 @@ Each cycle the script:
 
 Before trading, the skill checks:
 - **Flip-flop warning**: Skips if you've been reversing too much
-- **Slippage**: Skips if estimated slippage > 15%
-- **Time decay**: Skips if market resolves in < 2 hours
+- **Slippage**: Skips if estimated slippage > 15% (tunable via `SIMMER_WEATHER_SLIPPAGE_MAX`)
+- **Time decay**: Skips entries if market resolves in < `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` hours (default 2)
 - **Market status**: Skips if market already resolved
 - **Kalshi maintenance**: Kalshi's clearinghouse has a weekly maintenance window on Thursdays 3:00-5:00 AM ET — orders during this window will fail
 
-Disable with `--no-safeguards` (not recommended).
+`SIMMER_WEATHER_MIN_ENTRY_PRICE` (default 0 = off) is the other side of the entry-price check, not this list — `--no-safeguards` does not disable it.
+
+Disable the flip-flop / slippage / time-decay / resolved checks with `--no-safeguards` (not recommended).
 
 ## Troubleshooting
 
@@ -158,6 +164,12 @@ Disable with `--no-safeguards` (not recommended).
 
 **"Slippage too high"**
 - Market is illiquid, reduce position size or skip
+
+**"Resolves in Xh - too soon"**
+- Market resolves sooner than `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` (default 2h). Raise the env to skip resolve-day entries.
+
+**"Price $X.XX below min entry"**
+- Bucket mid is below `SIMMER_WEATHER_MIN_ENTRY_PRICE`. Lottery-ticket floor; default is off (`0`).
 
 **"No weather markets found"**
 - Weather markets may not be active (seasonal)

--- a/skills/kalshi-weather-trader/clawhub.json
+++ b/skills/kalshi-weather-trader/clawhub.json
@@ -20,6 +20,26 @@
       "name": "SOLANA_PRIVATE_KEY",
       "required": true,
       "description": "Solana wallet private key (base58) for signing DFlow trades. Kalshi has no managed-wallet mode \u2014 self-custody is the only option."
+    },
+    {
+      "name": "SIMMER_WEATHER_ENTRY_THRESHOLD",
+      "required": false,
+      "description": "Upper bound: buy when bucket price is below this (default 0.15)."
+    },
+    {
+      "name": "SIMMER_WEATHER_MIN_ENTRY_PRICE",
+      "required": false,
+      "description": "Lower bound: skip lottery-ticket mids below this (default 0 = off)."
+    },
+    {
+      "name": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE",
+      "required": false,
+      "description": "Skip entries if the market resolves in fewer than this many hours (default 2). Entry-only; exits keep a 2h floor."
+    },
+    {
+      "name": "SIMMER_WEATHER_EXIT_THRESHOLD",
+      "required": false,
+      "description": "Sell when price above this (default 0.45). Raise this if you raise ENTRY above 0.45, or the skill will self-exit."
     }
   ],
   "cron": null,
@@ -35,7 +55,23 @@
       "default": 0.15,
       "range": [0.01, 0.50],
       "step": 0.01,
-      "label": "Entry edge threshold"
+      "label": "Entry edge threshold (upper bound)"
+    },
+    {
+      "env": "SIMMER_WEATHER_MIN_ENTRY_PRICE",
+      "type": "number",
+      "default": 0,
+      "range": [0, 0.50],
+      "step": 0.01,
+      "label": "Min entry price (lottery-ticket floor; 0 = off)"
+    },
+    {
+      "env": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE",
+      "type": "number",
+      "default": 2,
+      "range": [0, 72],
+      "step": 1,
+      "label": "Min hours to resolution (time-decay skip)"
     },
     {
       "env": "SIMMER_WEATHER_EXIT_THRESHOLD",

--- a/skills/kalshi-weather-trader/tests/test_entry_safeguards.py
+++ b/skills/kalshi-weather-trader/tests/test_entry_safeguards.py
@@ -1,0 +1,173 @@
+"""
+Pinned proofs for Kalshi weather entry safeguards.
+
+Pure-unit: no network, no SIMMER_API_KEY.
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+_SKILL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SKILL_DIR)
+
+_mock_cfg = {
+    "entry_threshold": 0.15,
+    "min_entry_price": 0.0,
+    "min_hours_to_resolve": 2,
+    "exit_threshold": 0.45,
+    "max_position_usd": 2.00,
+    "sizing_pct": 0.05,
+    "max_trades_per_run": 5,
+    "locations": "NYC",
+    "binary_only": False,
+    "slippage_max": 0.15,
+    "min_liquidity": 0.0,
+}
+
+_skill_mod = types.ModuleType("simmer_sdk.skill")
+_skill_mod.load_config = lambda schema, file, slug=None: _mock_cfg.copy()
+_skill_mod.update_config = lambda updates, file, slug=None: None
+_skill_mod.get_config_path = lambda file: "/tmp/config.json"
+sys.modules["simmer_sdk"] = MagicMock()
+sys.modules["simmer_sdk.skill"] = _skill_mod
+
+import weather_trader as wt  # noqa: E402
+
+
+def _context(time_to_resolution=""):
+    return {
+        "market": {"time_to_resolution": time_to_resolution},
+        "warnings": [],
+        "discipline": {},
+        "slippage": {},
+        "edge": {},
+    }
+
+
+class TestMinEntryPrice(unittest.TestCase):
+    def tearDown(self):
+        wt.MIN_ENTRY_PRICE = 0.0
+        wt.ENTRY_THRESHOLD = 0.15
+
+    def test_schema_knob_is_env_backed_default_off(self):
+        spec = wt.CONFIG_SCHEMA["min_entry_price"]
+        self.assertEqual(spec["env"], "SIMMER_WEATHER_MIN_ENTRY_PRICE")
+        self.assertEqual(spec["default"], 0.0)
+        self.assertIs(spec["type"], float)
+
+    def test_default_zero_allows_lottery_mid(self):
+        wt.MIN_ENTRY_PRICE = 0.0
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.10)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_floor_rejects_low_mid(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.10)
+        self.assertFalse(ok)
+        self.assertIn("below min entry", reason)
+        self.assertIn("0.10", reason)
+        self.assertIn("0.15", reason)
+
+    def test_floor_allows_mid_inside_band(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.20)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "")
+
+    def test_upper_bound_still_rejects_above_entry(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        ok, reason = wt.check_entry_price(0.55)
+        self.assertFalse(ok)
+        self.assertIn("above threshold", reason)
+
+    def test_floor_is_invisible_to_context_safeguards(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        ok, reasons = wt.check_context_safeguards(_context("3h"))
+        self.assertTrue(ok)
+        self.assertFalse(any("min entry" in r for r in reasons))
+
+
+class TestMinHoursToResolve(unittest.TestCase):
+    def tearDown(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 2
+
+    def test_schema_knob_is_env_backed_default_two(self):
+        spec = wt.CONFIG_SCHEMA["min_hours_to_resolve"]
+        self.assertEqual(spec["env"], "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE")
+        self.assertEqual(spec["default"], 2)
+        self.assertIs(spec["type"], float)
+
+    def test_default_two_hours_rejects_one_hour(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 2
+        ok, reasons = wt.check_context_safeguards(_context("1h"))
+        self.assertFalse(ok)
+        self.assertTrue(any("too soon" in r for r in reasons))
+
+    def test_raised_floor_skips_resolve_day(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, reasons = wt.check_context_safeguards(_context("10h"))
+        self.assertFalse(ok)
+        self.assertTrue(any("too soon" in r for r in reasons))
+
+    def test_raised_floor_allows_next_day(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, reasons = wt.check_context_safeguards(_context("1d 6h"))
+        self.assertTrue(ok)
+        self.assertFalse(any("too soon" in r for r in reasons))
+
+    def test_exits_keep_two_hour_floor_when_entry_knob_is_raised(self):
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, reasons = wt.check_context_safeguards(_context("3h"), min_hours=wt.EXIT_MIN_HOURS_TO_RESOLVE)
+        self.assertTrue(ok)
+        self.assertFalse(any("too soon" in r for r in reasons))
+
+    def test_exit_floor_is_the_original_two_hours(self):
+        self.assertEqual(wt.EXIT_MIN_HOURS_TO_RESOLVE, 2)
+        wt.TIME_TO_RESOLUTION_MIN_HOURS = 24
+        ok, _ = wt.check_context_safeguards(_context("1h"), min_hours=wt.EXIT_MIN_HOURS_TO_RESOLVE)
+        self.assertFalse(ok)
+
+
+class TestEntryPathOrdering(unittest.TestCase):
+    def tearDown(self):
+        wt.MIN_ENTRY_PRICE = 0.0
+        wt.ENTRY_THRESHOLD = 0.15
+        wt.ACTIVE_LOCATIONS = ["NYC"]
+
+    def test_below_floor_candidate_makes_zero_context_or_history_calls(self):
+        wt.MIN_ENTRY_PRICE = 0.15
+        wt.ENTRY_THRESHOLD = 0.50
+        wt.ACTIVE_LOCATIONS = ["NYC"]
+        market = {
+            "id": "market-1",
+            "event_id": "event-1",
+            "event_name": "Highest temperature in NYC on September 30",
+            "outcome_name": "70 to 80",
+            "external_price_yes": 0.10,
+        }
+
+        with patch.object(wt, "get_client") as get_client, \
+                patch.object(wt, "discover_and_import_weather_markets", return_value=0), \
+                patch.object(wt, "fetch_weather_markets", return_value=[market]), \
+                patch.object(wt, "get_noaa_forecast", return_value={"2026-09-30": {"high": 75, "low": 60}}), \
+                patch.object(wt, "get_market_context") as get_market_context, \
+                patch.object(wt, "get_price_history") as get_price_history, \
+                patch.object(wt, "check_exit_opportunities", return_value=(0, 0)):
+            get_client.return_value.auto_redeem.return_value = []
+
+            wt.run_weather_strategy(dry_run=True, quiet=True)
+
+        get_market_context.assert_not_called()
+        get_price_history.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/kalshi-weather-trader/weather_trader.py
+++ b/skills/kalshi-weather-trader/weather_trader.py
@@ -56,6 +56,8 @@ from simmer_sdk.skill import load_config, update_config, get_config_path
 # resolved as fallbacks below for backwards compatibility.
 CONFIG_SCHEMA = {
     "entry_threshold":   {"env": "SIMMER_WEATHER_ENTRY_THRESHOLD",   "default": 0.15,  "type": float},
+    "min_entry_price":   {"env": "SIMMER_WEATHER_MIN_ENTRY_PRICE",   "default": 0.0,   "type": float},
+    "min_hours_to_resolve": {"env": "SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE", "default": 2, "type": float},
     "exit_threshold":    {"env": "SIMMER_WEATHER_EXIT_THRESHOLD",    "default": 0.45,  "type": float},
     "max_position_usd":  {"env": "SIMMER_WEATHER_MAX_POSITION_USD",  "default": 2.00,  "type": float},
     "sizing_pct":        {"env": "SIMMER_WEATHER_SIZING_PCT",        "default": 0.05,  "type": float},
@@ -114,6 +116,7 @@ MIN_TICK_SIZE = 0.01        # Minimum tradeable price
 
 # Strategy parameters - from config
 ENTRY_THRESHOLD = _config["entry_threshold"]
+MIN_ENTRY_PRICE = _config.get("min_entry_price", 0.0)
 EXIT_THRESHOLD = _config["exit_threshold"]
 MAX_POSITION_USD = _config["max_position_usd"]
 _automaton_max = os.environ.get("AUTOMATON_MAX_BET")
@@ -132,7 +135,8 @@ BINARY_ONLY = _config["binary_only"]
 # Context safeguard thresholds
 SLIPPAGE_MAX_PCT = _config["slippage_max"]  # Skip if slippage exceeds this (tunable)
 MIN_LIQUIDITY_USD = _config["min_liquidity"]  # Skip markets with liquidity below this (0 = disabled)
-TIME_TO_RESOLUTION_MIN_HOURS = 2  # Skip if resolving in < 2 hours
+TIME_TO_RESOLUTION_MIN_HOURS = _config.get("min_hours_to_resolve", 2)  # Entry-only: skip if resolving sooner
+EXIT_MIN_HOURS_TO_RESOLVE = 2  # Exits keep the original 2h floor regardless of the env knob
 
 # Price trend detection
 PRICE_DROP_THRESHOLD = 0.10  # 10% drop in last 24h = stronger signal
@@ -376,13 +380,24 @@ def get_price_history(market_id: str) -> list:
         return []
 
 
-def check_context_safeguards(context: dict, use_edge: bool = True) -> tuple:
+def check_entry_price(price: float) -> tuple:
+    """Validate the entry-only price band. Returns (should_enter, reason)."""
+    if price < MIN_ENTRY_PRICE:
+        return False, f"Price ${price:.2f} below min entry ${MIN_ENTRY_PRICE:.2f}"
+    if price >= ENTRY_THRESHOLD:
+        return False, f"Price ${price:.2f} above threshold ${ENTRY_THRESHOLD:.2f}"
+    return True, ""
+
+
+def check_context_safeguards(context: dict, use_edge: bool = True, min_hours: float = None) -> tuple:
     """
     Check context for safeguards. Returns (should_trade, reasons).
     
     Args:
         context: Context response from SDK
         use_edge: If True, respect edge recommendation (TRADE/HOLD/SKIP)
+        min_hours: Time-decay floor in hours. Defaults to the entry knob;
+            exits pass EXIT_MIN_HOURS_TO_RESOLVE.
     """
     if not context:
         return True, []  # No context = proceed (fail open)
@@ -420,7 +435,8 @@ def check_context_safeguards(context: dict, use_edge: bool = True) -> tuple:
                     h_part = h_part.split("d")[-1].strip()
                 hours += int(h_part)
 
-            if hours < TIME_TO_RESOLUTION_MIN_HOURS:
+            floor = TIME_TO_RESOLUTION_MIN_HOURS if min_hours is None else min_hours
+            if hours < floor:
                 return False, [f"Resolves in {hours}h - too soon"]
         except (ValueError, IndexError):
             pass
@@ -711,7 +727,7 @@ def check_exit_opportunities(dry_run: bool = False, use_safeguards: bool = True)
             # Check safeguards before selling
             if use_safeguards:
                 context = get_market_context(market_id)
-                should_trade, reasons = check_context_safeguards(context)
+                should_trade, reasons = check_context_safeguards(context, min_hours=EXIT_MIN_HOURS_TO_RESOLVE)
                 if not should_trade:
                     print(f"     ⏭️  Skipped: {'; '.join(reasons)}")
                     continue
@@ -770,7 +786,12 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
         log("\n  [PAPER MODE] Trades will be simulated with real prices. Use --live for real trades.")
 
     log(f"\n⚙️  Configuration:")
-    log(f"  Entry threshold: {ENTRY_THRESHOLD:.0%} (buy below this)")
+    log(f"  Entry threshold: {ENTRY_THRESHOLD:.0%} (buy below this; upper bound only)")
+    if MIN_ENTRY_PRICE > 0:
+        log(f"  Min entry price: {MIN_ENTRY_PRICE:.0%} (reject below this)")
+        if MIN_ENTRY_PRICE >= ENTRY_THRESHOLD:
+            log(f"  ⚠️  Min entry ${MIN_ENTRY_PRICE:.2f} >= entry threshold ${ENTRY_THRESHOLD:.2f}: every candidate will be skipped", force=True)
+    log(f"  Min hours to resolve: {TIME_TO_RESOLUTION_MIN_HOURS:g} (entries only; exits keep {EXIT_MIN_HOURS_TO_RESOLVE}h)")
     log(f"  Exit threshold:  {EXIT_THRESHOLD:.0%} (sell above this)")
     log(f"  Max position:    ${MAX_POSITION_USD:.2f}")
     log(f"  Max trades/run:  {MAX_TRADES_PER_RUN}")
@@ -941,6 +962,12 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
             skip_reasons.append("price at extreme")
             continue
 
+        should_enter, entry_reason = check_entry_price(price)
+        if not should_enter:
+            log(f"  ⏸️  {entry_reason} - skip")
+            skip_reasons.append(entry_reason)
+            continue
+
         # Check safeguards with edge analysis
         # NOAA forecasts are ~85% accurate for 1-2 day predictions when in-bucket
         noaa_probability = 0.85
@@ -964,7 +991,7 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
             elif trend["direction"] == "up":
                 trend_bonus = f" 📈 (up {trend['change_24h']:.0%} in 24h)"
 
-        if price < ENTRY_THRESHOLD:
+        if should_enter:
             position_size = calculate_position_size(MAX_POSITION_USD, smart_sizing)
 
             min_cost_for_shares = MIN_SHARES_PER_ORDER * price
@@ -1026,8 +1053,6 @@ def run_weather_strategy(dry_run: bool = True, positions_only: bool = False,
                 error = result.get("error", "Unknown error")
                 log(f"  ❌ Trade failed: {error}", force=True)
                 execution_errors.append(error[:120])
-        else:
-            log(f"  ⏸️  Price ${price:.2f} above threshold ${ENTRY_THRESHOLD:.2f} - skip")
 
     exits_found, exits_executed = check_exit_opportunities(dry_run, use_safeguards)
 
@@ -1096,6 +1121,8 @@ if __name__ == "__main__":
             _config = load_config(CONFIG_SCHEMA, __file__, slug="kalshi-weather-trader")
             # Update module-level vars
             globals()["ENTRY_THRESHOLD"] = _config["entry_threshold"]
+            globals()["MIN_ENTRY_PRICE"] = _config.get("min_entry_price", 0.0)
+            globals()["TIME_TO_RESOLUTION_MIN_HOURS"] = _config.get("min_hours_to_resolve", 2)
             globals()["EXIT_THRESHOLD"] = _config["exit_threshold"]
             globals()["MAX_POSITION_USD"] = _config["max_position_usd"]
             globals()["SMART_SIZING_PCT"] = _config["sizing_pct"]


### PR DESCRIPTION
## Summary
- port `SIMMER_WEATHER_MIN_ENTRY_PRICE` and `SIMMER_WEATHER_MIN_HOURS_TO_RESOLVE` to `kalshi-weather-trader`
- move the local entry price-band check before context and trend fetches
- keep exits on the original fixed 2h time-to-resolution floor and document/configure the new knobs
- bump `kalshi-weather-trader` to 1.0.12 and add pinned entry safeguard tests

## Verification
- `python3 -m json.tool skills/kalshi-weather-trader/clawhub.json`
- `python3 scripts/check-skill-governance.py`
- `python3 -m pytest skills/kalshi-weather-trader/tests -q`

Closes SIM-5160