### PR TITLE
docs: clarify Codex MCP preflight Python setup

### DIFF
--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.3.4"
+version: "0.3.5"
 published: true
 description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex / Grok Bot), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.3.4"
+  version: "0.3.5"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY

--- a/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
+++ b/mcp/bundled-skills/simmer-mcp-setup/SKILL.md
@@ -135,10 +135,18 @@ python3 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.17.13'
 ```
 
 Use a venv — most Linux hosts mark the system Python "externally managed", so a bare
-`pip install` fails with PEP 668. If `python3 -m venv` itself fails with
-*"ensurepip is not available"*, the venv module is packaged separately on that distro:
-`sudo apt install python3-venv` (Debian/Ubuntu), or use `pipx`, or as a last resort
-`pip install --break-system-packages`.
+`pip install` fails with PEP 668. Use Python 3.10 or newer for this venv; on macOS,
+`python3` can still be Apple's Python 3.9, which fails to resolve current Simmer SDK
+dependencies with errors such as `No matching distribution found for py-order-utils`.
+If that happens, create the venv with a newer interpreter instead:
+
+```bash
+python3.11 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.17.13'
+```
+
+If `python3 -m venv` itself fails with *"ensurepip is not available"*, the venv module is
+packaged separately on that distro: `sudo apt install python3-venv` (Debian/Ubuntu), or
+use `pipx`, or as a last resort `pip install --break-system-packages`.
 
 ⚠️ **Creating the venv is not enough — you must point the server at it.** The server is
 launched by your runtime as `npx -y simmer-mcp` and inherits *that* environment, not your

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simmer-mcp",
-  "version": "3.5.2",
+  "version": "3.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simmer-mcp",
-      "version": "3.5.2",
+      "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simmer-mcp",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "MCP server for Simmer — skill discovery, execution, autoresearch, and AI market tools",
   "type": "module",
   "repository": {

--- a/scripts/check_publish_lag.py
+++ b/scripts/check_publish_lag.py
@@ -226,15 +226,37 @@ RETRY_INTERVAL_SECS = 10
 RETRY_MAX_SECS = 120
 
 
-def check_package(label: str, repo_version: str, published_version: str) -> bool:
+def is_pull_request_event() -> bool:
+    return os.environ.get("GITHUB_EVENT_NAME") == "pull_request"
+
+
+def check_package(
+    label: str,
+    repo_version: str,
+    published_version: str,
+    is_pull_request: bool = False,
+) -> bool:
     comparison = compare_versions(repo_version, published_version)
     if comparison > 0:
+        if is_pull_request:
+            print(
+                f"{label}: repo version {repo_version} is ahead of published version "
+                f"{published_version}; publish is pending on merge to main."
+            )
+            return True
         print(
             f"::error::{label} repo version {repo_version} is ahead of "
             f"published version {published_version}. Publish the package before merging."
         )
         return False
     if comparison < 0:
+        if is_pull_request:
+            print(
+                f"::error::{label} published version {published_version} is ahead of "
+                f"repo version {repo_version}. The registry has a version not reflected "
+                "in git — investigate an out-of-band publish before merging."
+            )
+            return False
         print(
             f"{label}: repo version {repo_version} is behind published version "
             f"{published_version}; treating as already published/newer registry state."
@@ -250,6 +272,7 @@ def check_package_with_retry(
     repo_version: str,
     fetch_fn: "Callable[[], str]",
     retry: bool,
+    is_pull_request: bool = False,
 ) -> bool:
     """Check registry version, retrying if the package was just published.
 
@@ -258,7 +281,7 @@ def check_package_with_retry(
     With retry=True, poll up to RETRY_MAX_SECS before giving up.
     """
     if not retry:
-        return check_package(label, repo_version, fetch_fn())
+        return check_package(label, repo_version, fetch_fn(), is_pull_request=is_pull_request)
 
     deadline = time.monotonic() + RETRY_MAX_SECS
     attempt = 0
@@ -268,11 +291,11 @@ def check_package_with_retry(
         comparison = compare_versions(repo_version, published_version)
         if comparison <= 0:
             # registry caught up (match) or is ahead (newer release elsewhere)
-            return check_package(label, repo_version, published_version)
+            return check_package(label, repo_version, published_version, is_pull_request=is_pull_request)
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             # timed out — emit the real error
-            return check_package(label, repo_version, published_version)
+            return check_package(label, repo_version, published_version, is_pull_request=is_pull_request)
         wait = min(RETRY_INTERVAL_SECS, remaining)
         print(
             f"{label}: registry at {published_version}, waiting for {repo_version} to propagate"
@@ -316,22 +339,32 @@ def main() -> int:
 
     retry_npm = getattr(args, "retry_npm", False)
     retry_pypi = getattr(args, "retry_pypi", False)
+    is_pull_request = is_pull_request_event()
 
     if args.npm_published_version:
-        npm_ok = check_package(NPM_PACKAGE, npm_repo_version, args.npm_published_version)
+        npm_ok = check_package(
+            NPM_PACKAGE, npm_repo_version, args.npm_published_version, is_pull_request=is_pull_request
+        )
     else:
         npm_ok = check_package_with_retry(
-            NPM_PACKAGE, npm_repo_version, lambda: fetch_npm_latest(NPM_PACKAGE), retry=retry_npm
+            NPM_PACKAGE,
+            npm_repo_version,
+            lambda: fetch_npm_latest(NPM_PACKAGE),
+            retry=retry_npm,
+            is_pull_request=is_pull_request,
         )
 
     if args.pypi_published_version:
-        pypi_ok = check_package(PYPI_PACKAGE, pypi_repo_version, args.pypi_published_version)
+        pypi_ok = check_package(
+            PYPI_PACKAGE, pypi_repo_version, args.pypi_published_version, is_pull_request=is_pull_request
+        )
     else:
         pypi_ok = check_package_with_retry(
             PYPI_PACKAGE,
             pypi_repo_version,
             lambda: fetch_pypi_latest(PYPI_PACKAGE),
             retry=retry_pypi,
+            is_pull_request=is_pull_request,
         )
 
     errors = validate_mcp_version_bump(root)

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: simmer-mcp-setup
-version: "0.3.4"
+version: "0.3.5"
 published: true
 description: One-shot bootstrap for the Simmer MCP server. Detects your agent runtime (Claude Code / Cursor / OpenClaw / Hermes / Codex / Grok Bot), installs simmer-mcp via npm, writes the right MCP config, prompts a restart, and verifies the tool handshake. Use after registering an agent on simmer.markets to run pre-built Simmer trading strategies through your MCP-aware agent.
 metadata:
   author: "Simmer (@simmer_markets)"
-  version: "0.3.4"
+  version: "0.3.5"
   displayName: Simmer MCP Setup
   difficulty: beginner
   primaryEnv: SIMMER_API_KEY

--- a/skills/simmer-mcp-setup/SKILL.md
+++ b/skills/simmer-mcp-setup/SKILL.md
@@ -135,10 +135,18 @@ python3 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.17.13'
 ```
 
 Use a venv — most Linux hosts mark the system Python "externally managed", so a bare
