### PR TITLE
fix: sync replay engine for recent markets

### DIFF
--- a/simmer_sdk/backtest/replay/candles_service.py
+++ b/simmer_sdk/backtest/replay/candles_service.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/candles_service.py @ df6bde474420
+# vendored from simmer_v3/replay/candles_service.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Candles data-plane service (SIM-3070 Phase 1.5C — spec §C).
 

--- a/simmer_sdk/backtest/replay/duckdb_store.py
+++ b/simmer_sdk/backtest/replay/duckdb_store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/duckdb_store.py @ df6bde474420
+# vendored from simmer_v3/replay/duckdb_store.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """DuckDB-backed HistoricalStore over the Polymarket trade-tape parquet set.
 
@@ -63,7 +63,7 @@ class DuckDBStore:
 
     # -- HistoricalStore ----------------------------------------------------
 
-    def markets(self, at: datetime, *, limit: int = 500, **filters) -> list[MarketMeta]:
+    def markets(self, at: datetime, *, limit: int = 500, order_by: str = "volume", **filters) -> list[MarketMeta]:
         clauses = ["created_at <= ?", "(end_date IS NULL OR end_date > ?)"]
         params: list = [at, at]
         if "event_id" in filters:
@@ -73,11 +73,17 @@ class DuckDBStore:
             clauses.append("slug LIKE ?")
             params.append(filters["slug_like"])
         params.append(limit)
+        if order_by == "created_at":
+            order_clause = "created_at DESC, volume DESC"
+        elif order_by == "volume":
+            order_clause = "volume DESC"
+        else:
+            raise ValueError(f"unsupported replay market ordering: {order_by!r}")
         rows = self._con.execute(
             f"""SELECT id, question, slug, condition_id, answer1, answer2,
                        created_at, end_date, event_id, event_title, neg_risk, volume
                 FROM m WHERE {' AND '.join(clauses)}
-                ORDER BY volume DESC LIMIT ?""",
+                ORDER BY {order_clause} LIMIT ?""",
             params,
         ).fetchall()
         return [

--- a/simmer_sdk/backtest/replay/engine.py
+++ b/simmer_sdk/backtest/replay/engine.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/engine.py @ df6bde474420
+# vendored from simmer_v3/replay/engine.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay engine — the tick loop + report builder (SIM-3070 chunk 3).
 

--- a/simmer_sdk/backtest/replay/feeds/binance.py
+++ b/simmer_sdk/backtest/replay/feeds/binance.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/feeds/binance.py @ df6bde474420
+# vendored from simmer_v3/replay/feeds/binance.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Binance historical klines feed for replay (SIM-3079).
 

--- a/simmer_sdk/backtest/replay/harness.py
+++ b/simmer_sdk/backtest/replay/harness.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/harness.py @ df6bde474420
+# vendored from simmer_v3/replay/harness.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Unmodified-bundle replay harness (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/server.py
+++ b/simmer_sdk/backtest/replay/server.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/server.py @ df6bde474420
+# vendored from simmer_v3/replay/server.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """Replay API server — the minimal /api/sdk surface skills consume (SIM-3070).
 
@@ -173,13 +173,14 @@ def create_app(session: ReplaySession) -> FastAPI:
         tags: Optional[str] = None,
     ):
         _reject_unsupported(venue=venue, status=status, tags=tags)
-        metas = session.view.markets(limit=max(limit * 4, limit))
-        if q:
-            ql = q.lower()
-            metas = [m for m in metas if ql in m.question.lower() or ql in m.slug.lower()]
         sort_norm = sort.strip().lower() if sort else None
         if sort_norm == "created":
             sort_norm = "recent"
+        order_by = "created_at" if sort_norm == "recent" else "volume"
+        metas = session.view.markets(limit=max(limit * 4, limit), order_by=order_by)
+        if q:
+            ql = q.lower()
+            metas = [m for m in metas if ql in m.question.lower() or ql in m.slug.lower()]
         if sort_norm == "recent":
             metas = sorted(metas, key=lambda m: m.created_at, reverse=True)
         else:

--- a/simmer_sdk/backtest/replay/simstate.py
+++ b/simmer_sdk/backtest/replay/simstate.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/simstate.py @ df6bde474420
+# vendored from simmer_v3/replay/simstate.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """SimState — the simulated agent portfolio during replay (SIM-3070).
 

--- a/simmer_sdk/backtest/replay/store.py
+++ b/simmer_sdk/backtest/replay/store.py
@@ -1,4 +1,4 @@
-# vendored from simmer_v3/replay/store.py @ df6bde474420
+# vendored from simmer_v3/replay/store.py @ ce89ed16b684
 # DO NOT EDIT HERE — regenerate via scripts/sync_replay_engine.py
 """HistoricalStore protocol + the frozen-clock view the replay server uses.
 
@@ -68,7 +68,7 @@ class HistoricalStore(Protocol):
     Policy (clamping to the frozen tick) lives in ReplayView.
     """
 
-    def markets(self, at: datetime, *, limit: int = 500, **filters) -> list[MarketMeta]:
+    def markets(self, at: datetime, *, limit: int = 500, order_by: str = "volume", **filters) -> list[MarketMeta]:
         """Markets tradable at `at`: created_at <= at and not yet ended."""
         ...
 
@@ -117,8 +117,8 @@ class ReplayView:
         response field (e.g. seconds_to_expiry) from this, never wall clock."""
         return self._at
 
-    def markets(self, *, limit: int = 500, **filters) -> list[MarketMeta]:
-        return self._store.markets(self._at, limit=limit, **filters)
+    def markets(self, *, limit: int = 500, order_by: str = "volume", **filters) -> list[MarketMeta]:
+        return self._store.markets(self._at, limit=limit, order_by=order_by, **filters)
 
     def price(self, market_id: str) -> Optional[PricePoint]:
         return self._store.price(market_id, self._at)


### PR DESCRIPTION
Sync the vendored replay engine from SupaFund/simmer PR #2294 so the public backtest CLI gets the same explicit `sort=recent` / `sort=created` behavior.

Source backend commit: SupaFund/simmer@ce89ed16b6840a3aedc9aa0ee69cc3d338fa3e3a
Backend PR: https://github.com/SupaFund/simmer/pull/2294

Verification:
- `python3 scripts/sync_replay_engine.py --check --source /Users/simmer-ops/Documents/code/active/kozy/simmer`
- `python3 -m pytest -q tests/test_backtest_run.py tests/test_tape_endpoint.py`

Closes SIM-5182