### PR TITLE
fix: gate simmer skill bumps on website sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Check skill governance
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SIMMER_WEBSITE_SYNC_GITHUB_TOKEN: ${{ secrets.SIMMER_WEBSITE_SYNC_GITHUB_TOKEN }}
         run: python3 scripts/check-skill-governance.py
 
   build:

--- a/scripts/check-skill-governance.py
+++ b/scripts/check-skill-governance.py
@@ -35,6 +35,13 @@ WALLET_ENV_HINTS = {
     "SOLANA_PRIVATE_KEY",
     "EVM_PRIVATE_KEY",
 }
+SIMMER_SKILL_PATH = "skills/simmer/SKILL.md"
+SIMMER_WEBSITE_REPO = "SupaFund/simmer"
+SIMMER_WEBSITE_SKILL_PATH = "website/public/skill.md"
+SIMMER_WEBSITE_SYNC_WAIVER_MARKERS = {
+    "simmer-website-sync-waived",
+    "website-skill-sync-waived",
+}
 
 
 def run_git(args: list[str]) -> str:
@@ -114,6 +121,78 @@ def git_file_at_ref(ref: str, path: str) -> str | None:
         return None
 
 
+def current_pull_request() -> dict[str, Any]:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return {}
+
+    try:
+        event = load_json(Path(event_path))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    pr = event.get("pull_request")
+    return pr if isinstance(pr, dict) else {}
+
+
+def pr_has_simmer_website_sync_waiver() -> bool:
+    body = str(current_pull_request().get("body") or "").lower()
+    return any(
+        f"{marker}:" in body or f"{marker}=true" in body
+        for marker in SIMMER_WEBSITE_SYNC_WAIVER_MARKERS
+    )
+
+
+def github_json(url: str) -> Any:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "simmer-sdk-skill-governance",
+    }
+    token = os.environ.get("SIMMER_WEBSITE_SYNC_GITHUB_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return json.load(response)
+
+
+def open_simmer_website_sync_pr(new_version: str) -> str | None:
+    pulls = github_json(
+        f"https://api.github.com/repos/{SIMMER_WEBSITE_REPO}/pulls?state=open&per_page=100"
+    )
+    if not isinstance(pulls, list):
+        return None
+
+    for pr in pulls:
+        if not isinstance(pr, dict):
+            continue
+        number = pr.get("number")
+        if not number:
+            continue
+
+        files = github_json(
+            f"https://api.github.com/repos/{SIMMER_WEBSITE_REPO}/pulls/{number}/files?per_page=100"
+        )
+        if not isinstance(files, list):
+            continue
+
+        for changed_file in files:
+            if not isinstance(changed_file, dict):
+                continue
+            if changed_file.get("filename") != SIMMER_WEBSITE_SKILL_PATH:
+                continue
+
+            patch = str(changed_file.get("patch") or "")
+            if new_version in patch:
+                return str(pr.get("html_url") or f"{SIMMER_WEBSITE_REPO}#{number}")
+
+    return None
+
+
 def validate_skill_version_bumps(paths: list[str], base_ref: str) -> list[str]:
     errors: list[str] = []
 
@@ -153,6 +232,46 @@ def validate_skill_version_bumps(paths: list[str], base_ref: str) -> list[str]:
             )
 
     return errors
+
+
+def validate_simmer_website_sync_gate(paths: list[str], base_ref: str) -> list[str]:
+    if SIMMER_SKILL_PATH not in paths:
+        return []
+
+    current_text = (ROOT / SIMMER_SKILL_PATH).read_text(encoding="utf-8")
+    current_version = extract_skill_metadata_version(current_text)
+    previous_text = git_file_at_ref(base_ref, SIMMER_SKILL_PATH)
+    previous_version = (
+        extract_skill_metadata_version(previous_text)
+        if previous_text is not None
+        else None
+    )
+    if not current_version or not previous_version or current_version == previous_version:
+        return []
+
+    if pr_has_simmer_website_sync_waiver():
+        return []
+
+    try:
+        sync_pr = open_simmer_website_sync_pr(current_version)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        return [
+            f"{SIMMER_SKILL_PATH} metadata.version changed from {previous_version} "
+            f"to {current_version}, but the check could not inspect open "
+            f"{SIMMER_WEBSITE_REPO} PRs: {exc}. Open a matching PR that changes "
+            f"{SIMMER_WEBSITE_SKILL_PATH}, or add "
+            "'simmer-website-sync-waived: <reason>' to this PR body."
+        ]
+
+    if sync_pr:
+        return []
+
+    return [
+        f"{SIMMER_SKILL_PATH} metadata.version changed from {previous_version} "
+        f"to {current_version}; open a matching {SIMMER_WEBSITE_REPO} PR that "
+        f"changes {SIMMER_WEBSITE_SKILL_PATH} to {current_version}, or add "
+        "'simmer-website-sync-waived: <reason>' to this PR body."
+    ]
 
 
 def pr_has_sensitive_approval_marker() -> bool:
@@ -301,6 +420,7 @@ def main() -> int:
     errors: list[str] = []
     if paths and base_ref is not None:
         errors.extend(validate_skill_version_bumps(paths, base_ref))
+        errors.extend(validate_simmer_website_sync_gate(paths, base_ref))
     for skill_dir in sorted(skill_dirs):
         errors.extend(validate_skill(skill_dir, pr_approved))
 

