### PR TITLE
Spike: OpenAI Agents API session → simmer-mcp (#365)

### DIFF
--- a/examples/openai_agents_mcp_spike.py
+++ b/examples/openai_agents_mcp_spike.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Spike: OpenAI Agents API session driving simmer-mcp (#365).
+
+This is a proof, not a product harness. It builds a session that calls the
+existing simmer-mcp tool surface (markets / paper trade / briefing). It does
+not add a new agent runtime, fork Codex, or place live-venue orders.
+
+simmer-mcp ships as stdio (`npx simmer-mcp`). Agents API
+`environment.type: none` can call remote MCP only over HTTP, so you need a
+public Streamable HTTP URL in front of that same process. Credentials stay in
+the environment (`SIMMER_API_KEY`, `OPENAI_API_KEY`). Never commit them.
+
+Default mode is dry-run: print a redacted session payload and exit. CI uses
+that path. `--mock` prints the intended MCP tool sequence without calling
+OpenAI. `--run` creates a real session when keys (and a reachable MCP URL)
+are present.
+
+Usage:
+    python examples/openai_agents_mcp_spike.py
+    python examples/openai_agents_mcp_spike.py --mock
+    SIMMER_MCP_URL=https://your-host/mcp \\
+      OPENAI_API_KEY=... SIMMER_API_KEY=sk_live_... \\
+      python examples/openai_agents_mcp_spike.py --run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+AGENTS_BETA_HEADER = "agents=v1"
+AGENTS_SESSIONS_URL = "https://api.openai.com/v1/agents/sessions"
+DEFAULT_MODEL = "gpt-6-astra"
+PLACEHOLDER_MCP_URL = "https://mcp.example.invalid/mcp"
+
+# MCP names (not SDK aliases). simmer_browse_markets is the keyless stand-in
+# for simmer_get_markets when the HTTP process has no SIMMER_API_KEY.
+PROOF_TOOLS = (
+    "simmer_get_markets",
+    "simmer_browse_markets",
+    "simmer_trade",
+    "simmer_get_briefing",
+)
+
+SPIKE_INSTRUCTIONS = """You are a Simmer paper-trading spike agent.
+
+Use only the simmer MCP tools. Stay on the virtual SIM venue.
+Currency on that venue is written as a $SIM suffix (example: 1.00 $SIM).
+
+Hard rules:
+- Call simmer_get_markets (or simmer_browse_markets if the keyless catalogue is all you have).
+- Preview one paper trade with simmer_trade: venue=sim, dry_run=true, amount=1, side=yes.
+- Then call simmer_get_briefing.
+- Never set dry_run=false. Never use venue=polymarket or venue=kalshi.
+- Never ask for or print API keys.
+"""
+
+SPIKE_TASK = """Using simmer MCP tools only, do these three things and summarize the results:
+
+1. List a few active markets. Prefer simmer_get_markets with sort=volume and a small limit. If that tool is missing, use simmer_browse_markets.
+2. Preview a paper $SIM trade with simmer_trade: venue=sim, dry_run=true, amount=1, side=yes, action=buy. Pick any returned market_id. Do not place a live order.
+3. Call simmer_get_briefing.
+
+Report what each tool returned. Stop after the briefing.
+"""
+
+MOCK_TOOL_TRACE = (
+    {
+        "tool": "simmer_get_markets",
+        "arguments": {"sort": "volume", "limit": 5, "venue": "sim"},
+        "result": {
+            "markets": [
+                {
+                    "id": "00000000-0000-4000-8000-000000000001",
+                    "question": "Mock spike market (dry path)",
+                    "venue": "sim",
+                    "status": "active",
+                }
+            ]
+        },
+    },
+    {
+        "tool": "simmer_trade",
+        "arguments": {
+            "market_id": "00000000-0000-4000-8000-000000000001",
+            "side": "yes",
+            "action": "buy",
+            "amount": 1,
+            "venue": "sim",
+            "dry_run": True,
+            "reasoning": "Agents API spike paper preview",
+            "source": "sdk:openai-agents-mcp-spike",
+        },
+        "result": {
+            "success": True,
+            "dry_run": True,
+            "venue": "sim",
+            "cost_sim": "1.00 $SIM",
+        },
+    },
+    {
+        "tool": "simmer_get_briefing",
+        "arguments": {},
+        "result": {
+            "balance": "10000.00 $SIM",
+            "open_positions": 0,
+            "note": "Mock briefing. Live --run uses the real MCP tool.",
+        },
+    },
+)
+
+
+def _require_https_mcp_url(url: str) -> str:
+    parsed = url.strip()
+    if not parsed.startswith("https://"):
+        raise ValueError(
+            "SIMMER_MCP_URL must be an https Streamable HTTP endpoint "
+            "reachable from OpenAI (environment.type=none)."
+        )
+    return parsed
+
+
+def build_http_mcp_tool(
+    server_url: str,
+    *,
+    authorization: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Remote MCP tool for environment.type=none (OpenAI dials HTTP)."""
+    transport: Dict[str, Any] = {
+        "type": "http",
+        "server_url": server_url,
+    }
+    if authorization:
+        # Optional. simmer-mcp itself reads SIMMER_API_KEY from process env,
+        # not from HTTP headers. Set this only if your HTTP front-end maps
+        # Authorization onto that process.
+        transport["authorization"] = authorization
+    return {
+        "type": "mcp",
+        "server_label": "simmer",
+        "transport": transport,
+        "connection_origin": "service",
+        "required": True,
+        "allowed_tools": list(PROOF_TOOLS),
+    }
+
+
+def build_stdio_mcp_tool() -> Dict[str, Any]:
+    """Fallback: executor starts published simmer-mcp inside a sandbox."""
+    return {
+        "type": "mcp",
+        "server_label": "simmer",
+        "transport": {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "simmer-mcp"],
+            "cwd": "/workspace",
+            "env_vars": ["SIMMER_API_KEY"],
+        },
+        "required": True,
+        "allowed_tools": list(PROOF_TOOLS),
+    }
+
+
+def build_session_payload(
+    *,
+    model: str = DEFAULT_MODEL,
+    mcp_url: Optional[str] = None,
+    authorization: Optional[str] = None,
+    stdio_sandbox: bool = False,
+    simmer_api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Session body for POST /v1/agents/sessions (OpenAI-Beta: agents=v1)."""
+    if stdio_sandbox:
+        environment: Dict[str, Any] = {
+            "type": "openai_hosted",
+            "network": {"access": "enabled"},
+            "packages": {"npm": ["simmer-mcp"]},
+        }
+        if simmer_api_key:
+            # Visible to agent-generated code in the sandbox. Prefer HTTP +
+            # process-env on a host you control.
+            environment["env"] = {"SIMMER_API_KEY": simmer_api_key}
+        tools: List[Dict[str, Any]] = [build_stdio_mcp_tool()]
+    else:
+        environment = {"type": "none"}
+        tools = [
+            build_http_mcp_tool(
+                mcp_url or PLACEHOLDER_MCP_URL,
+                authorization=authorization,
+            )
+        ]
+
+    return {
+        "agent": {
+            "model": model,
+            "instructions": SPIKE_INSTRUCTIONS,
+            "tools": tools,
+        },
+        "environment": environment,
+        "input": SPIKE_TASK,
+    }
+
+
+def redact_secrets(value: Any) -> Any:
+    """Strip key material from printed payloads. Never log secrets."""
+    secret_keys = {
+        "authorization",
+        "simmer_api_key",
+        "openai_api_key",
+        "api_key",
+    }
+    if isinstance(value, dict):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = key.lower()
+            if lowered in secret_keys or lowered.endswith("_api_key"):
+                redacted[key] = "***"
+            elif lowered == "headers" and isinstance(item, dict):
+                redacted[key] = {
+                    hk: ("***" if "auth" in hk.lower() or "key" in hk.lower() else redact_secrets(hv))
+                    for hk, hv in item.items()
+                }
+            elif lowered == "env" and isinstance(item, dict):
+                redacted[key] = {ek: "***" for ek in item}
+            else:
+                redacted[key] = redact_secrets(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_secrets(item) for item in value]
+    return value
+
+
+def assert_paper_only(payload: Dict[str, Any]) -> None:
+    """Fail closed if the spike payload asks for a live venue."""
+    blob = json.dumps(payload)
+    if "SIMMER_MCP_ALLOW_LIVE" in blob:
+        raise AssertionError("spike must not enable SIMMER_MCP_ALLOW_LIVE")
+    instructions = payload["agent"]["instructions"]
+    if "dry_run=true" not in instructions or "venue=sim" not in instructions:
+        raise AssertionError("instructions must pin venue=sim and dry_run=true")
+    if "Never set dry_run=false" not in instructions:
+        raise AssertionError("instructions must forbid live execution")
+
+
+def create_session_via_sdk(payload: Dict[str, Any], openai_api_key: str) -> Any:
+    """Preferred live path: client.beta.agents.sessions.create."""
+    from openai import OpenAI  # type: ignore
+
+    client = OpenAI(api_key=openai_api_key)
+    return client.beta.agents.sessions.create(
+        extra_headers={"OpenAI-Beta": AGENTS_BETA_HEADER},
+        stream=True,
+        **payload,
+    )
+
+
+def create_session_via_http(payload: Dict[str, Any], openai_api_key: str) -> Any:
+    """Stdlib fallback when the OpenAI SDK is not installed."""
+    body = dict(payload)
+    body["stream"] = False
+    data = json.dumps(body).encode("utf-8")
+    request = Request(
+        AGENTS_SESSIONS_URL,
+        data=data,
+        method="POST",
+        headers={
+            "Authorization": "Bearer %s" % openai_api_key,
+            "Content-Type": "application/json",
+            "OpenAI-Beta": AGENTS_BETA_HEADER,
+        },
+    )
+    try:
+        with urlopen(request, timeout=120) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError("Agents API HTTP %s: %s" % (exc.code, detail)) from exc
+    except URLError as exc:
+        raise RuntimeError("Agents API request failed: %s" % exc.reason) from exc
+
+
+def print_json(value: Any) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def print_mock_trace(events: Iterable[Dict[str, Any]] = MOCK_TOOL_TRACE) -> None:
+    print("# Mock MCP proof (no OpenAI call, no Simmer network)")
+    print_json({"steps": list(events), "venue": "sim", "dry_run": True})
+
+
+def run_live(payload: Dict[str, Any], openai_api_key: str) -> int:
+    try:
+        events = create_session_via_sdk(payload, openai_api_key)
+        print("# Streaming client.beta.agents.sessions.create (OpenAI-Beta: agents=v1)")
+        with events:
+            for event in events:
+                rendered = event.to_json(indent=None) if hasattr(event, "to_json") else str(event)
+                print(rendered, flush=True)
+        return 0
+    except ImportError:
+        print(
+            "# openai SDK missing; falling back to stdlib POST "
+            "(pip install openai for client.beta.agents.sessions)",
+            file=sys.stderr,
+        )
+        result = create_session_via_http(payload, openai_api_key)
+        print_json(redact_secrets(result))
+        return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Create a real Agents API session. Requires OPENAI_API_KEY and a reachable MCP.",
+    )
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        help="Print the intended MCP tool sequence without calling OpenAI.",
+    )
+    parser.add_argument(
+        "--stdio-sandbox",
+        action="store_true",
+        help="Use smallest openai_hosted + stdio simmer-mcp instead of HTTP / environment.none.",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("OPENAI_AGENTS_MODEL", DEFAULT_MODEL),
+        help="Agents API model (default: gpt-6-astra or OPENAI_AGENTS_MODEL).",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    mcp_url = os.environ.get("SIMMER_MCP_URL")
+    simmer_key = os.environ.get("SIMMER_API_KEY")
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    authorization = os.environ.get("SIMMER_MCP_AUTHORIZATION")
+
+    if mcp_url:
+        mcp_url = _require_https_mcp_url(mcp_url)
+
+    if args.run and not args.stdio_sandbox and not mcp_url:
+        print(
+            "error: --run with environment.type=none needs SIMMER_MCP_URL "
+            "(public https Streamable HTTP in front of simmer-mcp).\n"
+            "Or pass --stdio-sandbox to start npx simmer-mcp inside openai_hosted.",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = build_session_payload(
+        model=args.model,
+        mcp_url=mcp_url,
+        authorization=authorization,
+        stdio_sandbox=args.stdio_sandbox,
+        simmer_api_key=simmer_key,
+    )
+    assert_paper_only(payload)
+
+    print("# Redacted session payload (secrets from env only; never committed)")
+    print_json(redact_secrets(payload))
+
+    if args.mock:
+        print()
+        print_mock_trace()
+        return 0
+
+    if not args.run:
+        print()
+        print(
+            "Dry-run only. Re-run with --mock for the tool sequence, "
+            "or --run after exporting OPENAI_API_KEY and SIMMER_MCP_URL."
+        )
+        return 0
+
+    if not openai_key:
+        print("error: --run requires OPENAI_API_KEY", file=sys.stderr)
+        return 2
+
+    print()
+    return run_live(payload, openai_key)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -148,6 +148,52 @@ allowlist decision and rationale.
 - Set `SIMMER_MCP_PYTHON` to that interpreter. The server resolves Python from
   `SIMMER_MCP_PYTHON`, then `PATH` — it never discovers a `.venv` on its own.
 
+## OpenAI Agents API (spike)
+
+Proof that a managed [Agents API](https://developers.openai.com/api/docs/guides/agents-api/overview)
+session can drive **this same simmer-mcp package** — markets, a paper `$SIM`
+trade, and briefing. Not a new runtime. Not a Codex fork. See
+[`examples/openai_agents_mcp_spike.py`](../examples/openai_agents_mcp_spike.py)
+and [#365](https://github.com/SpartanLabsXyz/simmer-sdk/issues/365).
+
+This package is still **stdio** (`npx simmer-mcp`). Agents API
+`environment.type: none` can call remote MCP only over **HTTP**, so you put a
+Streamable HTTP front (Smithery, `mcp-proxy`, or your own host) in front of the
+same process. Keep `SIMMER_API_KEY` on that process. Do not commit keys.
+
+```bash
+python examples/openai_agents_mcp_spike.py          # dry-run payload (no secrets)
+python examples/openai_agents_mcp_spike.py --mock   # intended MCP tool sequence
+export OPENAI_API_KEY=...
+export SIMMER_API_KEY=sk_live_...
+export SIMMER_MCP_URL=https://your-host/mcp
+python examples/openai_agents_mcp_spike.py --run    # live Agents session
+```
+
+`--run` needs a current `openai` SDK (`client.beta.agents.sessions.create` plus
+`OpenAI-Beta: agents=v1`). Without `SIMMER_MCP_URL`, pass `--stdio-sandbox` for
+the smallest `openai_hosted` fallback: `npx -y simmer-mcp` inside the sandbox.
+
+### What this spike is not
+
+- Not a generic agent harness, and not a replacement for Grok Bot / Cursor
+  eng-writers.
+- Not live Polymarket or Kalshi. Paper / virtual `$SIM` only
+  (`venue=sim`, `dry_run=true`). Do not set `SIMMER_MCP_ALLOW_LIVE`.
+
+### Auth and API limits
+
+- simmer-mcp reads `SIMMER_API_KEY` from **process env**, not from HTTP
+  `Authorization`. Agents API can send `transport.authorization`; that only
+  helps if your HTTP front-end maps it. Default: leave the header unset and
+  keep the key on the MCP process.
+- `environment.type: none` + HTTP: OpenAI dials your public URL
+  (`connection_origin: service`). Localhost is not reachable.
+- `openai_hosted` + stdio: the sandbox can read `environment.env`. Prefer HTTP
+  so the Simmer key never sits in agent-visible sandbox memory.
+- Agents API is US data residency only and is **not** ZDR. A self-hosted
+  sandbox does not make the API ZDR-eligible.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, test structure, and release checklist.

--- a/tests/test_openai_agents_mcp_spike.py
+++ b/tests/test_openai_agents_mcp_spike.py
@@ -1,0 +1,138 @@
+"""Dry/mocked coverage for the OpenAI Agents API → simmer-mcp spike (#365).
+
+Does not call OpenAI or Simmer. Secrets stay out of fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+SPIKE_PATH = Path(__file__).resolve().parents[1] / "examples" / "openai_agents_mcp_spike.py"
+
+
+def load_spike():
+    spec = importlib.util.spec_from_file_location("openai_agents_mcp_spike", SPIKE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def spike():
+    return load_spike()
+
+
+def test_http_none_payload_uses_existing_mcp_tools(spike):
+    payload = spike.build_session_payload(
+        mcp_url="https://example.com/mcp",
+        authorization="Bearer sk_live_placeholder",
+    )
+    spike.assert_paper_only(payload)
+
+    assert payload["environment"] == {"type": "none"}
+    tool = payload["agent"]["tools"][0]
+    assert tool["type"] == "mcp"
+    assert tool["server_label"] == "simmer"
+    assert tool["connection_origin"] == "service"
+    assert tool["transport"]["type"] == "http"
+    assert tool["transport"]["server_url"] == "https://example.com/mcp"
+    assert tool["required"] is True
+    for name in (
+        "simmer_get_markets",
+        "simmer_browse_markets",
+        "simmer_trade",
+        "simmer_get_briefing",
+    ):
+        assert name in tool["allowed_tools"]
+
+
+def test_stdio_sandbox_is_smallest_hosted_fallback(spike):
+    payload = spike.build_session_payload(
+        stdio_sandbox=True,
+        simmer_api_key="sk_live_placeholder",
+    )
+    spike.assert_paper_only(payload)
+
+    env = payload["environment"]
+    assert env["type"] == "openai_hosted"
+    assert env["network"] == {"access": "enabled"}
+    assert env["packages"] == {"npm": ["simmer-mcp"]}
+    assert env["env"]["SIMMER_API_KEY"] == "sk_live_placeholder"
+
+    tool = payload["agent"]["tools"][0]
+    assert tool["transport"]["type"] == "stdio"
+    assert tool["transport"]["command"] == "npx"
+    assert tool["transport"]["args"] == ["-y", "simmer-mcp"]
+    assert "SIMMER_API_KEY" in tool["transport"]["env_vars"]
+
+
+def test_redact_secrets_strips_keys(spike):
+    http_payload = spike.build_session_payload(
+        mcp_url="https://example.com/mcp",
+        authorization="Bearer sk_live_secret",
+    )
+    hosted_payload = spike.build_session_payload(
+        stdio_sandbox=True,
+        simmer_api_key="sk_live_secret",
+    )
+    for payload in (http_payload, hosted_payload):
+        blob = json.dumps(spike.redact_secrets(payload))
+        assert "sk_live_secret" not in blob
+        assert "***" in blob
+
+
+def test_https_mcp_url_required(spike):
+    with pytest.raises(ValueError, match="https"):
+        spike._require_https_mcp_url("http://localhost:8787/mcp")
+
+
+def test_mock_trace_is_paper_sim_only(spike):
+    for step in spike.MOCK_TOOL_TRACE:
+        args = step["arguments"]
+        if step["tool"] == "simmer_trade":
+            assert args["venue"] == "sim"
+            assert args["dry_run"] is True
+            assert args["amount"] == 1
+        assert args.get("venue") in (None, "sim")
+
+
+def test_cli_dry_run_and_mock(spike, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SIMMER_API_KEY", raising=False)
+    monkeypatch.delenv("SIMMER_MCP_URL", raising=False)
+
+    dry = io.StringIO()
+    with redirect_stdout(dry):
+        assert spike.main([]) == 0
+    dry_out = dry.getvalue()
+    assert '"type": "none"' in dry_out
+    assert "sk_live_" not in dry_out
+    assert "Dry-run only" in dry_out
+
+    mocked = io.StringIO()
+    with redirect_stdout(mocked):
+        assert spike.main(["--mock"]) == 0
+    mock_out = mocked.getvalue()
+    assert "simmer_get_markets" in mock_out
+    assert "simmer_trade" in mock_out
+    assert "simmer_get_briefing" in mock_out
+    assert "1.00 $SIM" in mock_out
+
+
+def test_cli_run_without_url_exits(spike, monkeypatch):
+    monkeypatch.delenv("SIMMER_MCP_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert spike.main(["--run"]) == 2
+
+
+def test_cli_run_without_openai_key_exits(spike, monkeypatch):
+    monkeypatch.setenv("SIMMER_MCP_URL", "https://example.com/mcp")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert spike.main(["--run"]) == 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Plan

1. Inspect existing `mcp/` packaging: simmer-mcp is the published **stdio** npm package (`npx simmer-mcp`). Do not invent a runtime or a second MCP server.
2. Prove Agents API can drive that same tool surface (markets / paper `$SIM` trade / briefing) with the smallest session: `environment.type: none` + HTTP MCP when a public Streamable HTTP URL exists.
3. Ship one example script + a short cookbook note. No new package. No skill/bundle regen.

Closes nothing. Spike for #365. Draft only — do not merge.

## What landed

- [`examples/openai_agents_mcp_spike.py`](examples/openai_agents_mcp_spike.py) — builds `client.beta.agents.sessions.create` with `OpenAI-Beta: agents=v1`. Default dry-run prints a redacted payload. `--mock` prints the intended MCP sequence without network. `--run` creates a real session when `OPENAI_API_KEY` and `SIMMER_MCP_URL` are set.
- Cookbook note in [`mcp/README.md`](mcp/README.md).
- Dry/mocked tests in [`tests/test_openai_agents_mcp_spike.py`](tests/test_openai_agents_mcp_spike.py) (no live OpenAI or Simmer calls).

Preferred payload:

```json
{
  "environment": { "type": "none" },
  "agent": {
    "tools": [{
      "type": "mcp",
      "server_label": "simmer",
      "connection_origin": "service",
      "transport": { "type": "http", "server_url": "$SIMMER_MCP_URL" },
      "allowed_tools": ["simmer_get_markets", "simmer_browse_markets", "simmer_trade", "simmer_get_briefing"]
    }]
  }
}
```

`--stdio-sandbox` is the smallest fallback if you have no public HTTP URL: `openai_hosted` + `npx -y simmer-mcp`. Hosted stdio MCP needs `network.access: enabled`.

## Spike writeup

### What worked (from packaging + public Agents API docs)

- Remote HTTP MCP works **without** a sandbox. `environment.type: none` is enough when OpenAI can reach the URL (`connection_origin: service`).
- The proof tools already exist on published simmer-mcp. SDK `find_markets` maps to `simmer_get_markets` (or keyless `simmer_browse_markets`). Paper path is `simmer_trade` with `venue=sim` and `dry_run=true`. Briefing is `simmer_get_briefing`.
- No reason to add HTTP transport to the npm package for this spike. Put any Streamable HTTP front in front of the same stdio process (Smithery, `mcp-proxy`, or your host).

### Auth gotchas

- simmer-mcp reads `SIMMER_API_KEY` from **process env**, not from HTTP `Authorization`. Agents API `transport.authorization` only helps if your HTTP front-end maps it. Default: leave the header unset; keep the key on the MCP process.
- `environment.type: none` cannot see localhost. The URL must be public HTTPS.
- `openai_hosted` + stdio puts `SIMMER_API_KEY` in `environment.env`. Agent-generated sandbox code can read it. Prefer HTTP so the key stays on a host you control.
- Application `OPENAI_API_KEY` must stay **outside** the sandbox. Agents keys need `api.agents.read`, `api.agents.write`, and `api.responses.write`.
- Never commit keys. This script redacts them on stdout.

### Agents API limits

- US data residency only.
- **Not ZDR.** A self-hosted sandbox does not make the API ZDR-eligible.
- Public beta (`OpenAI-Beta: agents=v1`). Model default is `gpt-6-astra` (override with `OPENAI_AGENTS_MODEL`).

### Non-goals

- No generic agent harness.
- No replacement for Grok Bot / Cursor eng-writers.
- No live Polymarket/Kalshi. No `SIMMER_MCP_ALLOW_LIVE`. Virtual `$SIM` / paper only.
- No new npm/PyPI package. No skill or `bundled-skills` change (so no `bundle-skills` in this PR).

## Manual live steps (secrets not available in CI)

1. `pip install --upgrade openai`
2. Export `OPENAI_API_KEY` and `SIMMER_API_KEY` (from [simmer.markets/dashboard](https://simmer.markets/dashboard)).
3. Put Streamable HTTP in front of `npx -y simmer-mcp` (process env has the Simmer key). Export that public URL as `SIMMER_MCP_URL`.
4. `python examples/openai_agents_mcp_spike.py --run`
5. Confirm the turn calls `simmer_get_markets` (or `simmer_browse_markets`), `simmer_trade` with `dry_run=true` / `venue=sim`, and `simmer_get_briefing`.

Without a public MCP URL: `python examples/openai_agents_mcp_spike.py --run --stdio-sandbox`.

## Test

- `python3 -m pytest tests/test_openai_agents_mcp_spike.py` — 8 passed.
- Dry-run and `--mock` exercised locally. No live Agents or Simmer call (no keys in this environment).

AI-assisted PR. Meeting notes did not record a wiring decision for this spike.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b28a1357-51ec-4ea1-934b-f474b8154acc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b28a1357-51ec-4ea1-934b-f474b8154acc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