-`pip install` fails with PEP 668. If `python3 -m venv` itself fails with
-*"ensurepip is not available"*, the venv module is packaged separately on that distro:
-`sudo apt install python3-venv` (Debian/Ubuntu), or use `pipx`, or as a last resort
-`pip install --break-system-packages`.
+`pip install` fails with PEP 668. Use Python 3.10 or newer for this venv; on macOS,
+`python3` can still be Apple's Python 3.9, which fails to resolve current Simmer SDK
+dependencies with errors such as `No matching distribution found for py-order-utils`.
+If that happens, create the venv with a newer interpreter instead:
+
+```bash
+python3.11 -m venv .venv && .venv/bin/pip install 'simmer-sdk>=0.17.13'
+```
+
+If `python3 -m venv` itself fails with *"ensurepip is not available"*, the venv module is
+packaged separately on that distro: `sudo apt install python3-venv` (Debian/Ubuntu), or
+use `pipx`, or as a last resort `pip install --break-system-packages`.
 
 ⚠️ **Creating the venv is not enough — you must point the server at it.** The server is
 launched by your runtime as `npx -y simmer-mcp` and inherits *that* environment, not your

--- a/tests/test_check_publish_lag.py
+++ b/tests/test_check_publish_lag.py
@@ -255,6 +255,51 @@ def test_mcp_source_change_allows_npm_version_bump(
     assert check_publish_lag.main() == 0
 
 
+def test_pull_request_repo_ahead_of_registry_is_green(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A version-bump PR is legitimately ahead of the registry until merge publishes it."""
+    write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.1")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: make_args(root=tmp_path, npm_published_version="3.4.9", pypi_published_version="0.20.0"),
+    )
+
+    assert check_publish_lag.main() == 0
+
+
+def test_pull_request_registry_ahead_of_repo_is_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Registry ahead of repo means someone published outside git — always a real failure."""
+    write_package_files(tmp_path, npm_version="3.4.9", pypi_version="0.20.0")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: make_args(root=tmp_path, npm_published_version="3.4.10", pypi_published_version="0.20.0"),
+    )
+
+    assert check_publish_lag.main() == 1
+
+
+def test_push_repo_ahead_of_registry_still_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Push-to-main behaviour is unchanged: repo ahead after merge means publish didn't run."""
+    write_package_files(tmp_path, npm_version="3.4.10", pypi_version="0.20.0")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setattr(
+        check_publish_lag,
+        "parse_args",
+        lambda: make_args(root=tmp_path, npm_published_version="3.4.9", pypi_published_version="0.20.0"),
+    )
+
+    assert check_publish_lag.main() == 1
+
+
 def test_non_mcp_package_input_does_not_require_npm_version_bump(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_check_publish_lag.py
+++ b/tests/test_check_publish_lag.py
@@ -18,6 +18,13 @@ sys.modules[SPEC.name] = check_publish_lag
 SPEC.loader.exec_module(check_publish_lag)
 
 
+@pytest.fixture(autouse=True)
+def _clear_github_event_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests run under this suite's own CI job, where GITHUB_EVENT_NAME=pull_request
+    is genuinely set — isolate it so push/local-shaped tests don't inherit that."""
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+
+
 def write_package_files(root: Path, npm_version: str, pypi_version: str) -> None:
     (root / "mcp").mkdir()
     (root / "mcp" / "package.json").write_text(


### PR DESCRIPTION
## Summary
- verified the Simmer MCP Codex path on MBP-13 using isolated Codex config overrides
- documented that current preflight SDK installs need Python 3.10+; Apple Python 3.9 venvs fail dependency resolution on this host
- kept the public skill and bundled MCP copy in sync

## Verification
- Codex MCP handshake succeeded with 23 Simmer tools exposed.
- Safe Codex MCP call: `simmer_get_markets` on `venue=sim` returned 3 markets out of 184; no trades placed.
- Discriminating preflight test:
  - `SIMMER_MCP_PYTHON=/tmp/sim-5298-no-sdk-53531/bin/python` -> `simmer_preflight` exited 2 with `ERROR: simmer-sdk not installed — run: pip install simmer-sdk>=0.17.13`.
  - `SIMMER_MCP_PYTHON=/tmp/sim-5298-with-sdk-py311/bin/python` -> `simmer_preflight` completed successfully in 11.0s, `trades_attempted: 0`, `ok_to_trade: true`.
- Startup runtime banners showed the configured interpreter path in both cases.

Closes SIM-5298