--- a/tests/test_skill_governance.py
+++ b/tests/test_skill_governance.py
@@ -117,3 +117,118 @@ def test_changed_skill_requires_current_metadata_version(tmp_path, monkeypatch) 
         "skills/weather/SKILL.md is missing metadata.version; add a skill version "
         "so ClawHub can publish it"
     ]
+
+
+def simmer_skill_md(version: str) -> str:
+    return f"""---
+name: simmer
+metadata:
+  author: Simmer
+  version: "{version}"
+---
+# Simmer
+"""
+
+
+def write_simmer_skill(tmp_path: Path, version: str) -> None:
+    skill_dir = tmp_path / "skills" / "simmer"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(simmer_skill_md(version), encoding="utf-8")
+
+
+def patch_simmer_gate_repo(monkeypatch, tmp_path: Path, previous_version: str) -> None:
+    monkeypatch.setattr(check_skill_governance, "ROOT", tmp_path)
+    monkeypatch.setattr(check_skill_governance, "SKILLS_DIR", tmp_path / "skills")
+
+    def fake_git_file_at_ref(ref: str, path: str) -> str | None:
+        assert ref == "base-ref"
+        assert path == "skills/simmer/SKILL.md"
+        return simmer_skill_md(previous_version)
+
+    monkeypatch.setattr(check_skill_governance, "git_file_at_ref", fake_git_file_at_ref)
+
+
+def test_simmer_website_sync_gate_ignores_non_version_change(tmp_path, monkeypatch) -> None:
+    write_simmer_skill(tmp_path, "1.25.2")
+    patch_simmer_gate_repo(monkeypatch, tmp_path, previous_version="1.25.2")
+    monkeypatch.setattr(
+        check_skill_governance,
+        "open_simmer_website_sync_pr",
+        lambda version: (_ for _ in ()).throw(AssertionError("should not query GitHub")),
+    )
+
+    assert (
+        check_skill_governance.validate_simmer_website_sync_gate(
+            ["skills/simmer/SKILL.md"],
+            "base-ref",
+        )
+        == []
+    )
+
+
+def test_simmer_website_sync_gate_allows_pr_body_waiver(tmp_path, monkeypatch) -> None:
+    write_simmer_skill(tmp_path, "1.25.3")
+    patch_simmer_gate_repo(monkeypatch, tmp_path, previous_version="1.25.2")
+    monkeypatch.setattr(
+        check_skill_governance,
+        "current_pull_request",
+        lambda: {"body": "simmer-website-sync-waived: emergency hotfix"},
+    )
+    monkeypatch.setattr(
+        check_skill_governance,
+        "open_simmer_website_sync_pr",
+        lambda version: (_ for _ in ()).throw(AssertionError("should not query GitHub")),
+    )
+
+    assert (
+        check_skill_governance.validate_simmer_website_sync_gate(
+            ["skills/simmer/SKILL.md"],
+            "base-ref",
+        )
+        == []
+    )
+
+
+def test_simmer_website_sync_gate_allows_matching_open_sync_pr(
+    tmp_path, monkeypatch
+) -> None:
+    write_simmer_skill(tmp_path, "1.25.3")
+    patch_simmer_gate_repo(monkeypatch, tmp_path, previous_version="1.25.2")
+    monkeypatch.setattr(check_skill_governance, "current_pull_request", lambda: {"body": ""})
+    monkeypatch.setattr(
+        check_skill_governance,
+        "open_simmer_website_sync_pr",
+        lambda version: "https://github.com/SupaFund/simmer/pull/2000",
+    )
+
+    assert (
+        check_skill_governance.validate_simmer_website_sync_gate(
+            ["skills/simmer/SKILL.md"],
+            "base-ref",
+        )
+        == []
+    )
+
+
+def test_simmer_website_sync_gate_requires_matching_open_sync_pr(
+    tmp_path, monkeypatch
+) -> None:
+    write_simmer_skill(tmp_path, "1.25.3")
+    patch_simmer_gate_repo(monkeypatch, tmp_path, previous_version="1.25.2")
+    monkeypatch.setattr(check_skill_governance, "current_pull_request", lambda: {"body": ""})
+    monkeypatch.setattr(
+        check_skill_governance,
+        "open_simmer_website_sync_pr",
+        lambda version: None,
+    )
+
+    errors = check_skill_governance.validate_simmer_website_sync_gate(
+        ["skills/simmer/SKILL.md"],
+        "base-ref",
+    )
+
+    assert errors == [
+        "skills/simmer/SKILL.md metadata.version changed from 1.25.2 to 1.25.3; "
+        "open a matching SupaFund/simmer PR that changes website/public/skill.md "
+        "to 1.25.3, or add 'simmer-website-sync-waived: <reason>' to this PR body."
+    ]


### PR DESCRIPTION
## Summary

- Added a `skill-governance` gate for `skills/simmer/SKILL.md` metadata.version bumps.
- The gate requires an open `SupaFund/simmer` PR that changes `website/public/skill.md` to the bumped version, or an explicit `simmer-website-sync-waived: <reason>` PR-body waiver.
- Wired an optional `SIMMER_WEBSITE_SYNC_GITHUB_TOKEN` secret into CI for private cross-repo reads, falling back to `GITHUB_TOKEN`.

## Verification

- `pytest tests/test_skill_governance.py -q`
- `python3 -m py_compile scripts/check-skill-governance.py`
- `GITHUB_BASE_REF=main python3 scripts/check-skill-governance.py`

Closes SIM-4673